### PR TITLE
docs: draft S2 data contracts

### DIFF
--- a/docs/data-contract/README.md
+++ b/docs/data-contract/README.md
@@ -1,16 +1,33 @@
 # Data Contract
 
-Data-contract documents define the stable JSON and TypeScript-facing contracts used by `@fairy/data`, `@fairy/core`, and `@fairy/cli`.
+Data-contract documents define the stable JSON and TypeScript-facing contracts used by
+`@fairy/data`, `@fairy/core`, and `@fairy/cli`.
 
-Current S2 inputs:
+S2 starts with documents first. Runtime validators and package source schemas should
+mirror these contracts after cross-role review.
 
-- [../architecture/naming-policy.md](../architecture/naming-policy.md)
-- [pending-term-resolution-table.md](pending-term-resolution-table.md)
+## Inputs
 
-Future documents:
+- [Naming policy](../architecture/naming-policy.md)
+- [Pending term resolution table](pending-term-resolution-table.md)
+- [Glossary](../glossary/glossary.md)
+- [Product v2.0](../product/v2.0.md)
 
-- `battle-snapshot.md`
-- `game-data.md`
-- `calc-result.md`
-- `handler-spec.md`
-- `trace.md`
+## Contracts
+
+- [BattleSnapshot](battle-snapshot.md): user-authored static battle input.
+- [GameData](game-data.md): cleaned generated game data consumed by core.
+- [CalcResult](calc-result.md): JSON-only calculation output.
+- [Trace](trace.md): explainability and golden-test evidence model.
+- [Handler spec](handler-spec.md): safe typed modifier and handler boundary.
+
+## Hard Rules
+
+- `attackSegments[]` is always an array; no executable schema may collapse it
+  to a single `attackSegment`.
+- JSON keys and enum values are English and language-independent.
+- `--lang` only affects messages, explanations, and prompt rendering.
+- Runtime handlers are registered deterministic functions. JSON data never
+  contains arbitrary scripts.
+- Formal `@fairy/data` values must be source-derived. User overrides and test
+  fixtures are separate provenance classes.

--- a/docs/data-contract/battle-snapshot.md
+++ b/docs/data-contract/battle-snapshot.md
@@ -1,0 +1,393 @@
+# BattleSnapshot
+
+Status: S2 draft
+Owner: @TechLead
+Reviewers: @Product, @UX, @QA
+Inputs: Product v2.0, glossary v0.3.2, naming policy, QA-1 golden field mapping
+
+`BattleSnapshot` is the user-authored static input for one calculation. It
+describes a single battle moment: 1-3 agents, one active actor, one enemy state,
+one or more attack segments, manual events, and typed modifiers that are already
+known to be active or intentionally inactive.
+
+It is not raw source data and it is not a rotation simulation.
+
+## 1. Shape
+
+```ts
+interface BattleSnapshot {
+  schemaVersion: string
+  gameVersion: string
+  ruleSetVersion: string
+  dataVersion: string
+  sourceVersion: string
+
+  originalGameVersion?: string
+  originalRuleSetVersion?: string
+  originalDataVersion?: string
+  originalSourceVersion?: string
+
+  locale?: "zh" | "en"
+  context?: BattleContext
+  team: [AgentSnapshot] | [AgentSnapshot, AgentSnapshot] | [AgentSnapshot, AgentSnapshot, AgentSnapshot]
+  activeActor: ActiveActorRef
+  attackSegments: AttackSegment[]
+  enemy: EnemySnapshot
+  modifiers?: TypedModifier[]
+  manualEvents?: ManualEvent[]
+  options?: CalculationOptions
+  fieldProvenance?: FieldProvenanceMap
+  overrides?: FieldOverride[]
+}
+```
+
+### Version Fields
+
+| Field | Meaning |
+|---|---|
+| `schemaVersion` | Snapshot JSON schema version. |
+| `gameVersion` | ZZZ game major/minor version used by the user. |
+| `ruleSetVersion` | Formula/rule implementation version. |
+| `dataVersion` | Cleaned `@fairy/data` package version. |
+| `sourceVersion` | Source-data snapshot version. |
+| `original*` | Preserved values when an imported snapshot is recalculated with newer rules/data. |
+
+`original*` fields are mandatory in results produced by the "recalculate with
+current rules" path when any version differs from the imported snapshot.
+
+## 2. Battle Context
+
+```ts
+interface BattleContext {
+  gameMode?: GameMode
+  stageId?: string
+  nodeId?: string
+  phaseId?: string
+  activeRuleIds?: string[]
+  resoniumIds?: string[]
+}
+
+type GameMode =
+  | "generic"
+  | "lostVoid"
+  | "defenseGameMode"
+  | "hollowZeroAssault"
+```
+
+`context` is the place for mode-specific rules that affect formulas, for
+example Lost Void Resonium, Shiyu Defense node effects, or Critical Assault data
+source rules. `defenseGameMode` keeps the current internal ID until official
+English is verified.
+
+## 3. Team And Active Actor
+
+```ts
+interface ActiveActorRef {
+  agentId: string
+}
+
+interface AgentSnapshot {
+  agentId: string
+  level: number
+  agentSpecialty: AgentSpecialty
+  attribute: Attribute
+
+  skillLevels?: Partial<Record<SkillId, number>>
+  mindscapeCinema?: MindscapeCinemaSnapshot
+  potentialActivations?: PotentialActivationSnapshot[]
+  wEngine?: WEngineSnapshot
+  driveDiscs?: DriveDiscSnapshot[]
+  panel: AgentPanelSnapshot
+  fieldProvenance?: FieldProvenanceMap
+  overrides?: FieldOverride[]
+  subordinate?: UnsupportedSubordinate
+}
+```
+
+`team` contains 1-3 agents. `activeActor.agentId` must match exactly one
+`team[].agentId`. V1 does not model Bangboo; `subordinate` is reserved for
+V1.1+ and must produce an unsupported-feature warning if provided.
+
+### Equipment Naming Decisions
+
+| Concept | Field | Notes |
+|---|---|---|
+| 音擎 / W-Engine | `wEngine` | Official stylized term; `weaponEngine` is an alias only. |
+| 驱动盘 / Drive Disc | `driveDiscs` | Plural because a snapshot can equip multiple discs. |
+| 影画 / Mindscape Cinema | `mindscapeCinema` | Official-first readable field. |
+
+## 4. Agent Panel
+
+`panel` is the already-resolved stat snapshot that core consumes. UI import modes
+such as "panel input" or "substat input" must resolve to this shape before core.
+
+```ts
+interface AgentPanelSnapshot {
+  attack: number
+  maxHp: number
+  defense?: number
+  impact?: number
+  critRate?: number
+  critDamage?: number
+  penetrationRate?: number
+  flatPenetration?: number
+  anomalyMastery?: number
+  anomalyProficiency?: number
+
+  sheerForce?: number
+  fireDamageBonus?: number
+  iceDamageBonus?: number
+  electricDamageBonus?: number
+  etherDamageBonus?: number
+  physicalDamageBonus?: number
+  sheerDamageBonus?: number
+
+  energyRegen?: number
+  energyGenerationRate?: number
+  maxEnergy?: number
+  adrenaline?: number
+  automaticAdrenalineAccumulation?: number
+  adrenalineGenerationRate?: number
+  maxAdrenaline?: number
+}
+```
+
+Field semantics follow D-11:
+
+- `anomalyMastery` = 异常掌控 / Anomaly Mastery, buildup side.
+- `anomalyProficiency` = 异常精通 / Anomaly Proficiency, damage side.
+- `sheerForce` = 贯穿力 / Sheer Force.
+- `adrenaline*` fields are static resource values only in V1. V1 does not
+  simulate an Adrenaline cycle.
+
+## 5. Provenance And Overrides
+
+```ts
+type FieldProvenance = "panel" | "stats" | "data" | "userOverride"
+
+interface FieldProvenanceMap {
+  [fieldPath: string]: FieldProvenanceEntry
+}
+
+interface FieldProvenanceEntry {
+  provenance: FieldProvenance
+  source?: SourceRef
+  overriddenFromData?: unknown
+  reason?: string
+}
+
+interface FieldOverride {
+  path: string
+  value: unknown
+  overriddenFromData?: unknown
+  reason?: string
+  source?: SourceRef
+}
+```
+
+Formal data values use `provenance: "data"`. User edits to data-derived fields
+use `provenance: "userOverride"` and must include `overriddenFromData` in
+`CalcResult.trace`.
+
+Earlier discussions used the string `user-override`; it is a source alias for
+`userOverride`, not a new V1 enum value.
+
+`BattleSnapshot.fieldProvenance` and `BattleSnapshot.overrides` can point to any
+snapshot path, including `attackSegments[]`, `manualEvents[]`, `context`, and
+resolver-derived fields. The nested maps on `AgentSnapshot` and `EnemySnapshot`
+are convenience mirrors for common UI forms; top-level paths are the
+authoritative round-trip contract.
+
+## 6. Attack Segments
+
+```ts
+interface AttackSegment {
+  id: string
+  actorId?: string
+  skillId?: string
+  levelKey?: string
+  multiplier?: number
+  baseDazeMultiplier?: number
+  attribute: Attribute
+  tags: AttackTag[]
+  damageType: DamageType
+  hitCount?: number
+  distanceDecay?: number
+  expectedCrit?: boolean
+  anomalyContribution?: AnomalyContributionInput
+  source?: SourceRef
+}
+```
+
+`attackSegments[]` is a hard contract. Even a one-hit CLI example must use an
+array. Core rounds display damage per segment and then sums displayed segment
+values; it must never round only the final total.
+
+`actorId` defaults to `activeActor.agentId`. A segment with another `actorId`
+is valid only for explicit manual/assist scenarios and must be traceable.
+
+### Anomaly Contribution Input
+
+```ts
+interface AnomalyContributionInput {
+  status: AnomalyStatus
+  triggerCountBefore?: number
+  buildup?: number
+  thresholdOverride?: number
+  overflowBuildup?: number
+  contributors?: AnomalyContributionActorInput[]
+}
+
+interface AnomalyContributionActorInput {
+  actorId: string
+  level?: number
+  anomalyMastery?: number
+  anomalyProficiency?: number
+  buildup: number
+  included: boolean
+  excludedReason?: "bangboo" | "overflowOnly" | "notInSnapshot" | "manualExclude"
+  source?: SourceRef
+}
+```
+
+This input is optional. If absent, the resolver may derive contribution rows
+from `GameData` and battle state. If present, core must preserve contribution,
+overflow, and exclusion evidence in `CalcResult.trace` so golden anchors can
+assert virtual-agent behavior.
+
+## 7. Enemy Snapshot
+
+```ts
+interface EnemySnapshot {
+  enemyId?: string
+  level: number
+  rank: EnemyRank
+  maxHp?: number
+  defense?: number
+  baseDaze?: number
+  dazeCap?: number
+  resistance?: Partial<Record<ResistanceAttribute, number>>
+  dazeResistance?: number
+  anomalyBuildupResistance?: Partial<Record<ResistanceAttribute, number>>
+  anomalyTriggerCounts?: Partial<Record<AnomalyStatus, number>>
+  states?: EnemyState[]
+  corruptedShield?: CorruptedShieldState
+  fieldProvenance?: FieldProvenanceMap
+  overrides?: FieldOverride[]
+}
+```
+
+`frost` damage maps to ice resistance and ice damage bonus. `auricInk` maps to
+ether resistance and ether damage bonus. Attribute mapping must be traceable.
+
+## 8. Typed Modifiers
+
+```ts
+interface TypedModifier {
+  id: string
+  label?: LocalizedLabel
+  handlerId: string
+  bucket?: MultiplierBucket
+  params: Record<string, unknown>
+  appliesTo: TargetSelector
+  when?: Condition
+  priority?: number
+  stackingKey?: string
+  source?: SourceRef
+  active?: boolean
+}
+```
+
+Formal data modifiers without `source` are data validation errors. User-provided
+or temporary modifiers without `source` may calculate, but `CalcResult.warnings`
+and modifier trace must mark them as unsourced.
+
+## 9. Manual Events
+
+```ts
+type ManualEvent =
+  | TrueDamageEvent
+  | CorruptedShieldCleanseEvent
+  | PartBreakEvent
+
+interface BaseManualEvent {
+  id: string
+  kind: ManualEventKind
+  ruleId?: string
+  source?: SourceRef
+  fieldProvenance?: FieldProvenanceMap
+  overrides?: FieldOverride[]
+}
+
+interface TrueDamageEvent extends BaseManualEvent {
+  kind: "trueDamage"
+  basePath: "enemy.maxHp" | "custom"
+  multiplier?: number
+  flatValue?: number
+  trueDamageRule?: string
+}
+
+interface CorruptedShieldCleanseEvent extends BaseManualEvent {
+  kind: "corruptedShieldCleanse"
+  basePath: "enemy.maxHp"
+  multiplier?: number
+  trueDamageRule: "default15Percent" | "pre22CorruptionPriest3Percent" | "post22ShieldBoss25Permille" | string
+}
+
+interface PartBreakEvent extends BaseManualEvent {
+  kind: "partBreak"
+  partId: string
+  partType?: string
+  basePath: "enemy.maxHp" | "part.maxHp" | "custom"
+  multiplier?: number
+  flatValue?: number
+  trueDamageRule?: string
+}
+
+type ManualEventKind = "trueDamage" | "corruptedShieldCleanse" | "partBreak"
+```
+
+Manual events describe known instant events such as corrupted-shield cleanse or
+part-break true damage. They do not simulate shield reduction, part durability,
+or timing.
+
+## 10. Options
+
+```ts
+interface CalculationOptions {
+  resultMode?: "expected" | "crit" | "nonCrit"
+  includeTrace?: boolean
+  strictDataSource?: boolean
+  lang?: "zh" | "en"
+}
+```
+
+`lang` only selects human-facing messages or explanation templates. It never
+changes JSON key names or enum values.
+
+## 11. Enums
+
+```ts
+type AgentSpecialty = "attack" | "stun" | "anomaly" | "support" | "defense" | "rupture"
+type Attribute = "fire" | "electric" | "ice" | "physical" | "ether" | "frost" | "auricInk"
+type ResistanceAttribute = "fire" | "electric" | "ice" | "physical" | "ether"
+type DamageType = "regular" | "sheer" | "anomaly" | "disorder" | "trueDamage" | "daze"
+type EnemyRank = "normal" | "elite" | "boss" | "special"
+type AttackTag =
+  | "basic"
+  | "dash"
+  | "dodgeCounter"
+  | "special"
+  | "exSpecial"
+  | "ultimate"
+  | "chain"
+  | "assistAssault"
+  | "parrySupportTag"
+  | "quickAssist"
+  | "evadeAssist"
+  | "heavyHit"
+  | "followUp"
+```
+
+The five attack tags whose official English is still pending keep their v0.3.2
+public IDs until screenshots or data-source text confirms better names.

--- a/docs/data-contract/calc-result.md
+++ b/docs/data-contract/calc-result.md
@@ -1,0 +1,224 @@
+# CalcResult
+
+Status: S2 draft
+Owner: @TechLead
+Reviewers: @Product, @UX, @QA
+Inputs: BattleSnapshot, GameData, handler spec, trace contract
+
+`CalcResult` is the only authoritative output of `@fairy/core` and
+`@fairy/cli`. Human-readable tables, prompt outputs, and future UI views are
+renderers over this JSON.
+
+## 1. Shape
+
+```ts
+interface CalcResult {
+  schemaVersion: string
+  gameVersion: string
+  ruleSetVersion: string
+  dataVersion: string
+  sourceVersion: string
+
+  originalGameVersion?: string
+  originalRuleSetVersion?: string
+  originalDataVersion?: string
+  originalSourceVersion?: string
+
+  snapshotId?: string
+  calculationId: string
+  locale?: "zh" | "en"
+
+  summary: CalcSummary
+  attackSegments: SegmentResult[]
+  buckets: BucketResult[]
+  modifiers: ModifierResult[]
+  events?: ManualEventResult[]
+  trace: TraceEvent[]
+  warnings: Diagnostic[]
+  errors: Diagnostic[]
+}
+```
+
+`errors[]` means calculation did not produce a trustworthy result. `warnings[]`
+means calculation can continue, but consumers must preserve and display the
+warning.
+
+## 2. Summary
+
+```ts
+interface CalcSummary {
+  activeActorId: string
+  enemyId?: string
+  damageType: DamageType
+  rawTotalDamage: number
+  displayTotalDamage: number
+  expectedDamage?: number
+  critDamage?: number
+  nonCritDamage?: number
+  dazeValue?: number
+  anomalyBuildup?: number
+  disorderDamage?: number
+  trueDamage?: number
+}
+```
+
+`rawTotalDamage` is the theoretical sum before display rounding.
+`displayTotalDamage` is the game-style displayed total after each segment has
+been rounded according to the segment rounding rule.
+
+## 3. Segment Results
+
+```ts
+interface SegmentResult {
+  id: string
+  actorId: string
+  attribute: Attribute
+  tags: AttackTag[]
+  damageType: DamageType
+  rawDamage: number
+  segmentDisplayDamage: number
+  roundingMode: RoundingMode
+  baseDamage?: number
+  baseDaze?: number
+  expectedDamage?: number
+  critDamage?: number
+  nonCritDamage?: number
+  dazeValue?: number
+  anomalyBuildup?: number
+  traceRefs: string[]
+}
+```
+
+Multi-segment display totals are:
+
+```ts
+displayTotalDamage = sum(attackSegments.map(segment => segment.segmentDisplayDamage))
+```
+
+This is a testable invariant for golden anchor #7.
+
+## 4. Bucket Results
+
+```ts
+interface BucketResult {
+  bucketId: MultiplierBucket
+  label?: LocalizedLabel
+  before: number
+  after: number
+  effectiveMultiplier: number
+  contributors: BucketContributor[]
+  traceRefs: string[]
+}
+
+interface BucketContributor {
+  id: string
+  source?: SourceRef
+  sourceMissing?: boolean
+  sourceAnchor?: string
+  value: number
+  operation: "add" | "multiply" | "replace" | "min" | "max" | "ignore"
+  active: boolean
+  inactiveReason?: string
+  modifierId?: string
+  diagnosticRefs?: string[]
+}
+```
+
+Formula buckets may aggregate specific data fields. For example,
+`fireDamageBonus`, `iceDamageBonus`, and `physicalDamageBonus` can all
+contribute to `damageBonusZone`; `sheerDamageBonus` contributes to
+`sheerDamageBonusZone`.
+
+`source` is optional only for user-authored or temporary contributors. In that
+case `sourceMissing` must be true, `diagnosticRefs` must include the warning
+diagnostic id, and the same omission must appear in modifier trace. Formal data
+contributors require `source`.
+
+## 5. Modifier Results
+
+```ts
+interface ModifierResult {
+  id: string
+  handlerId: string
+  active: boolean
+  appliesTo: TargetSelector
+  bucket?: MultiplierBucket
+  source?: SourceRef
+  sourceMissing?: boolean
+  inactiveReason?: string
+  producedContributors?: string[]
+  traceRefs: string[]
+}
+```
+
+All modifiers, including inactive ones, appear in `modifiers[]` when
+`includeTrace` is true. Debug prompt templates depend on this for explaining
+"why this buff did not apply".
+
+## 6. Manual Event Results
+
+```ts
+interface ManualEventResult {
+  id: string
+  kind: ManualEventKind
+  ruleId?: string
+  source?: SourceRef
+  basePath?: string
+  baseValue?: number
+  multiplier?: number
+  flatValue?: number
+  rawDamage: number
+  displayDamage: number
+  traceRefs: string[]
+}
+```
+
+Manual event results must expose the event id, selected true-damage rule,
+base path/value, multiplier or flat value, and final damage so corrupted-shield
+cleanse and part-break golden anchors can be asserted without implementation
+internals.
+
+## 7. Diagnostics
+
+```ts
+interface Diagnostic {
+  key: string
+  severity: "info" | "warning" | "error"
+  path?: string
+  messageParams?: Record<string, unknown>
+  source?: SourceRef
+}
+```
+
+Diagnostics use i18n keys such as `ERR-RNG-001`. Core does not emit localized
+message strings. CLI, AI prompt renderers, and future UI select `messages.zh.json`
+or `messages.en.json` by `--lang` / `lang`.
+
+## 8. Required Evidence Fields
+
+The result must expose these fields directly or through `traceRefs`:
+
+| Area | Required evidence |
+|---|---|
+| Defense | `levelBase`, `baseDefense`, `defenseReduction`, `penetrationRate`, `flatPenetration`, `effectiveDefense`, `defenseZone` |
+| Crit | `critRate`, `critDamage`, `critZone`, `expectedMultiplier`, non-crit/crit/expected paths |
+| Resistance | resistance attribute mapping, weak/resist attributes, `resistanceZone` |
+| Vulnerability | `vulnerabilityZone`, `dazeVulnerabilityZone` |
+| Daze | `dazeValue`, `dazeRatio`, `dazeCap`, `dazeResistance`, recovery time/rate fields |
+| Anomaly | `anomalyMastery`, `anomalyProficiency`, `anomalyBuildup`, `anomalyThreshold`, trigger counts |
+| Disorder | formula id, remaining duration, virtual-agent contribution, overflow/exclusion evidence |
+| Sheer/Rupture | `agentSpecialty: "rupture"`, `sheerForce`, `sheerDamage`, `sheerDamageBonusZone`, defense skip evidence |
+| True damage | manual event id, `enemy.maxHp`, selected `trueDamageRule`, final true damage |
+| Provenance | data source, user override, `overriddenFromData`, alias migration evidence |
+
+## 9. Version Mismatch Paths
+
+Imported snapshots can take two paths:
+
+1. Recalculate with current rules/data. The new result uses current version
+   fields and preserves imported values in `original*` fields.
+2. Keep original result read-only. The result preserves original version fields
+   and must not silently rewrite `gameVersion`, `ruleSetVersion`,
+   `dataVersion`, or `sourceVersion`.
+
+Both paths must be visible in `warnings[]` and trace metadata.

--- a/docs/data-contract/game-data.md
+++ b/docs/data-contract/game-data.md
@@ -1,0 +1,222 @@
+# GameData
+
+Status: S2 draft
+Owner: @TechLead
+Reviewers: @Product, @QA
+Inputs: Product v2.0, D-11 naming policy, data-source decisions
+
+`GameData` is the cleaned, generated data shape that `@fairy/data` publishes and
+`@fairy/core` consumes through a resolver. It is not raw Excel, raw HTML, or
+user-authored calculation input.
+
+## 1. Data Pipeline Boundary
+
+```text
+raw source (Excel / crawler)
+  -> parser-specific raw records
+  -> cleaned GameData
+  -> resolver(GameData, BattleSnapshot)
+  -> resolved calculation input
+  -> @fairy/core
+```
+
+Core must not depend on raw source field names. `sourceAliases` are accepted only
+at ingestion/migration boundaries.
+
+## 2. Shape
+
+```ts
+interface GameData {
+  schemaVersion: string
+  gameVersion: string
+  dataVersion: string
+  sourceVersion: string
+  generatedAt: string
+  sources: SourceDocument[]
+
+  agents: Record<string, AgentData>
+  skills: Record<string, SkillData>
+  wEngines: Record<string, WEngineData>
+  driveDiscs: Record<string, DriveDiscData>
+  enemies: Record<string, EnemyData>
+  resonium: Record<string, ResoniumData>
+  modifiers: Record<string, ModifierTemplate>
+  rules: RuleTables
+  aliases: SourceAliasTable
+}
+```
+
+Formal `GameData` values must be derived from source documents. Manually written
+golden fixtures are allowed under `fixtures/golden/`, but they are not formal
+published data.
+
+## 3. Source Metadata
+
+```ts
+interface SourceDocument {
+  id: string
+  kind: "excel" | "mihoyoWiki" | "thirdPartySite" | "manualReview"
+  url?: string
+  fileName?: string
+  gameVersion?: string
+  sourceVersion: string
+  fetchedAt?: string
+  parsedAt: string
+  parserVersion: string
+  licenseNote?: string
+}
+
+interface SourceRef {
+  sourceId: string
+  sourceAnchor?: string
+  sourceVersion?: string
+  dataPath?: string
+}
+```
+
+`manualReview` means a human reviewed source-derived data or a fixture. It must
+not become a source for invented formal data.
+
+## 4. Agents
+
+```ts
+interface AgentData {
+  id: string
+  label: LocalizedLabel
+  source: SourceRef
+  attribute: Attribute
+  agentSpecialty: AgentSpecialty
+  baseStatsByLevel?: LevelTable<AgentBaseStats>
+  skillIds: string[]
+  mindscapeCinema?: MindscapeCinemaData
+  potentialActivation?: PotentialActivationData
+  corePassiveModifiers?: ModifierTemplate[]
+  sourceAliases?: string[]
+}
+```
+
+Rupture agents expose `agentSpecialty: "rupture"`. Agent-specific `sheerForce`
+coefficients are data-driven and must fail loudly when a rupture calculation
+requires them but the data row is missing.
+
+## 5. Skills And Attack Segments
+
+```ts
+interface SkillData {
+  id: string
+  agentId: string
+  label: LocalizedLabel
+  source: SourceRef
+  tags: AttackTag[]
+  attribute?: Attribute
+  segments: SkillSegmentData[]
+}
+
+interface SkillSegmentData {
+  id: string
+  levelKey: string
+  multiplierByLevel?: LevelTable<number>
+  dazeMultiplierByLevel?: LevelTable<number>
+  damageType?: DamageType
+  hitCount?: number
+  defaultTags?: AttackTag[]
+  source: SourceRef
+}
+```
+
+Skill data can provide default segments. `BattleSnapshot.attackSegments[]` still
+remains the executable calculation input because the user may override segment
+state, target, tags, distance decay, or manual scenario fields.
+
+## 6. Equipment And Sources
+
+```ts
+interface WEngineData {
+  id: string
+  label: LocalizedLabel
+  source: SourceRef
+  baseStatsByLevel?: LevelTable<Record<string, number>>
+  passiveModifiers?: ModifierTemplate[]
+  sourceAliases?: string[]
+}
+
+interface DriveDiscData {
+  id: string
+  label: LocalizedLabel
+  source: SourceRef
+  twoPieceModifiers?: ModifierTemplate[]
+  fourPieceModifiers?: ModifierTemplate[]
+  sourceAliases?: string[]
+}
+
+interface ResoniumData {
+  id: string
+  label: LocalizedLabel
+  sourceMode: "lostVoid"
+  category?: string
+  source: SourceRef
+  modifiers?: ModifierTemplate[]
+  sourceAliases?: string[]
+}
+```
+
+V1 needs Resonium only when it affects damage, daze, anomaly, or recovery
+calculations. Lost Void submodules are out of bilingual scope unless a data
+source requires a stable internal key.
+
+## 7. Enemies
+
+```ts
+interface EnemyData {
+  id: string
+  label: LocalizedLabel
+  source: SourceRef
+  rank: EnemyRank
+  levelDefaults?: LevelTable<EnemyLevelStats>
+  resistance?: Partial<Record<ResistanceAttribute, number>>
+  anomalyBuildupResistance?: Partial<Record<ResistanceAttribute, number>>
+  dazeRecovery?: DazeRecoveryData
+  specialRules?: ModifierTemplate[]
+  sourceAliases?: string[]
+}
+```
+
+Enemy presets may be incomplete outside golden-anchor coverage. Missing required
+fields must be a data validation error or calculation error, not a silent
+fallback.
+
+## 8. Rule Tables
+
+```ts
+interface RuleTables {
+  defense?: DefenseRuleTable
+  anomalyThreshold?: AnomalyThresholdTable
+  disorder?: DisorderRuleTable
+  dazeLevelZone?: DazeLevelZoneRule
+  trueDamage?: TrueDamageRuleTable
+  rounding?: RoundingRuleTable
+  attributeMapping?: AttributeMappingTable
+}
+```
+
+Rule tables carry `source` and `ruleSetVersion`. Numeric game data can have its
+own `dataVersion`; formula behavior is controlled by `ruleSetVersion`.
+
+## 9. Aliases And Migration
+
+```ts
+interface SourceAliasTable {
+  fields: Record<string, string>
+  enumValues: Record<string, string>
+  sourceTerms: Record<string, string>
+}
+```
+
+At minimum, S2 migration tests should cover:
+
+- one old `breach*` field mapping to a D-11 `sheer*` or `adrenaline*` field
+- one old anomaly field mapping after the candidate-Y swap
+- one community/source alias such as `resonia` -> `resonium`
+
+Aliases should be preserved in trace when an imported snapshot or source row is
+migrated.

--- a/docs/data-contract/handler-spec.md
+++ b/docs/data-contract/handler-spec.md
@@ -1,0 +1,215 @@
+# Handler Spec
+
+Status: S2 draft
+Owner: @TechLead
+Reviewers: @Product, @QA, @UX
+Inputs: CONFIRM-1, Product v2.0, naming policy, QA-1
+
+Handlers are deterministic functions registered by `@fairy/core`. Typed
+modifiers reference handlers by `handlerId` and pass data-only `params`.
+
+No V1 JSON file may contain executable code.
+
+## 1. Handler Contract
+
+```ts
+interface ModifierHandler<TParams = Record<string, unknown>> {
+  id: string
+  bucket?: MultiplierBucket
+  apply(ctx: HandlerContext, modifier: TypedModifier<TParams>): HandlerResult
+}
+
+interface HandlerContext {
+  snapshot: BattleSnapshot
+  activeActor: AgentSnapshot
+  segment?: AttackSegment
+  enemy: EnemySnapshot
+  gameData: GameData
+  trace: TraceWriter
+}
+
+interface HandlerResult {
+  contributors?: BucketContributor[]
+  events?: TraceEvent[]
+  warnings?: Diagnostic[]
+}
+```
+
+Handlers must be pure for the same `(snapshot, gameData, modifier, segment)`.
+They cannot read files, call the network, use time/randomness, mutate global
+state, or register new handlers during calculation.
+
+## 2. Typed Modifier
+
+```ts
+interface TypedModifier<TParams = Record<string, unknown>> {
+  id: string
+  label?: LocalizedLabel
+  handlerId: string
+  bucket?: MultiplierBucket
+  params: TParams
+  appliesTo: TargetSelector
+  when?: Condition
+  priority?: number
+  stackingKey?: string
+  source?: SourceRef
+  active?: boolean
+}
+```
+
+`handlerId` uses kebab-case, for example:
+
+- `damage-bonus`
+- `defense-reduction`
+- `defense-ignore`
+- `resistance-reduction`
+- `daze-vulnerability-bonus`
+- `sheer-damage-bonus`
+- `anomaly-threshold-multiplier`
+- `true-damage-event`
+
+The exact registry list is locked with implementation, but IDs must follow this
+style and appear in trace.
+
+## 3. Target Selector
+
+```ts
+type TargetSelector =
+  | { kind: "self" }
+  | { kind: "activeActor" }
+  | { kind: "agent"; agentId: string }
+  | { kind: "team"; includeSelf?: boolean }
+  | { kind: "enemy" }
+  | { kind: "segment" }
+  | { kind: "global" }
+```
+
+`appliesTo` says what entity the modifier targets. It does not by itself decide
+whether the modifier is active for a given segment; activation conditions belong
+in `when`.
+
+## 4. Condition DSL
+
+`when` is a JSON condition tree. It is intentionally small and safe.
+
+```ts
+type Condition =
+  | { all: Condition[] }
+  | { any: Condition[] }
+  | { not: Condition }
+  | FieldCondition
+
+interface FieldCondition {
+  field: ConditionFieldPath
+  op: "eq" | "neq" | "in" | "notIn" | "gt" | "gte" | "lt" | "lte" | "exists"
+  value?: unknown
+}
+```
+
+Allowed field roots:
+
+- `snapshot.*`
+- `activeActor.*`
+- `target.*`
+- `enemy.*`
+- `segment.*`
+- `modifier.*`
+
+No arbitrary expressions, function calls, regular-expression execution, or path
+mutation are allowed.
+
+Example:
+
+```json
+{
+  "all": [
+    { "field": "segment.tags", "op": "in", "value": "exSpecial" },
+    { "field": "enemy.states", "op": "in", "value": "dazed" }
+  ]
+}
+```
+
+### Condition Semantics
+
+| Form | Meaning |
+|---|---|
+| `all` | Non-empty list; true only when every child condition is true. |
+| `any` | Non-empty list; true when at least one child condition is true. |
+| `not` | Boolean negation of exactly one child condition. |
+| `exists` | Ignores `value`; true when the field path resolves to a non-null value. |
+| `eq` / `neq` | Deep equality / inequality for resolved scalar, array, or object values. |
+| `in` | If the resolved field is an array, true when it contains `value`; otherwise true when `value` is an array containing the resolved field. |
+| `notIn` | Inverse of `in`, but only when the field exists. |
+| `gt` / `gte` / `lt` / `lte` | Numeric comparison only; type mismatch returns false. |
+
+Missing paths return false for every operator except `exists`, which also returns
+false. Use `{ "not": { "field": "...", "op": "exists" } }` when "missing" is
+the intended condition.
+
+## 5. Buckets
+
+```ts
+type MultiplierBucket =
+  | "baseDamageZone"
+  | "damageBonusZone"
+  | "critZone"
+  | "defenseZone"
+  | "resistanceZone"
+  | "vulnerabilityZone"
+  | "dazeVulnerabilityZone"
+  | "sheerDamageBonusZone"
+  | "anomalyProficiencyZone"
+  | "damageLevelZone"
+  | "anomalyDamageBonusZone"
+  | "anomalyCritZone"
+  | "dazeValueZone"
+  | "dazeResistanceZone"
+  | "dazeInflictZone"
+  | "dazeReceiveZone"
+  | "specialZone"
+```
+
+Field-specific bonuses and formula buckets are separate concepts. A
+`fireDamageBonus` stat can contribute to `damageBonusZone`; `sheerDamageBonus`
+contributes to `sheerDamageBonusZone`.
+
+## 6. Source Rules
+
+| Modifier origin | Missing source behavior |
+|---|---|
+| Formal `@fairy/data` | Data validation error. Must be fixed before package release. |
+| User snapshot / temporary override | Calculation may proceed with warning and trace. |
+| Test fixture | Allowed only when the fixture explicitly tests missing-source behavior. |
+
+The result should expose `sourceMissing: true` and a diagnostic key such as
+`ERR-SRC-001` for user modifiers without source.
+
+## 7. Ordering And Stacking
+
+Handlers run in deterministic order:
+
+1. source resolution and alias migration
+2. modifier activation and target filtering
+3. priority sort inside each bucket
+4. bucket-specific aggregation
+5. formula assembly
+6. rounding and display conversion
+
+`priority` is only meaningful within a bucket. `stackingKey` prevents multiple
+exclusive contributors from stacking accidentally.
+
+## 8. Trace Requirements
+
+Every handler execution must emit trace evidence for:
+
+- handler id
+- modifier id
+- target selector
+- condition result
+- source/sourceAnchor when present
+- active/inactive state
+- produced contributor ids
+- warning/error diagnostics
+
+This makes inactive buffs and source omissions testable without reading
+implementation internals.

--- a/docs/data-contract/pending-term-resolution-table.md
+++ b/docs/data-contract/pending-term-resolution-table.md
@@ -1,7 +1,7 @@
 # Pending Term Resolution Table
 
-Status: S2 draft  
-Owner: @TechLead  
+Status: S2 draft
+Owner: @TechLead
 Purpose: collect terms that affect executable schema, data matching, trace fields, or V1 display.
 
 ## Locked By @lo-user Screenshots
@@ -23,6 +23,9 @@ Purpose: collect terms that affect executable schema, data matching, trace field
 | 闪能上限 | Max Adrenaline | `maxAdrenaline` | locked by D-11 | new V1 field |
 | 能量获得效率 | Energy Generation Rate | `energyGenerationRate` | locked by D-11 | replaces `energyGainEfficiency` |
 | 能量上限 | Energy Limit | `maxEnergy` | locked by D-11 | new V1 field |
+| 音擎 | W-Engine | `wEngine` | locked by TL-3 schema | `weaponEngine` is alias only |
+| 驱动盘 | Drive Disc | `driveDiscs` | locked by TL-3 schema | array field; `DriveDisc` remains type name |
+| 影画 | Mindscape Cinema | `mindscapeCinema` | locked by TL-3 schema | `mindscape` is alias only |
 
 ## Required For V1 Display / i18n
 
@@ -31,7 +34,7 @@ Purpose: collect terms that affect executable schema, data matching, trace field
 | Basic stats | attack, maxHp, defense, impact, critRate, critDamage, penetrationRate, flatPenetration, anomalyMastery, anomalyProficiency, sheerForce |
 | Attack tags | basic, dash, dodgeCounter, special, exSpecial, ultimate, chain, assistAssault, parrySupportTag, quickAssist, evadeAssist, heavyHit, followUp |
 | Game modes | lostVoid, defenseGameMode |
-| Equipment and sources | wEngine or weaponEngine, driveDisc, driveDiscSet2, driveDiscSet4, mindscapeCinema, resonium |
+| Equipment and sources | wEngine, driveDiscs, driveDiscSet2, driveDiscSet4, mindscapeCinema, resonium |
 
 ## Still Pending
 
@@ -40,8 +43,6 @@ Purpose: collect terms that affect executable schema, data matching, trace field
 | 式舆防卫战 | `defenseGameMode` | official English not yet verified | S2 data-source discovery or @lo-user screenshot |
 | 鸣徽分类 | `critical`, `duel`, etc. | complete zh/en enum list not collected | S2 source crawl or later screenshots |
 | 零号空洞子模块 | not in V1 | not needed for damage calculator display | keep out unless data source needs stable enum |
-| 音擎 field name | `wEngine` / `weaponEngine` | official term is W-Engine; field readability undecided | decide during S2 schema review |
-| 驱动盘 field name | `driveDisc` / `drive` | official term is Drive Disc; field readability undecided | decide during S2 schema review |
 | 支援突击 | `assistAssault` | official English pending | keep ID from glossary v0.3.2 until verified |
 | 招架支援（标签） | `parrySupportTag` | official English pending | keep tag/event split |
 | 回避支援 | `evadeAssist` | official English pending | keep ID from glossary v0.3.2 until verified |
@@ -73,3 +74,7 @@ Aliases are accepted for data ingestion, migration, and prompt matching, but new
 | `penRate` | `penetrationRate` |
 | `penFlat` | `flatPenetration` |
 | `hpMax` | `maxHp` |
+| `weaponEngine` | `wEngine` |
+| `driveDisc` | `driveDiscs` |
+| `drive` | `driveDiscs` |
+| `mindscape` | `mindscapeCinema` |

--- a/docs/data-contract/trace.md
+++ b/docs/data-contract/trace.md
@@ -1,0 +1,168 @@
+# Trace Contract
+
+Status: S2 draft
+Owner: @TechLead
+Reviewers: @QA, @UX
+Inputs: QA-1 golden field mapping, Product v2.0
+
+Trace data explains how a result was produced. It is not a log stream and should
+not depend on implementation-private variable names.
+
+## 1. Shape
+
+```ts
+interface TraceEvent {
+  id: string
+  kind: TraceKind
+  path: string
+  label?: LocalizedLabel
+  inputs?: Record<string, unknown>
+  formula?: string
+  rawValue?: unknown
+  displayValue?: unknown
+  rounding?: RoundingTrace
+  source?: SourceRef
+  sourceAlias?: string
+  sourceAnchor?: string
+  active?: boolean
+  inactiveReason?: string
+  refs?: string[]
+}
+```
+
+`path` is a stable JSON-style path into `CalcResult` or into the source field
+being explained, for example `attackSegments[0].segmentDisplayDamage` or
+`buckets[?bucketId=defenseZone]`.
+
+## 2. Trace Kinds
+
+```ts
+type TraceKind =
+  | "sourceResolution"
+  | "aliasMigration"
+  | "provenance"
+  | "modifierActivation"
+  | "bucketContribution"
+  | "formula"
+  | "rounding"
+  | "version"
+  | "warning"
+  | "error"
+```
+
+## 3. Rounding Trace
+
+```ts
+interface RoundingTrace {
+  mode: RoundingMode
+  input: number
+  output: number
+  reason: string
+}
+
+type RoundingMode =
+  | "none"
+  | "ceilPerSegment"
+  | "floorForFormula"
+  | "floorForDisplay"
+  | "roundToDisplay"
+```
+
+Required V1 rounding evidence:
+
+- segment damage display uses `ceilPerSegment`
+- anomaly mastery/proficiency formula flooring uses `floorForFormula` when the
+  rule requires it
+- daze ratio display exposes raw and displayed values separately
+
+## 4. Provenance Trace
+
+User overrides must be traceable:
+
+```json
+{
+  "kind": "provenance",
+  "path": "team[0].panel.sheerForce",
+  "inputs": {
+    "provenance": "userOverride",
+    "overriddenFromData": 2388,
+    "value": 2423,
+    "reason": "panel screenshot"
+  }
+}
+```
+
+Formal data-derived values must carry `source`. Missing source in formal data is
+an error; missing source in user modifiers is a warning.
+
+## 5. Defense Chain Evidence
+
+Defense trace must expose:
+
+- `levelBase`
+- `baseDefense`
+- `defenseReduction`
+- `penetrationRate`
+- `flatPenetration`
+- `effectiveDefense`
+- `defenseZone`
+- corrupted-shield defense modifier when active
+- defense skip flag for `damageType: "sheer"`
+
+Sheer damage must still trace that defense was skipped; absence of a defense
+trace is not enough.
+
+## 6. Anomaly And Disorder Evidence
+
+Anomaly/disorder trace must expose:
+
+- `anomalyMastery` and its rounding/flooring if used for buildup
+- `anomalyProficiency` and the anomaly damage zone
+- `anomalyThreshold` lookup by enemy rank and trigger count
+- physical threshold multiplier when applicable
+- special enemy and mode threshold multipliers as separate contributors
+- virtual-agent contribution rows
+- overflow buildup
+- excluded Bangboo buildup
+- disorder formula id and remaining duration
+
+## 7. Daze Evidence
+
+Daze trace must expose:
+
+- base daze value
+- `impact` and daze multiplier contributors
+- `dazeResistance`
+- `dazeInflictZone`
+- `dazeReceiveZone`
+- `dazeRatio` raw/display values
+- `dazeRecoveryTime` and recovery-rate contributors
+- Resonium source ids for Lost Void examples
+
+## 8. Version Trace
+
+Version mismatch trace must show:
+
+- imported `originalGameVersion`, `originalRuleSetVersion`,
+  `originalDataVersion`, `originalSourceVersion`
+- current versions used for recalculation
+- selected path: `recalculateCurrent` or `keepOriginalReadOnly`
+
+No importer may silently rewrite version fields without a trace event.
+
+## 9. Alias Migration Trace
+
+When imported data uses old or community names, trace must preserve both terms:
+
+```json
+{
+  "kind": "aliasMigration",
+  "path": "team[0].panel.sheerForce",
+  "sourceAlias": "breachForce",
+  "rawValue": 2423,
+  "displayValue": "sheerForce"
+}
+```
+
+At minimum, golden migration tests should cover a `breach*` alias, an old
+anomaly-field alias, and a Resonium alias.


### PR DESCRIPTION
## Slock Context
- Owner: @TechLead
- Task: #11
- Reviewers: @Product, @UX, @QA
- Related decisions: D-02-rev / D-11 / CONFIRM-1 / CONFIRM-4 / CONFIRM-12 / CONFIRM-13
- i18n impact: docs-only

## Summary
- Adds S2 draft contracts for `BattleSnapshot`, `GameData`, `CalcResult`, trace, and typed modifier handlers.
- Locks `attackSegments[]` as the executable input shape, including per-segment rounding requirements.
- Defines safe `appliesTo` / `when` selector and condition DSL for typed modifiers.
- Records version, provenance, override, alias migration, and diagnostic boundaries required by QA golden anchors.
- Updates `docs/data-contract/README.md` to link the new contract set and state hard rules.

## Notes
- This PR is documentation-first. Runtime validators and package source schemas should mirror these contracts after cross-role review.
- UX starter scenario JSON remains a UX sample baseline until these contracts are reviewed and TL-3 field paths are accepted.

## Verification
- `pnpm -C fairy install --frozen-lockfile`
- `pnpm -C fairy check`
- `git diff --cached --check`
