### PR TITLE
feat(core): add runtime contract schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
   "scripts": {
     "check": "pnpm -r --if-present check",
     "test": "pnpm -r --if-present test"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,5 +2,15 @@
   "name": "@fairy/core",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema"
+export * from "./validators"

--- a/packages/core/src/schema/battle-snapshot.ts
+++ b/packages/core/src/schema/battle-snapshot.ts
@@ -1,0 +1,290 @@
+import { z } from "zod"
+import {
+  agentSpecialtySchema,
+  anomalyStatusSchema,
+  attackTagSchema,
+  attributeSchema,
+  damageTypeSchema,
+  enemyRankSchema,
+  fieldOverrideSchema,
+  fieldProvenanceMapSchema,
+  localeSchema,
+  manualEventKindSchema,
+  resistanceAttributeSchema,
+  sourceRefSchema,
+} from "./common"
+import { typedModifierSchema } from "./modifier"
+
+export const battleContextSchema = z
+  .object({
+    gameMode: z
+      .enum(["generic", "lostVoid", "defenseGameMode", "hollowZeroAssault"])
+      .optional(),
+    stageId: z.string().min(1).optional(),
+    nodeId: z.string().min(1).optional(),
+    phaseId: z.string().min(1).optional(),
+    activeRuleIds: z.array(z.string().min(1)).optional(),
+    resoniumIds: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const agentPanelSnapshotSchema = z
+  .object({
+    attack: z.number().finite(),
+    maxHp: z.number().finite(),
+    defense: z.number().finite().optional(),
+    impact: z.number().finite().optional(),
+    critRate: z.number().finite().optional(),
+    critDamage: z.number().finite().optional(),
+    penetrationRate: z.number().finite().optional(),
+    flatPenetration: z.number().finite().optional(),
+    anomalyMastery: z.number().finite().optional(),
+    anomalyProficiency: z.number().finite().optional(),
+    sheerForce: z.number().finite().optional(),
+    fireDamageBonus: z.number().finite().optional(),
+    iceDamageBonus: z.number().finite().optional(),
+    electricDamageBonus: z.number().finite().optional(),
+    etherDamageBonus: z.number().finite().optional(),
+    physicalDamageBonus: z.number().finite().optional(),
+    sheerDamageBonus: z.number().finite().optional(),
+    energyRegen: z.number().finite().optional(),
+    energyGenerationRate: z.number().finite().optional(),
+    maxEnergy: z.number().finite().optional(),
+    adrenaline: z.number().finite().optional(),
+    automaticAdrenalineAccumulation: z.number().finite().optional(),
+    adrenalineGenerationRate: z.number().finite().optional(),
+    maxAdrenaline: z.number().finite().optional(),
+  })
+  .strict()
+
+export const wEngineSnapshotSchema = z
+  .object({
+    id: z.string().min(1),
+    level: z.number().int().positive().optional(),
+    phase: z.number().int().positive().optional(),
+  })
+  .strict()
+
+export const driveDiscSnapshotSchema = z
+  .object({
+    id: z.string().min(1),
+    slot: z.number().int().min(1).max(6).optional(),
+    setId: z.string().min(1).optional(),
+  })
+  .strict()
+
+export const agentSnapshotSchema = z
+  .object({
+    agentId: z.string().min(1),
+    level: z.number().int().positive(),
+    agentSpecialty: agentSpecialtySchema,
+    attribute: attributeSchema,
+    skillLevels: z.record(z.string(), z.number().int().nonnegative()).optional(),
+    mindscapeCinema: z
+      .object({ level: z.number().int().min(0).max(6) })
+      .strict()
+      .optional(),
+    potentialActivations: z.array(z.record(z.string(), z.unknown())).optional(),
+    wEngine: wEngineSnapshotSchema.optional(),
+    driveDiscs: z.array(driveDiscSnapshotSchema).optional(),
+    panel: agentPanelSnapshotSchema,
+    fieldProvenance: fieldProvenanceMapSchema.optional(),
+    overrides: z.array(fieldOverrideSchema).optional(),
+    subordinate: z
+      .object({
+        kind: z.literal("bangboo").optional(),
+        id: z.string().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+export const anomalyContributionActorInputSchema = z
+  .object({
+    actorId: z.string().min(1),
+    level: z.number().int().positive().optional(),
+    anomalyMastery: z.number().finite().optional(),
+    anomalyProficiency: z.number().finite().optional(),
+    buildup: z.number().finite(),
+    included: z.boolean(),
+    excludedReason: z
+      .enum(["bangboo", "overflowOnly", "notInSnapshot", "manualExclude"])
+      .optional(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
+export const anomalyContributionInputSchema = z
+  .object({
+    status: anomalyStatusSchema,
+    triggerCountBefore: z.number().int().nonnegative().optional(),
+    buildup: z.number().finite().optional(),
+    thresholdOverride: z.number().finite().optional(),
+    overflowBuildup: z.number().finite().optional(),
+    contributors: z.array(anomalyContributionActorInputSchema).optional(),
+  })
+  .strict()
+
+export const attackSegmentSchema = z
+  .object({
+    id: z.string().min(1),
+    actorId: z.string().min(1).optional(),
+    skillId: z.string().min(1).optional(),
+    levelKey: z.string().min(1).optional(),
+    multiplier: z.number().finite().optional(),
+    baseDazeMultiplier: z.number().finite().optional(),
+    attribute: attributeSchema,
+    tags: z.array(attackTagSchema),
+    damageType: damageTypeSchema,
+    hitCount: z.number().int().positive().optional(),
+    distanceDecay: z.number().finite().optional(),
+    expectedCrit: z.boolean().optional(),
+    anomalyContribution: anomalyContributionInputSchema.optional(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
+export const enemySnapshotSchema = z
+  .object({
+    enemyId: z.string().min(1).optional(),
+    level: z.number().int().positive(),
+    rank: enemyRankSchema,
+    maxHp: z.number().finite().optional(),
+    defense: z.number().finite().optional(),
+    baseDaze: z.number().finite().optional(),
+    dazeCap: z.number().finite().optional(),
+    resistance: z.partialRecord(resistanceAttributeSchema, z.number().finite()).optional(),
+    dazeResistance: z.number().finite().optional(),
+    anomalyBuildupResistance: z
+      .partialRecord(resistanceAttributeSchema, z.number().finite())
+      .optional(),
+    anomalyTriggerCounts: z
+      .partialRecord(anomalyStatusSchema, z.number().int().nonnegative())
+      .optional(),
+    states: z.array(z.string().min(1)).optional(),
+    corruptedShield: z
+      .object({
+        active: z.boolean(),
+        defenseMultiplier: z.number().finite().optional(),
+      })
+      .strict()
+      .optional(),
+    fieldProvenance: fieldProvenanceMapSchema.optional(),
+    overrides: z.array(fieldOverrideSchema).optional(),
+  })
+  .strict()
+
+const baseManualEventSchema = z.object({
+  id: z.string().min(1),
+  ruleId: z.string().min(1).optional(),
+  source: sourceRefSchema.optional(),
+  fieldProvenance: fieldProvenanceMapSchema.optional(),
+  overrides: z.array(fieldOverrideSchema).optional(),
+})
+
+export const manualEventSchema = z.discriminatedUnion("kind", [
+  baseManualEventSchema
+    .extend({
+      kind: z.literal("trueDamage"),
+      basePath: z.enum(["enemy.maxHp", "custom"]),
+      multiplier: z.number().finite().optional(),
+      flatValue: z.number().finite().optional(),
+      trueDamageRule: z.string().min(1).optional(),
+    })
+    .strict(),
+  baseManualEventSchema
+    .extend({
+      kind: z.literal("corruptedShieldCleanse"),
+      basePath: z.literal("enemy.maxHp"),
+      multiplier: z.number().finite().optional(),
+      trueDamageRule: z.union([
+        z.enum([
+          "default15Percent",
+          "pre22CorruptionPriest3Percent",
+          "post22ShieldBoss25Permille",
+        ]),
+        z.string().min(1),
+      ]),
+    })
+    .strict(),
+  baseManualEventSchema
+    .extend({
+      kind: z.literal("partBreak"),
+      partId: z.string().min(1),
+      partType: z.string().min(1).optional(),
+      basePath: z.enum(["enemy.maxHp", "part.maxHp", "custom"]),
+      multiplier: z.number().finite().optional(),
+      flatValue: z.number().finite().optional(),
+      trueDamageRule: z.string().min(1).optional(),
+    })
+    .strict(),
+])
+
+export const calculationOptionsSchema = z
+  .object({
+    resultMode: z.enum(["expected", "crit", "nonCrit"]).optional(),
+    includeTrace: z.boolean().optional(),
+    strictDataSource: z.boolean().optional(),
+    lang: localeSchema.optional(),
+  })
+  .strict()
+
+export const battleSnapshotSchema = z
+  .object({
+    schemaVersion: z.string().min(1),
+    gameVersion: z.string().min(1),
+    ruleSetVersion: z.string().min(1),
+    dataVersion: z.string().min(1),
+    sourceVersion: z.string().min(1),
+    originalGameVersion: z.string().min(1).optional(),
+    originalRuleSetVersion: z.string().min(1).optional(),
+    originalDataVersion: z.string().min(1).optional(),
+    originalSourceVersion: z.string().min(1).optional(),
+    locale: localeSchema.optional(),
+    context: battleContextSchema.optional(),
+    team: z.union([
+      z.tuple([agentSnapshotSchema]),
+      z.tuple([agentSnapshotSchema, agentSnapshotSchema]),
+      z.tuple([agentSnapshotSchema, agentSnapshotSchema, agentSnapshotSchema]),
+    ]),
+    activeActor: z.object({ agentId: z.string().min(1) }).strict(),
+    attackSegments: z.array(attackSegmentSchema).min(1),
+    enemy: enemySnapshotSchema,
+    modifiers: z.array(typedModifierSchema).optional(),
+    manualEvents: z.array(manualEventSchema).optional(),
+    options: calculationOptionsSchema.optional(),
+    fieldProvenance: fieldProvenanceMapSchema.optional(),
+    overrides: z.array(fieldOverrideSchema).optional(),
+  })
+  .strict()
+  .superRefine((snapshot, ctx) => {
+    const teamAgentIds = new Set(snapshot.team.map(agent => agent.agentId))
+
+    if (!teamAgentIds.has(snapshot.activeActor.agentId)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["activeActor", "agentId"],
+        message: "activeActor.agentId must reference a team agent",
+      })
+    }
+
+    snapshot.attackSegments.forEach((segment, index) => {
+      if (segment.actorId !== undefined && !teamAgentIds.has(segment.actorId)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attackSegments", index, "actorId"],
+          message: "attackSegments[].actorId must reference a team agent when provided",
+        })
+      }
+    })
+  })
+
+export type BattleContext = z.infer<typeof battleContextSchema>
+export type AgentPanelSnapshot = z.infer<typeof agentPanelSnapshotSchema>
+export type AgentSnapshot = z.infer<typeof agentSnapshotSchema>
+export type AnomalyContributionInput = z.infer<typeof anomalyContributionInputSchema>
+export type AttackSegment = z.infer<typeof attackSegmentSchema>
+export type EnemySnapshot = z.infer<typeof enemySnapshotSchema>
+export type ManualEvent = z.infer<typeof manualEventSchema>
+export type BattleSnapshot = z.infer<typeof battleSnapshotSchema>

--- a/packages/core/src/schema/calc-result.ts
+++ b/packages/core/src/schema/calc-result.ts
@@ -1,0 +1,144 @@
+import { z } from "zod"
+import {
+  attackTagSchema,
+  attributeSchema,
+  damageTypeSchema,
+  diagnosticSchema,
+  localeSchema,
+  localizedLabelSchema,
+  manualEventKindSchema,
+  multiplierBucketSchema,
+  roundingModeSchema,
+  sourceRefSchema,
+} from "./common"
+import { targetSelectorSchema } from "./modifier"
+import { traceEventSchema } from "./trace"
+
+export const calcSummarySchema = z
+  .object({
+    activeActorId: z.string().min(1),
+    enemyId: z.string().min(1).optional(),
+    damageType: damageTypeSchema,
+    rawTotalDamage: z.number().finite(),
+    displayTotalDamage: z.number().finite(),
+    expectedDamage: z.number().finite().optional(),
+    critDamage: z.number().finite().optional(),
+    nonCritDamage: z.number().finite().optional(),
+    dazeValue: z.number().finite().optional(),
+    anomalyBuildup: z.number().finite().optional(),
+    disorderDamage: z.number().finite().optional(),
+    trueDamage: z.number().finite().optional(),
+  })
+  .strict()
+
+export const segmentResultSchema = z
+  .object({
+    id: z.string().min(1),
+    actorId: z.string().min(1),
+    attribute: attributeSchema,
+    tags: z.array(attackTagSchema),
+    damageType: damageTypeSchema,
+    rawDamage: z.number().finite(),
+    segmentDisplayDamage: z.number().finite(),
+    roundingMode: roundingModeSchema,
+    baseDamage: z.number().finite().optional(),
+    baseDaze: z.number().finite().optional(),
+    expectedDamage: z.number().finite().optional(),
+    critDamage: z.number().finite().optional(),
+    nonCritDamage: z.number().finite().optional(),
+    dazeValue: z.number().finite().optional(),
+    anomalyBuildup: z.number().finite().optional(),
+    traceRefs: z.array(z.string().min(1)),
+  })
+  .strict()
+
+export const bucketContributorSchema = z
+  .object({
+    id: z.string().min(1),
+    source: sourceRefSchema.optional(),
+    sourceMissing: z.boolean().optional(),
+    sourceAnchor: z.string().min(1).optional(),
+    value: z.number().finite(),
+    operation: z.enum(["add", "multiply", "replace", "min", "max", "ignore"]),
+    active: z.boolean(),
+    inactiveReason: z.string().min(1).optional(),
+    modifierId: z.string().min(1).optional(),
+    diagnosticRefs: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const bucketResultSchema = z
+  .object({
+    bucketId: multiplierBucketSchema,
+    label: localizedLabelSchema.optional(),
+    before: z.number().finite(),
+    after: z.number().finite(),
+    effectiveMultiplier: z.number().finite(),
+    contributors: z.array(bucketContributorSchema),
+    traceRefs: z.array(z.string().min(1)),
+  })
+  .strict()
+
+export const modifierResultSchema = z
+  .object({
+    id: z.string().min(1),
+    handlerId: z.string().min(1),
+    active: z.boolean(),
+    appliesTo: targetSelectorSchema,
+    bucket: multiplierBucketSchema.optional(),
+    source: sourceRefSchema.optional(),
+    sourceMissing: z.boolean().optional(),
+    inactiveReason: z.string().min(1).optional(),
+    producedContributors: z.array(z.string().min(1)).optional(),
+    traceRefs: z.array(z.string().min(1)),
+  })
+  .strict()
+
+export const manualEventResultSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: manualEventKindSchema,
+    ruleId: z.string().min(1).optional(),
+    source: sourceRefSchema.optional(),
+    basePath: z.string().min(1).optional(),
+    baseValue: z.number().finite().optional(),
+    multiplier: z.number().finite().optional(),
+    flatValue: z.number().finite().optional(),
+    rawDamage: z.number().finite(),
+    displayDamage: z.number().finite(),
+    traceRefs: z.array(z.string().min(1)),
+  })
+  .strict()
+
+export const calcResultSchema = z
+  .object({
+    schemaVersion: z.string().min(1),
+    gameVersion: z.string().min(1),
+    ruleSetVersion: z.string().min(1),
+    dataVersion: z.string().min(1),
+    sourceVersion: z.string().min(1),
+    originalGameVersion: z.string().min(1).optional(),
+    originalRuleSetVersion: z.string().min(1).optional(),
+    originalDataVersion: z.string().min(1).optional(),
+    originalSourceVersion: z.string().min(1).optional(),
+    snapshotId: z.string().min(1).optional(),
+    calculationId: z.string().min(1),
+    locale: localeSchema.optional(),
+    summary: calcSummarySchema,
+    attackSegments: z.array(segmentResultSchema),
+    buckets: z.array(bucketResultSchema),
+    modifiers: z.array(modifierResultSchema),
+    events: z.array(manualEventResultSchema).optional(),
+    trace: z.array(traceEventSchema),
+    warnings: z.array(diagnosticSchema),
+    errors: z.array(diagnosticSchema),
+  })
+  .strict()
+
+export type CalcSummary = z.infer<typeof calcSummarySchema>
+export type SegmentResult = z.infer<typeof segmentResultSchema>
+export type BucketContributor = z.infer<typeof bucketContributorSchema>
+export type BucketResult = z.infer<typeof bucketResultSchema>
+export type ModifierResult = z.infer<typeof modifierResultSchema>
+export type ManualEventResult = z.infer<typeof manualEventResultSchema>
+export type CalcResult = z.infer<typeof calcResultSchema>

--- a/packages/core/src/schema/calc-result.ts
+++ b/packages/core/src/schema/calc-result.ts
@@ -66,6 +66,26 @@ export const bucketContributorSchema = z
     diagnosticRefs: z.array(z.string().min(1)).optional(),
   })
   .strict()
+  .superRefine((contributor, ctx) => {
+    if (contributor.source !== undefined)
+      return
+
+    if (contributor.sourceMissing !== true) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["sourceMissing"],
+        message: "sourceMissing must be true when source is omitted",
+      })
+    }
+
+    if (contributor.diagnosticRefs === undefined || contributor.diagnosticRefs.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["diagnosticRefs"],
+        message: "diagnosticRefs must reference a warning when source is omitted",
+      })
+    }
+  })
 
 export const bucketResultSchema = z
   .object({

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -1,0 +1,195 @@
+import { z } from "zod"
+
+export const localeSchema = z.enum(["zh", "en"])
+
+export const localizedLabelSchema = z
+  .object({
+    zh: z.string().optional(),
+    en: z.string().optional(),
+  })
+  .strict()
+
+export const sourceRefSchema = z
+  .object({
+    sourceId: z.string().min(1),
+    sourceAnchor: z.string().min(1).optional(),
+    sourceVersion: z.string().min(1).optional(),
+    dataPath: z.string().min(1).optional(),
+  })
+  .strict()
+
+export const sourceDocumentSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.enum(["excel", "mihoyoWiki", "thirdPartySite", "manualReview"]),
+    url: z.string().url().optional(),
+    fileName: z.string().min(1).optional(),
+    gameVersion: z.string().min(1).optional(),
+    sourceVersion: z.string().min(1),
+    fetchedAt: z.string().min(1).optional(),
+    parsedAt: z.string().min(1),
+    parserVersion: z.string().min(1),
+    licenseNote: z.string().optional(),
+  })
+  .strict()
+
+export const agentSpecialtySchema = z.enum([
+  "attack",
+  "stun",
+  "anomaly",
+  "support",
+  "defense",
+  "rupture",
+])
+
+export const attributeSchema = z.enum([
+  "fire",
+  "electric",
+  "ice",
+  "physical",
+  "ether",
+  "frost",
+  "auricInk",
+])
+
+export const resistanceAttributeSchema = z.enum([
+  "fire",
+  "electric",
+  "ice",
+  "physical",
+  "ether",
+])
+
+export const damageTypeSchema = z.enum([
+  "regular",
+  "sheer",
+  "anomaly",
+  "disorder",
+  "trueDamage",
+  "daze",
+])
+
+export const enemyRankSchema = z.enum(["normal", "elite", "boss", "special"])
+
+export const attackTagSchema = z.enum([
+  "basic",
+  "dash",
+  "dodgeCounter",
+  "special",
+  "exSpecial",
+  "ultimate",
+  "chain",
+  "assistAssault",
+  "parrySupportTag",
+  "quickAssist",
+  "evadeAssist",
+  "heavyHit",
+  "followUp",
+])
+
+export const anomalyStatusSchema = z.enum([
+  "frozen",
+  "frostbite",
+  "assault",
+  "flinch",
+  "corruption",
+  "shock",
+  "burn",
+  "disorder",
+  "polarityDisorder",
+])
+
+export const manualEventKindSchema = z.enum([
+  "trueDamage",
+  "corruptedShieldCleanse",
+  "partBreak",
+])
+
+export const roundingModeSchema = z.enum([
+  "none",
+  "ceilPerSegment",
+  "floorForFormula",
+  "floorForDisplay",
+  "roundToDisplay",
+])
+
+export const fieldProvenanceSchema = z.enum([
+  "panel",
+  "stats",
+  "data",
+  "userOverride",
+])
+
+export const fieldProvenanceEntrySchema = z
+  .object({
+    provenance: fieldProvenanceSchema,
+    source: sourceRefSchema.optional(),
+    overriddenFromData: z.unknown().optional(),
+    reason: z.string().optional(),
+  })
+  .strict()
+
+export const fieldProvenanceMapSchema = z.record(
+  z.string().min(1),
+  fieldProvenanceEntrySchema,
+)
+
+export const fieldOverrideSchema = z
+  .object({
+    path: z.string().min(1),
+    value: z.unknown(),
+    overriddenFromData: z.unknown().optional(),
+    reason: z.string().optional(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
+export const diagnosticSchema = z
+  .object({
+    key: z.string().min(1),
+    severity: z.enum(["info", "warning", "error"]),
+    path: z.string().min(1).optional(),
+    messageParams: z.record(z.string(), z.unknown()).optional(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
+export const multiplierBucketSchema = z.enum([
+  "baseDamageZone",
+  "damageBonusZone",
+  "critZone",
+  "defenseZone",
+  "resistanceZone",
+  "vulnerabilityZone",
+  "dazeVulnerabilityZone",
+  "sheerDamageBonusZone",
+  "anomalyProficiencyZone",
+  "damageLevelZone",
+  "anomalyDamageBonusZone",
+  "anomalyCritZone",
+  "dazeValueZone",
+  "dazeResistanceZone",
+  "dazeInflictZone",
+  "dazeReceiveZone",
+  "specialZone",
+])
+
+export type Locale = z.infer<typeof localeSchema>
+export type LocalizedLabel = z.infer<typeof localizedLabelSchema>
+export type SourceRef = z.infer<typeof sourceRefSchema>
+export type SourceDocument = z.infer<typeof sourceDocumentSchema>
+export type AgentSpecialty = z.infer<typeof agentSpecialtySchema>
+export type Attribute = z.infer<typeof attributeSchema>
+export type ResistanceAttribute = z.infer<typeof resistanceAttributeSchema>
+export type DamageType = z.infer<typeof damageTypeSchema>
+export type EnemyRank = z.infer<typeof enemyRankSchema>
+export type AttackTag = z.infer<typeof attackTagSchema>
+export type AnomalyStatus = z.infer<typeof anomalyStatusSchema>
+export type ManualEventKind = z.infer<typeof manualEventKindSchema>
+export type RoundingMode = z.infer<typeof roundingModeSchema>
+export type FieldProvenance = z.infer<typeof fieldProvenanceSchema>
+export type FieldProvenanceEntry = z.infer<typeof fieldProvenanceEntrySchema>
+export type FieldProvenanceMap = z.infer<typeof fieldProvenanceMapSchema>
+export type FieldOverride = z.infer<typeof fieldOverrideSchema>
+export type Diagnostic = z.infer<typeof diagnosticSchema>
+export type MultiplierBucket = z.infer<typeof multiplierBucketSchema>

--- a/packages/core/src/schema/game-data.ts
+++ b/packages/core/src/schema/game-data.ts
@@ -1,0 +1,143 @@
+import { z } from "zod"
+import {
+  agentSpecialtySchema,
+  attackTagSchema,
+  attributeSchema,
+  damageTypeSchema,
+  enemyRankSchema,
+  localizedLabelSchema,
+  resistanceAttributeSchema,
+  sourceDocumentSchema,
+  sourceRefSchema,
+} from "./common"
+import { typedModifierSchema } from "./modifier"
+
+const numberTableSchema = z.record(z.string(), z.number().finite())
+
+export const agentDataSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema,
+    source: sourceRefSchema,
+    attribute: attributeSchema,
+    agentSpecialty: agentSpecialtySchema,
+    baseStatsByLevel: z.record(z.string(), z.record(z.string(), z.number().finite())).optional(),
+    skillIds: z.array(z.string().min(1)),
+    mindscapeCinema: z.record(z.string(), z.unknown()).optional(),
+    potentialActivation: z.record(z.string(), z.unknown()).optional(),
+    corePassiveModifiers: z.array(typedModifierSchema).optional(),
+    sourceAliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const skillSegmentDataSchema = z
+  .object({
+    id: z.string().min(1),
+    levelKey: z.string().min(1),
+    multiplierByLevel: numberTableSchema.optional(),
+    dazeMultiplierByLevel: numberTableSchema.optional(),
+    damageType: damageTypeSchema.optional(),
+    hitCount: z.number().int().positive().optional(),
+    defaultTags: z.array(attackTagSchema).optional(),
+    source: sourceRefSchema,
+  })
+  .strict()
+
+export const skillDataSchema = z
+  .object({
+    id: z.string().min(1),
+    agentId: z.string().min(1),
+    label: localizedLabelSchema,
+    source: sourceRefSchema,
+    tags: z.array(attackTagSchema),
+    attribute: attributeSchema.optional(),
+    segments: z.array(skillSegmentDataSchema),
+  })
+  .strict()
+
+export const wEngineDataSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema,
+    source: sourceRefSchema,
+    baseStatsByLevel: z.record(z.string(), z.record(z.string(), z.number().finite())).optional(),
+    passiveModifiers: z.array(typedModifierSchema).optional(),
+    sourceAliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const driveDiscDataSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema,
+    source: sourceRefSchema,
+    twoPieceModifiers: z.array(typedModifierSchema).optional(),
+    fourPieceModifiers: z.array(typedModifierSchema).optional(),
+    sourceAliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const resoniumDataSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema,
+    sourceMode: z.literal("lostVoid"),
+    category: z.string().min(1).optional(),
+    source: sourceRefSchema,
+    modifiers: z.array(typedModifierSchema).optional(),
+    sourceAliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const enemyDataSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema,
+    source: sourceRefSchema,
+    rank: enemyRankSchema,
+    levelDefaults: z.record(z.string(), z.record(z.string(), z.number().finite())).optional(),
+    resistance: z.partialRecord(resistanceAttributeSchema, z.number().finite()).optional(),
+    anomalyBuildupResistance: z
+      .partialRecord(resistanceAttributeSchema, z.number().finite())
+      .optional(),
+    dazeRecovery: z.record(z.string(), z.unknown()).optional(),
+    specialRules: z.array(typedModifierSchema).optional(),
+    sourceAliases: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export const sourceAliasTableSchema = z
+  .object({
+    fields: z.record(z.string(), z.string()),
+    enumValues: z.record(z.string(), z.string()),
+    sourceTerms: z.record(z.string(), z.string()),
+  })
+  .strict()
+
+export const gameDataSchema = z
+  .object({
+    schemaVersion: z.string().min(1),
+    gameVersion: z.string().min(1),
+    dataVersion: z.string().min(1),
+    sourceVersion: z.string().min(1),
+    generatedAt: z.string().min(1),
+    sources: z.array(sourceDocumentSchema),
+    agents: z.record(z.string(), agentDataSchema),
+    skills: z.record(z.string(), skillDataSchema),
+    wEngines: z.record(z.string(), wEngineDataSchema),
+    driveDiscs: z.record(z.string(), driveDiscDataSchema),
+    enemies: z.record(z.string(), enemyDataSchema),
+    resonium: z.record(z.string(), resoniumDataSchema),
+    modifiers: z.record(z.string(), typedModifierSchema),
+    rules: z.record(z.string(), z.unknown()),
+    aliases: sourceAliasTableSchema,
+  })
+  .strict()
+
+export type AgentData = z.infer<typeof agentDataSchema>
+export type SkillData = z.infer<typeof skillDataSchema>
+export type WEngineData = z.infer<typeof wEngineDataSchema>
+export type DriveDiscData = z.infer<typeof driveDiscDataSchema>
+export type ResoniumData = z.infer<typeof resoniumDataSchema>
+export type EnemyData = z.infer<typeof enemyDataSchema>
+export type GameData = z.infer<typeof gameDataSchema>

--- a/packages/core/src/schema/game-data.ts
+++ b/packages/core/src/schema/game-data.ts
@@ -13,6 +13,16 @@ import {
 import { typedModifierSchema } from "./modifier"
 
 const numberTableSchema = z.record(z.string(), z.number().finite())
+const formalModifierSchema = typedModifierSchema.superRefine((modifier, ctx) => {
+  if (modifier.source !== undefined)
+    return
+
+  ctx.addIssue({
+    code: "custom",
+    path: ["source"],
+    message: "formal data modifiers require source",
+  })
+})
 
 export const agentDataSchema = z
   .object({
@@ -25,7 +35,7 @@ export const agentDataSchema = z
     skillIds: z.array(z.string().min(1)),
     mindscapeCinema: z.record(z.string(), z.unknown()).optional(),
     potentialActivation: z.record(z.string(), z.unknown()).optional(),
-    corePassiveModifiers: z.array(typedModifierSchema).optional(),
+    corePassiveModifiers: z.array(formalModifierSchema).optional(),
     sourceAliases: z.array(z.string().min(1)).optional(),
   })
   .strict()
@@ -61,7 +71,7 @@ export const wEngineDataSchema = z
     label: localizedLabelSchema,
     source: sourceRefSchema,
     baseStatsByLevel: z.record(z.string(), z.record(z.string(), z.number().finite())).optional(),
-    passiveModifiers: z.array(typedModifierSchema).optional(),
+    passiveModifiers: z.array(formalModifierSchema).optional(),
     sourceAliases: z.array(z.string().min(1)).optional(),
   })
   .strict()
@@ -71,8 +81,8 @@ export const driveDiscDataSchema = z
     id: z.string().min(1),
     label: localizedLabelSchema,
     source: sourceRefSchema,
-    twoPieceModifiers: z.array(typedModifierSchema).optional(),
-    fourPieceModifiers: z.array(typedModifierSchema).optional(),
+    twoPieceModifiers: z.array(formalModifierSchema).optional(),
+    fourPieceModifiers: z.array(formalModifierSchema).optional(),
     sourceAliases: z.array(z.string().min(1)).optional(),
   })
   .strict()
@@ -84,7 +94,7 @@ export const resoniumDataSchema = z
     sourceMode: z.literal("lostVoid"),
     category: z.string().min(1).optional(),
     source: sourceRefSchema,
-    modifiers: z.array(typedModifierSchema).optional(),
+    modifiers: z.array(formalModifierSchema).optional(),
     sourceAliases: z.array(z.string().min(1)).optional(),
   })
   .strict()
@@ -101,7 +111,7 @@ export const enemyDataSchema = z
       .partialRecord(resistanceAttributeSchema, z.number().finite())
       .optional(),
     dazeRecovery: z.record(z.string(), z.unknown()).optional(),
-    specialRules: z.array(typedModifierSchema).optional(),
+    specialRules: z.array(formalModifierSchema).optional(),
     sourceAliases: z.array(z.string().min(1)).optional(),
   })
   .strict()
@@ -128,7 +138,7 @@ export const gameDataSchema = z
     driveDiscs: z.record(z.string(), driveDiscDataSchema),
     enemies: z.record(z.string(), enemyDataSchema),
     resonium: z.record(z.string(), resoniumDataSchema),
-    modifiers: z.record(z.string(), typedModifierSchema),
+    modifiers: z.record(z.string(), formalModifierSchema),
     rules: z.record(z.string(), z.unknown()),
     aliases: sourceAliasTableSchema,
   })

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,0 +1,6 @@
+export * from "./battle-snapshot"
+export * from "./calc-result"
+export * from "./common"
+export * from "./game-data"
+export * from "./modifier"
+export * from "./trace"

--- a/packages/core/src/schema/modifier.ts
+++ b/packages/core/src/schema/modifier.ts
@@ -1,0 +1,70 @@
+import { z } from "zod"
+import {
+  diagnosticSchema,
+  localizedLabelSchema,
+  multiplierBucketSchema,
+  sourceRefSchema,
+} from "./common"
+
+export const targetSelectorSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("self") }).strict(),
+  z.object({ kind: z.literal("activeActor") }).strict(),
+  z.object({ kind: z.literal("agent"), agentId: z.string().min(1) }).strict(),
+  z.object({ kind: z.literal("team"), includeSelf: z.boolean().optional() }).strict(),
+  z.object({ kind: z.literal("enemy") }).strict(),
+  z.object({ kind: z.literal("segment") }).strict(),
+  z.object({ kind: z.literal("global") }).strict(),
+])
+
+type Condition =
+  | { all: Condition[] }
+  | { any: Condition[] }
+  | { not: Condition }
+  | {
+      field: string
+      op: "eq" | "neq" | "in" | "notIn" | "gt" | "gte" | "lt" | "lte" | "exists"
+      value?: unknown
+    }
+
+export const conditionSchema: z.ZodType<Condition> = z.lazy(() =>
+  z.union([
+    z.object({ all: z.array(conditionSchema).min(1) }).strict(),
+    z.object({ any: z.array(conditionSchema).min(1) }).strict(),
+    z.object({ not: conditionSchema }).strict(),
+    z
+      .object({
+        field: z.string().min(1),
+        op: z.enum(["eq", "neq", "in", "notIn", "gt", "gte", "lt", "lte", "exists"]),
+        value: z.unknown().optional(),
+      })
+      .strict(),
+  ]),
+)
+
+export const typedModifierSchema = z
+  .object({
+    id: z.string().min(1),
+    label: localizedLabelSchema.optional(),
+    handlerId: z.string().min(1),
+    bucket: multiplierBucketSchema.optional(),
+    params: z.record(z.string(), z.unknown()),
+    appliesTo: targetSelectorSchema,
+    when: conditionSchema.optional(),
+    priority: z.number().int().optional(),
+    stackingKey: z.string().min(1).optional(),
+    source: sourceRefSchema.optional(),
+    active: z.boolean().optional(),
+  })
+  .strict()
+
+export const modifierHandlerResultSchema = z
+  .object({
+    contributors: z.array(z.unknown()).optional(),
+    events: z.array(z.unknown()).optional(),
+    warnings: z.array(diagnosticSchema).optional(),
+  })
+  .strict()
+
+export type TargetSelector = z.infer<typeof targetSelectorSchema>
+export type ConditionAst = z.infer<typeof conditionSchema>
+export type TypedModifier = z.infer<typeof typedModifierSchema>

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest"
+import {
+  battleSnapshotSchema,
+  calcResultSchema,
+  conditionSchema,
+  gameDataSchema,
+} from "./index"
+
+const source = {
+  sourceId: "guide",
+  sourceVersion: "rules-v0.1",
+  sourceAnchor: "PART-01",
+}
+
+const minimalAgent = {
+  agentId: "yixuan",
+  level: 60,
+  agentSpecialty: "rupture",
+  attribute: "auricInk",
+  panel: {
+    attack: 3000,
+    maxHp: 18000,
+    critRate: 0.5,
+    critDamage: 1.2,
+    sheerForce: 2423,
+  },
+}
+
+describe("BattleSnapshot schema", () => {
+  it("accepts the TL-3 static snapshot shape", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      locale: "zh",
+      context: {
+        gameMode: "lostVoid",
+        resoniumIds: ["critical-example"],
+      },
+      team: [minimalAgent],
+      activeActor: { agentId: "yixuan" },
+      attackSegments: [
+        {
+          id: "seg-1",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+          multiplier: 3.2,
+          source,
+          anomalyContribution: {
+            status: "corruption",
+            overflowBuildup: 12,
+            contributors: [
+              {
+                actorId: "yixuan",
+                buildup: 120,
+                included: true,
+                source,
+              },
+            ],
+          },
+        },
+      ],
+      enemy: {
+        enemyId: "corrupted-priest",
+        level: 60,
+        rank: "boss",
+        maxHp: 1000000,
+        resistance: {
+          ether: 0.1,
+        },
+        corruptedShield: { active: true, defenseMultiplier: 1.8 },
+      },
+      manualEvents: [
+        {
+          id: "purge-1",
+          kind: "corruptedShieldCleanse",
+          basePath: "enemy.maxHp",
+          trueDamageRule: "default15Percent",
+          source,
+        },
+      ],
+      fieldProvenance: {
+        "attackSegments[0].multiplier": {
+          provenance: "userOverride",
+          overriddenFromData: 3,
+          reason: "golden fixture",
+        },
+      },
+      overrides: [
+        {
+          path: "attackSegments[0].multiplier",
+          value: 3.2,
+          overriddenFromData: 3,
+        },
+      ],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects legacy singular attackSegment", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [minimalAgent],
+      activeActor: { agentId: "yixuan" },
+      attackSegment: {
+        id: "legacy",
+        attribute: "auricInk",
+        tags: ["exSpecial"],
+        damageType: "sheer",
+      },
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an activeActor outside the team", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [minimalAgent],
+      activeActor: { agentId: "yanagi" },
+      attackSegments: [
+        {
+          id: "seg-1",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+        },
+      ],
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("CalcResult schema", () => {
+  it("accepts unsourced user contributors when sourceMissing and diagnosticRefs are present", () => {
+    const result = calcResultSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      calculationId: "calc-1",
+      summary: {
+        activeActorId: "yixuan",
+        damageType: "sheer",
+        rawTotalDamage: 10.2,
+        displayTotalDamage: 11,
+      },
+      attackSegments: [
+        {
+          id: "seg-1",
+          actorId: "yixuan",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+          rawDamage: 10.2,
+          segmentDisplayDamage: 11,
+          roundingMode: "ceilPerSegment",
+          traceRefs: ["trace-rounding-1"],
+        },
+      ],
+      buckets: [
+        {
+          bucketId: "sheerDamageBonusZone",
+          before: 1,
+          after: 1.2,
+          effectiveMultiplier: 1.2,
+          contributors: [
+            {
+              id: "manual-bonus",
+              sourceMissing: true,
+              value: 0.2,
+              operation: "add",
+              active: true,
+              diagnosticRefs: ["warn-src-1"],
+            },
+          ],
+          traceRefs: ["trace-bucket-1"],
+        },
+      ],
+      modifiers: [],
+      trace: [],
+      warnings: [
+        {
+          key: "ERR-SRC-001",
+          severity: "warning",
+          path: "modifiers[0]",
+        },
+      ],
+      errors: [],
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe("Condition schema", () => {
+  it("accepts nested condition DSL trees", () => {
+    const result = conditionSchema.safeParse({
+      all: [
+        { field: "segment.tags", op: "in", value: "exSpecial" },
+        { not: { field: "enemy.states", op: "in", value: "dazed" } },
+      ],
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe("GameData schema", () => {
+  it("accepts source-derived cleaned data envelopes", () => {
+    const result = gameDataSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      generatedAt: "2026-05-05T00:00:00.000Z",
+      sources: [
+        {
+          id: "excel-1",
+          kind: "excel",
+          fileName: "source.xlsx",
+          sourceVersion: "source-v0.1.0",
+          parsedAt: "2026-05-05T00:00:00.000Z",
+          parserVersion: "parser-v0.1.0",
+        },
+      ],
+      agents: {},
+      skills: {},
+      wEngines: {},
+      driveDiscs: {},
+      enemies: {},
+      resonium: {},
+      modifiers: {},
+      rules: {},
+      aliases: {
+        fields: { breachForce: "sheerForce" },
+        enumValues: {},
+        sourceTerms: { resonia: "resonium" },
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -150,6 +150,68 @@ describe("BattleSnapshot schema", () => {
 
     expect(result.success).toBe(false)
   })
+
+  it("rejects an attack segment actor outside the team", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [minimalAgent],
+      activeActor: { agentId: "yixuan" },
+      attackSegments: [
+        {
+          id: "seg-1",
+          actorId: "yanagi",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+        },
+      ],
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects legacy panel aliases outside migration", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [
+        {
+          ...minimalAgent,
+          panel: {
+            ...minimalAgent.panel,
+            breachForce: 2423,
+            hpMax: 18000,
+          },
+        },
+      ],
+      activeActor: { agentId: "yixuan" },
+      attackSegments: [
+        {
+          id: "seg-1",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+        },
+      ],
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
 })
 
 describe("CalcResult schema", () => {
@@ -213,6 +275,59 @@ describe("CalcResult schema", () => {
 
     expect(result.success).toBe(true)
   })
+
+  it("rejects unsourced bucket contributors without warning trace", () => {
+    const result = calcResultSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      calculationId: "calc-1",
+      summary: {
+        activeActorId: "yixuan",
+        damageType: "sheer",
+        rawTotalDamage: 10.2,
+        displayTotalDamage: 11,
+      },
+      attackSegments: [
+        {
+          id: "seg-1",
+          actorId: "yixuan",
+          attribute: "auricInk",
+          tags: ["exSpecial"],
+          damageType: "sheer",
+          rawDamage: 10.2,
+          segmentDisplayDamage: 11,
+          roundingMode: "ceilPerSegment",
+          traceRefs: ["trace-rounding-1"],
+        },
+      ],
+      buckets: [
+        {
+          bucketId: "sheerDamageBonusZone",
+          before: 1,
+          after: 1.2,
+          effectiveMultiplier: 1.2,
+          contributors: [
+            {
+              id: "manual-bonus",
+              value: 0.2,
+              operation: "add",
+              active: true,
+            },
+          ],
+          traceRefs: ["trace-bucket-1"],
+        },
+      ],
+      modifiers: [],
+      trace: [],
+      warnings: [],
+      errors: [],
+    })
+
+    expect(result.success).toBe(false)
+  })
 })
 
 describe("Condition schema", () => {
@@ -262,5 +377,48 @@ describe("GameData schema", () => {
     })
 
     expect(result.success).toBe(true)
+  })
+
+  it("rejects formal data modifiers without source", () => {
+    const result = gameDataSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      generatedAt: "2026-05-05T00:00:00.000Z",
+      sources: [
+        {
+          id: "excel-1",
+          kind: "excel",
+          fileName: "source.xlsx",
+          sourceVersion: "source-v0.1.0",
+          parsedAt: "2026-05-05T00:00:00.000Z",
+          parserVersion: "parser-v0.1.0",
+        },
+      ],
+      agents: {},
+      skills: {},
+      wEngines: {},
+      driveDiscs: {},
+      enemies: {},
+      resonium: {},
+      modifiers: {
+        unsourcedFormalModifier: {
+          id: "unsourced-formal-modifier",
+          handlerId: "damage-bonus",
+          bucket: "damageBonusZone",
+          params: { value: 0.1 },
+          appliesTo: { kind: "activeActor" },
+        },
+      },
+      rules: {},
+      aliases: {
+        fields: {},
+        enumValues: {},
+        sourceTerms: {},
+      },
+    })
+
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/core/src/schema/trace.ts
+++ b/packages/core/src/schema/trace.ts
@@ -1,0 +1,52 @@
+import { z } from "zod"
+import {
+  localizedLabelSchema,
+  roundingModeSchema,
+  sourceRefSchema,
+} from "./common"
+
+export const traceKindSchema = z.enum([
+  "sourceResolution",
+  "aliasMigration",
+  "provenance",
+  "modifierActivation",
+  "bucketContribution",
+  "formula",
+  "rounding",
+  "version",
+  "warning",
+  "error",
+])
+
+export const roundingTraceSchema = z
+  .object({
+    mode: roundingModeSchema,
+    input: z.number().finite(),
+    output: z.number().finite(),
+    reason: z.string().min(1),
+  })
+  .strict()
+
+export const traceEventSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: traceKindSchema,
+    path: z.string().min(1),
+    label: localizedLabelSchema.optional(),
+    inputs: z.record(z.string(), z.unknown()).optional(),
+    formula: z.string().min(1).optional(),
+    rawValue: z.unknown().optional(),
+    displayValue: z.unknown().optional(),
+    rounding: roundingTraceSchema.optional(),
+    source: sourceRefSchema.optional(),
+    sourceAlias: z.string().min(1).optional(),
+    sourceAnchor: z.string().min(1).optional(),
+    active: z.boolean().optional(),
+    inactiveReason: z.string().min(1).optional(),
+    refs: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+export type TraceKind = z.infer<typeof traceKindSchema>
+export type RoundingTrace = z.infer<typeof roundingTraceSchema>
+export type TraceEvent = z.infer<typeof traceEventSchema>

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -1,0 +1,30 @@
+import type { z } from "zod"
+import { battleSnapshotSchema } from "./schema/battle-snapshot"
+import { calcResultSchema } from "./schema/calc-result"
+import { gameDataSchema } from "./schema/game-data"
+
+export function parseWithSchema<TSchema extends z.ZodType>(
+  schema: TSchema,
+  input: unknown,
+): z.infer<TSchema> {
+  return schema.parse(input)
+}
+
+export function safeParseWithSchema<TSchema extends z.ZodType>(
+  schema: TSchema,
+  input: unknown,
+) {
+  return schema.safeParse(input)
+}
+
+export function parseBattleSnapshot(input: unknown) {
+  return parseWithSchema(battleSnapshotSchema, input)
+}
+
+export function parseGameData(input: unknown) {
+  return parseWithSchema(gameDataSchema, input)
+}
+
+export function parseCalcResult(input: unknown) {
+  return parseWithSchema(calcResultSchema, input)
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,773 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(vite@8.0.10)
 
   packages/cli: {}
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/data: {}
+
+packages:
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10)':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  vite@8.0.10:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.5(vite@8.0.10):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10)
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.4.3: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  }
+}


### PR DESCRIPTION
## Slock Context
- Owner: @TechLead
- Task: #22
- Reviewers: @Product, @QA
- Related decisions: D-02-rev / D-11 / CONFIRM-1 / CONFIRM-4 / CONFIRM-12 / CONFIRM-13
- i18n impact: no

## Summary
- Adds `@fairy/core` runtime schemas and inferred TypeScript types for the TL-3 contracts: `BattleSnapshot`, `GameData`, `CalcResult`, trace, typed modifiers, manual events, and Condition DSL.
- Adds parse helpers: `parseBattleSnapshot`, `parseGameData`, `parseCalcResult`, plus generic parse/safeParse wrappers.
- Adds TypeScript/Vitest tooling for `@fairy/core` and schema tests covering: valid static snapshot, legacy `attackSegment` rejection, `activeActor` team reference validation, unsourced contributor warning shape, nested Condition DSL, and source-derived GameData envelope.
- Uses `z.partialRecord` for partial resistance/anomaly maps so fixtures can specify only relevant attributes.

## Out of scope
- Formula implementation is task #23.
- Condition DSL evaluation and handler registry are task #24.
- Golden fixture contents are task #25.

## Verification
- `pnpm -C fairy check`
- `pnpm -C fairy test`
- `git diff --check`
