### PR TITLE
docs: add monorepo development guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Slock Context
+
+- Owner: @TechLead
+- Task: task #N
+- Reviewers: @Product, @QA
+- Related decisions: D-XX / CONFIRM-XX
+- i18n impact: no
+
+## Summary
+
+-
+
+## Verification
+
+-
+
+## Notes
+
+-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 
 ## Current Phase
 
-S2 data-contract design. First outputs:
+S3 core implementation. Current engineering entry points:
 
 - `docs/architecture/naming-policy.md`
-- `docs/data-contract/pending-term-resolution-table.md`
+- `docs/architecture/monorepo-development.md`
+- `docs/data-contract/`

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ V1 focuses on a TypeScript monorepo with three packages:
 - `@fairy/cli`: JSON-only command-line access to `@fairy/core`.
 
 Start with [docs/index.md](docs/index.md).
+
+## Development
+
+Fairy uses pnpm workspaces. See [docs/architecture/monorepo-development.md](docs/architecture/monorepo-development.md) for package boundaries, dependency rules, verification commands, and PR workflow.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,3 +3,4 @@
 Architecture documents cover repository structure, package boundaries, build and release flow, and cross-cutting engineering policy.
 
 - [naming-policy.md](naming-policy.md)
+- [monorepo-development.md](monorepo-development.md)

--- a/docs/architecture/monorepo-development.md
+++ b/docs/architecture/monorepo-development.md
@@ -1,0 +1,171 @@
+# Monorepo Development Guide
+
+Status: S3 baseline
+Owner: @TechLead
+Inputs: Product v2.0, D-11 naming policy, TL-3 data contracts, WF-1~WF-4 workflow decisions
+
+This guide defines how to work in the Fairy pnpm workspace without breaking package boundaries, data provenance, or review traceability.
+
+## Workspace Layout
+
+```text
+.
+├─ packages/
+│  ├─ core/   # pure schemas, validators, formula engine, trace output
+│  ├─ data/   # source ingestion, cleaning, source metadata, queryable game data
+│  └─ cli/    # JSON-only command surface over core/data
+├─ docs/
+│  ├─ architecture/
+│  ├─ data-contract/
+│  ├─ glossary/
+│  ├─ product/
+│  ├─ qa/
+│  └─ ux/
+└─ fixtures/
+   └─ golden/ # QA-owned fixture specs and later executable regression cases
+```
+
+`CLAUDE.md` is the short agent entry. `docs/index.md` is the documentation map.
+
+## Package Responsibilities
+
+| Package | Owns | Must Not Own |
+|---|---|---|
+| `@fairy/core` | Runtime schemas, validators, pure calculation functions, registered handler interfaces, traceable `CalcResult` output | Crawlers, file IO, network IO, CLI rendering, formal data source parsing |
+| `@fairy/data` | Source readers, raw-to-clean transforms, source metadata, alias migration, queryable game data | Formula decisions, CLI UX, hand-written formal game values |
+| `@fairy/cli` | JSON input/output shell, command parsing, diagnostics rendering when needed | Core math, source scraping, package-private data mutation |
+
+The core package is the lowest-level runtime dependency. It must stay deterministic and side-effect-light so QA can validate formulas and trace output independently.
+
+## Dependency Rules
+
+Allowed:
+
+```text
+@fairy/cli  -> @fairy/core
+@fairy/cli  -> @fairy/data
+@fairy/data -> @fairy/core   # only for shared schema/types/validators when useful
+```
+
+Forbidden:
+
+```text
+@fairy/core -> @fairy/data
+@fairy/core -> @fairy/cli
+@fairy/data -> @fairy/cli
+```
+
+Core code must not read files, call the network, use wall-clock time, use randomness, or infer hidden state in formula paths. If a handler needs data, the resolved data must be passed through `GameData`, `BattleSnapshot`, or registered handler params.
+
+## pnpm Commands
+
+Install from a clean checkout:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Run the workspace checks exposed by packages:
+
+```bash
+pnpm check
+pnpm test
+```
+
+Run one package:
+
+```bash
+pnpm --filter @fairy/core check
+pnpm --filter @fairy/core test
+pnpm --filter @fairy/data check
+pnpm --filter @fairy/cli check
+```
+
+Package scripts may be added incrementally, but every PR that changes runtime code should leave `pnpm check` and relevant package tests passing.
+
+## Data and Fixture Boundary
+
+Formal data in `@fairy/data` must be source-derived:
+
+- Excel rows supplied by @lo-user;
+- live-server crawler output from approved sources;
+- source metadata with `sourceId`, `sourceVersion`, `fetchedAt` or `parsedAt`, and parser version;
+- alias migration at the ingestion boundary.
+
+Do not hand-write formal game data directly into `@fairy/data`.
+
+Fixtures are different. QA-owned fixtures under `fixtures/golden/` may be hand-authored and reviewed because they are test assertions, not redistributable game data. Before V1 release, golden fixtures that depend on real game values must either point to source-derived rows or be marked as pending data.
+
+## Naming and i18n
+
+Use D-11 official-first names for public JSON keys, TypeScript APIs, trace paths, and docs. Old names such as `breachForce`, `hpMax`, and candidate-X anomaly aliases belong in `sourceAliases` or migration traces, not in canonical output.
+
+JSON keys and enum values are always English and language-independent. `locale: "zh" | "en"` affects human-facing diagnostics, explanations, and future renderers only.
+
+## Handler and Formula Rules
+
+V1 handlers are registered deterministic functions. Data may choose a handler by `handlerId` and provide structured `params`, but data must not inject arbitrary JavaScript or runtime scripts.
+
+Each formula path must emit enough evidence for QA:
+
+- per-segment raw and display values;
+- bucket-level before/after/effective multiplier;
+- applied and skipped modifiers with reasons;
+- source metadata or source-missing diagnostics;
+- override/provenance trace for user-overridden data;
+- version mismatch path evidence.
+
+## Branch and PR Workflow
+
+Use small PRs with one owner and one main task. Every PR description must include:
+
+```markdown
+## Slock Context
+
+- Owner: @TechLead
+- Task: task #N
+- Reviewers: @Product, @QA
+- Related decisions: D-XX / CONFIRM-XX
+- i18n impact: zh-only / zh+en / docs-only / no
+```
+
+Merge policy:
+
+- require at least one cross-role review before self-merge;
+- use squash and merge;
+- delete the development branch after merge;
+- critical formula, schema, data-source, crawler, and release PRs need explicit channel review before merge;
+- production/deployment/data-run changes require @lo-user approval.
+
+Keep the squash commit message tied to the PR/task so QA can trace main-branch changes back to evidence.
+
+## Verification Before Handoff
+
+For docs-only PRs:
+
+```bash
+git diff --check
+```
+
+For runtime/schema PRs:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm check
+pnpm test
+git diff --check
+```
+
+For data-ingestion PRs, add source-specific smoke checks and record the command output in the PR. A crawler skeleton may test fixture files; a formal data PR must prove source metadata exists and no hand-written formal values entered the cleaned data package.
+
+## Release Notes
+
+Packages are private during V1 development. Public publishing is out of scope until Product explicitly opens a release task.
+
+When package publishing is introduced, release notes must include:
+
+- package versions;
+- `schemaVersion`, `ruleSetVersion`, `dataVersion`, and `sourceVersion`;
+- source snapshot provenance;
+- migration notes for renamed fields or aliases;
+- QA golden fixture status.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,12 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)
 
-## S2 当前重点
+## S3 当前重点
 
-1. 先锁命名策略与 pending 术语。
-2. 再定义 `BattleSnapshot`、`GameData`、`CalcResult`、handler、trace。
-3. 最后进入 core/cli 实现与 data 全量化。
+1. 落地 `@fairy/core` runtime schema、validators 与黄金 fixture 接入。
+2. 实现核心公式与逐乘区 trace，包括常规 / 贯穿 / 真实伤害 / 异常 / 紊乱 / 失衡值。
+3. 实现 handler registry、Condition DSL 与 source/provenance/版本双路径硬契约。
+4. 并行推进 `@fairy/data` scraper 骨架与 monorepo 开发指南。
 
 ## 关键文档
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,5 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 ## 关键文档
 
 - 命名策略：[architecture/naming-policy.md](architecture/naming-policy.md)
+- Monorepo 开发指南：[architecture/monorepo-development.md](architecture/monorepo-development.md)
 - Pending 术语表：[data-contract/pending-term-resolution-table.md](data-contract/pending-term-resolution-table.md)


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #13
- Reviewers: @Product, @QA
- Related decisions: WF-1 / WF-2 / WF-3 / WF-4 / D-11 / CONFIRM-4
- i18n impact: docs-only

## Summary

- Add `docs/architecture/monorepo-development.md` covering package ownership, dependency direction, pnpm commands, data/fixture boundaries, handler rules, PR workflow, and verification gates.
- Add `.github/PULL_REQUEST_TEMPLATE.md` with the Slock Context block and verification sections.
- Link the guide from README, docs index, architecture README, and CLAUDE.md.

## Verification

- `git diff --check`
- `pnpm -C fairy check`
- `pnpm -C fairy test`

## Notes

- Docs-only PR. Does not touch package runtime code.
