### PR TITLE
feat(core): add formula engine and handler DSL

### DIFF
--- a/packages/core/src/engine/buckets.ts
+++ b/packages/core/src/engine/buckets.ts
@@ -1,0 +1,147 @@
+import type {
+  Attribute,
+  BucketContributor,
+  BucketResult,
+  EnemySnapshot,
+  MultiplierBucket,
+  SourceRef,
+} from "../schema"
+import type { BucketInput } from "./types"
+import { clamp, getDefaultEnemyBaseDefense, getLevelBase } from "./math"
+
+const attributeDamageBonusField: Record<Attribute, string> = {
+  fire: "fireDamageBonus",
+  electric: "electricDamageBonus",
+  ice: "iceDamageBonus",
+  physical: "physicalDamageBonus",
+  ether: "etherDamageBonus",
+  frost: "iceDamageBonus",
+  auricInk: "etherDamageBonus",
+}
+
+const resistanceAttributeByAttribute: Record<Attribute, "fire" | "electric" | "ice" | "physical" | "ether"> = {
+  fire: "fire",
+  electric: "electric",
+  ice: "ice",
+  physical: "physical",
+  ether: "ether",
+  frost: "ice",
+  auricInk: "ether",
+}
+
+export function getDamageBonusField(attribute: Attribute): string {
+  return attributeDamageBonusField[attribute]
+}
+
+export function getResistanceAttribute(attribute: Attribute): "fire" | "electric" | "ice" | "physical" | "ether" {
+  return resistanceAttributeByAttribute[attribute]
+}
+
+export function makeContributor(input: {
+  id: string
+  value: number
+  operation?: BucketContributor["operation"]
+  active?: boolean
+  source?: SourceRef
+  sourceAnchor?: string
+  modifierId?: string
+  inactiveReason?: string
+  sourceMissing?: boolean
+  diagnosticRefs?: string[]
+}): BucketContributor {
+  return {
+    id: input.id,
+    value: input.value,
+    operation: input.operation ?? "add",
+    active: input.active ?? true,
+    ...(input.source === undefined ? {} : { source: input.source }),
+    ...(input.sourceAnchor === undefined ? {} : { sourceAnchor: input.sourceAnchor }),
+    ...(input.modifierId === undefined ? {} : { modifierId: input.modifierId }),
+    ...(input.inactiveReason === undefined ? {} : { inactiveReason: input.inactiveReason }),
+    ...(input.sourceMissing === undefined ? {} : { sourceMissing: input.sourceMissing }),
+    ...(input.diagnosticRefs === undefined ? {} : { diagnosticRefs: input.diagnosticRefs }),
+  }
+}
+
+export function makeBucket(input: BucketInput): BucketResult {
+  return {
+    bucketId: input.bucketId,
+    before: input.before ?? 1,
+    after: input.after,
+    effectiveMultiplier: input.effectiveMultiplier,
+    contributors: input.contributors ?? [],
+    traceRefs: input.traceRefs ?? [],
+  }
+}
+
+export function getAttributeDamageBonus(panel: Record<string, unknown>, attribute: Attribute): number {
+  const field = getDamageBonusField(attribute)
+  const value = panel[field]
+  return typeof value === "number" ? value : 0
+}
+
+export function getResistance(enemy: EnemySnapshot, attribute: Attribute): number {
+  return enemy.resistance?.[getResistanceAttribute(attribute)] ?? 0
+}
+
+export function getEnemyDefense(enemy: EnemySnapshot, attackerLevel: number): number {
+  return enemy.defense ?? getDefaultEnemyBaseDefense(Math.min(attackerLevel, enemy.level), enemy.rank)
+}
+
+export function getDefenseMultiplier(input: {
+  attackerLevel: number
+  enemy: EnemySnapshot
+  penetrationRate?: number
+  flatPenetration?: number
+  defenseReduction?: number
+}): {
+  levelBase: number
+  baseDefense: number
+  effectiveDefense: number
+  multiplier: number
+} {
+  const levelBase = getLevelBase(input.attackerLevel)
+  const baseDefense = getEnemyDefense(input.enemy, input.attackerLevel)
+  const corruptedShieldMultiplier = input.enemy.corruptedShield?.active
+    ? input.enemy.corruptedShield.defenseMultiplier ?? 1.8
+    : 1
+  const effectiveDefense = Math.max(
+    0,
+    baseDefense
+    * corruptedShieldMultiplier
+    * (1 - (input.defenseReduction ?? 0))
+    * (1 - (input.penetrationRate ?? 0))
+    - (input.flatPenetration ?? 0),
+  )
+
+  return {
+    levelBase,
+    baseDefense,
+    effectiveDefense,
+    multiplier: levelBase / (effectiveDefense + levelBase),
+  }
+}
+
+export function getResistanceMultiplier(resistance: number, resistanceReduction = 0): number {
+  return clamp(1 - resistance + resistanceReduction, 0, 2)
+}
+
+export function getVulnerabilityMultiplier(vulnerability = 0, reduction = 0): number {
+  return clamp(1 + vulnerability - reduction, 0.2, 2)
+}
+
+export function getDazeVulnerabilityMultiplier(isDazed: boolean, dazeVulnerability = 0.5, nonDazeVulnerability = 0): number {
+  return isDazed
+    ? clamp(1 + dazeVulnerability, 0.2, 5)
+    : clamp(1 + nonDazeVulnerability, 1, 3)
+}
+
+export function isEnemyDazed(enemy: EnemySnapshot): boolean {
+  return enemy.states?.includes("dazed") ?? false
+}
+
+export function getCorruptedShieldDamageReduction(enemy: EnemySnapshot): number {
+  return enemy.corruptedShield?.active ? 0.25 : 0
+}
+
+export { clamp }

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest"
+import { calculate } from "./calculate"
+
+const source = {
+  sourceId: "fixture",
+  sourceVersion: "rules-v0.1",
+  sourceAnchor: "golden",
+}
+
+const baseSnapshot = {
+  schemaVersion: "1.0.0",
+  gameVersion: "ZZZ-2.2",
+  ruleSetVersion: "rules-v0.1",
+  dataVersion: "data-v0.1.0",
+  sourceVersion: "source-v0.1.0",
+  team: [
+    {
+      agentId: "yixuan",
+      level: 60,
+      agentSpecialty: "rupture",
+      attribute: "ether",
+      panel: {
+        attack: 1000,
+        maxHp: 12000,
+        sheerForce: 1000,
+        impact: 120,
+        critRate: 0,
+        critDamage: 0,
+      },
+    },
+  ],
+  activeActor: { agentId: "yixuan" },
+  attackSegments: [
+    {
+      id: "seg-1",
+      attribute: "ether",
+      tags: ["basic"],
+      damageType: "regular",
+      multiplier: 1,
+      source,
+    },
+  ],
+  enemy: {
+    level: 60,
+    rank: "boss",
+    maxHp: 1000000,
+  },
+}
+
+describe("calculate", () => {
+  it("computes the level 60 boss defense bucket for regular damage", () => {
+    const result = calculate(baseSnapshot)
+    const defense = result.buckets.find(bucket => bucket.bucketId === "defenseZone")
+
+    expect(defense?.effectiveMultiplier).toBeCloseTo(0.454545, 5)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.displayTotalDamage).toBe(455)
+  })
+
+  it("shows the corrupted shield sheer damage defense skip ratio", () => {
+    const regular = calculate({
+      ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        corruptedShield: { active: true, defenseMultiplier: 1.8 },
+      },
+    })
+    const sheer = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-sheer",
+          damageType: "sheer",
+        },
+      ],
+      enemy: {
+        ...baseSnapshot.enemy,
+        corruptedShield: { active: true, defenseMultiplier: 1.8 },
+      },
+    })
+
+    expect(regular.summary.rawTotalDamage).toBeCloseTo(237.342, 3)
+    expect(sheer.summary.rawTotalDamage).toBeCloseTo(750, 3)
+    expect(sheer.summary.rawTotalDamage / regular.summary.rawTotalDamage).toBeCloseTo(3.16, 3)
+    expect(sheer.trace.some(event => event.displayValue === "defenseSkipped")).toBe(true)
+  })
+
+  it("sums display damage after per-segment ceiling", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            sheerForce: 10,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-a",
+          damageType: "sheer",
+          multiplier: 0.11,
+        },
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-b",
+          damageType: "sheer",
+          multiplier: 0.11,
+        },
+      ],
+    })
+
+    expect(result.summary.rawTotalDamage).toBeCloseTo(2.2, 5)
+    expect(result.attackSegments.map(segment => segment.segmentDisplayDamage)).toEqual([2, 2])
+    expect(result.summary.displayTotalDamage).toBe(4)
+  })
+
+  it("computes corrupted shield cleanse true damage manual events", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      manualEvents: [
+        {
+          id: "cleanse-1",
+          kind: "corruptedShieldCleanse",
+          basePath: "enemy.maxHp",
+          trueDamageRule: "default15Percent",
+          source,
+        },
+      ],
+    })
+
+    expect(result.events?.[0]?.rawDamage).toBe(150000)
+    expect(result.summary.trueDamage).toBe(150000)
+  })
+
+  it("reports manual true damage events with missing base values as errors", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+      manualEvents: [
+        {
+          id: "cleanse-1",
+          kind: "corruptedShieldCleanse",
+          basePath: "enemy.maxHp",
+          trueDamageRule: "default15Percent",
+          source,
+        },
+      ],
+    })
+
+    expect(result.events?.[0]?.rawDamage).toBe(0)
+    expect(result.errors.some(item => item.key === "ERR-EVENT-001")).toBe(true)
+  })
+
+  it("keeps user modifiers without source calculable with sourceMissing diagnostics", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      modifiers: [
+        {
+          id: "tmp-bonus",
+          handlerId: "damage-bonus",
+          params: { value: 0.1 },
+          appliesTo: { kind: "activeActor" },
+        },
+      ],
+    })
+
+    const contributor = result.buckets
+      .find(bucket => bucket.bucketId === "damageBonusZone")
+      ?.contributors.find(item => item.modifierId === "tmp-bonus")
+
+    expect(result.warnings.some(item => item.key === "ERR-SRC-001")).toBe(true)
+    expect(contributor?.sourceMissing).toBe(true)
+    expect(contributor?.diagnosticRefs).toContain("ERR-SRC-001")
+    expect(result.modifiers.find(item => item.id === "tmp-bonus")?.active).toBe(true)
+  })
+
+  it("evaluates Condition DSL field/op/value trees for modifier activation", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        states: ["dazed"],
+      },
+      modifiers: [
+        {
+          id: "dazed-vulnerability",
+          handlerId: "vulnerability-bonus",
+          params: { value: 0.25 },
+          appliesTo: { kind: "enemy" },
+          when: { field: "enemy.states", op: "in", value: "dazed" },
+          source,
+        },
+      ],
+    })
+
+    const modifier = result.modifiers.find(item => item.id === "dazed-vulnerability")
+    const vulnerability = result.buckets.find(bucket => bucket.bucketId === "vulnerabilityZone")
+
+    expect(modifier?.active).toBe(true)
+    expect(vulnerability?.effectiveMultiplier).toBeCloseTo(1.25, 5)
+  })
+
+  it("emits bucket contribution trace refs for multiplier buckets", () => {
+    const result = calculate(baseSnapshot)
+    const defense = result.buckets.find(bucket => bucket.bucketId === "defenseZone")
+
+    expect(defense?.traceRefs.length).toBeGreaterThan(0)
+    expect(result.trace.some(event => event.kind === "bucketContribution" && event.path.includes("defenseZone"))).toBe(true)
+    expect(result.trace.find(event => event.path === "attackSegments[0].rawDamage")?.refs?.length).toBeGreaterThan(0)
+  })
+
+  it("applies daze modifiers to regular attack segments with baseDazeMultiplier", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          baseDazeMultiplier: 1,
+        },
+      ],
+      modifiers: [
+        {
+          id: "daze-inflict-up",
+          handlerId: "daze-inflict-bonus",
+          params: { value: 0.5 },
+          appliesTo: { kind: "activeActor" },
+          source,
+        },
+      ],
+    })
+
+    expect(result.attackSegments[0]?.dazeValue).toBe(180)
+    expect(result.buckets.some(bucket => bucket.bucketId === "dazeInflictZone")).toBe(true)
+  })
+
+  it("does not emit trusted anomaly damage before TL-S3-4", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            critRate: 0.5,
+            critDamage: 1,
+            anomalyProficiency: 600,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-anomaly",
+          damageType: "anomaly",
+          anomalyContribution: {
+            status: "shock",
+            buildup: 100,
+          },
+        },
+      ],
+    })
+
+    expect(result.summary.rawTotalDamage).toBe(0)
+    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-ANOMALY")).toBe(true)
+    expect(result.buckets.some(bucket => bucket.bucketId === "critZone")).toBe(false)
+    expect(result.trace.some(event => event.displayValue === "pending-formula")).toBe(true)
+  })
+
+  it("does not emit trusted disorder damage before TL-S3-4", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-disorder",
+          damageType: "disorder",
+          anomalyContribution: {
+            status: "disorder",
+            buildup: 100,
+          },
+        },
+      ],
+    })
+
+    expect(result.summary.rawTotalDamage).toBe(0)
+    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-DISORDER")).toBe(true)
+  })
+})

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -1,0 +1,1085 @@
+import type {
+  AgentSnapshot,
+  AttackSegment,
+  BattleSnapshot,
+  BucketContributor,
+  BucketResult,
+  CalcResult,
+  DamageType,
+  Diagnostic,
+  ManualEvent,
+  ManualEventResult,
+  ModifierResult,
+  MultiplierBucket,
+  SegmentResult,
+  SourceRef,
+  TargetSelector,
+  TraceEvent,
+  TypedModifier,
+} from "../schema"
+import { battleSnapshotSchema, calcResultSchema } from "../schema"
+import {
+  getAttributeDamageBonus,
+  getCorruptedShieldDamageReduction,
+  getDazeVulnerabilityMultiplier,
+  getDefenseMultiplier,
+  getResistance,
+  getResistanceMultiplier,
+  getVulnerabilityMultiplier,
+  isEnemyDazed,
+  makeBucket,
+  makeContributor,
+} from "./buckets"
+import { evaluateCondition } from "./condition"
+import { error, warning } from "./diagnostics"
+import { getHandlerBucket, resolveHandler } from "./handlers"
+import { clamp, sum } from "./math"
+import { makeTraceEvent, resetTraceCounter } from "./trace"
+import type { CalculateOptions } from "./types"
+
+const sourceMissingDiagnosticRef = "ERR-SRC-001"
+
+export function calculate(input: unknown, options: CalculateOptions = {}): CalcResult {
+  const snapshot = battleSnapshotSchema.parse(input)
+  resetTraceCounter()
+
+  const warnings: Diagnostic[] = [
+    ...getUnsupportedFeatureWarnings(snapshot),
+  ]
+  const errors: Diagnostic[] = []
+  const activeActor = getActiveActor(snapshot)
+  const segmentComputations = snapshot.attackSegments.map((segment, index) =>
+    calculateSegment(snapshot, activeActor, segment, index),
+  )
+  const manualEventResults = (snapshot.manualEvents ?? []).map((event, index) =>
+    calculateManualEvent(snapshot, event, index),
+  )
+
+  for (const segment of segmentComputations) {
+    warnings.push(...segment.warnings)
+    errors.push(...segment.errors)
+  }
+
+  for (const event of manualEventResults) {
+    warnings.push(...event.warnings)
+    errors.push(...event.errors)
+  }
+
+  const trace = [
+    ...segmentComputations.flatMap(segment => segment.trace),
+    ...manualEventResults.flatMap(event => event.trace),
+  ]
+  const attackSegments = segmentComputations.map(segment => segment.result)
+  const eventResults = manualEventResults.map(event => event.result)
+  const rawTotalDamage = sum([
+    ...attackSegments.map(segment => segment.rawDamage),
+    ...eventResults.map(event => event.rawDamage),
+  ])
+  const displayTotalDamage = sum([
+    ...attackSegments.map(segment => segment.segmentDisplayDamage),
+    ...eventResults.map(event => event.displayDamage),
+  ])
+  const expectedDamage = sum([
+    ...attackSegments.map(segment => segment.expectedDamage ?? segment.rawDamage),
+    ...eventResults.map(event => event.rawDamage),
+  ])
+  const result: CalcResult = {
+    schemaVersion: snapshot.schemaVersion,
+    gameVersion: snapshot.gameVersion,
+    ruleSetVersion: snapshot.ruleSetVersion,
+    dataVersion: snapshot.dataVersion,
+    sourceVersion: snapshot.sourceVersion,
+    ...(snapshot.originalGameVersion === undefined ? {} : { originalGameVersion: snapshot.originalGameVersion }),
+    ...(snapshot.originalRuleSetVersion === undefined ? {} : { originalRuleSetVersion: snapshot.originalRuleSetVersion }),
+    ...(snapshot.originalDataVersion === undefined ? {} : { originalDataVersion: snapshot.originalDataVersion }),
+    ...(snapshot.originalSourceVersion === undefined ? {} : { originalSourceVersion: snapshot.originalSourceVersion }),
+    ...(options.snapshotId === undefined ? {} : { snapshotId: options.snapshotId }),
+    calculationId: options.calculationId ?? "calc-1",
+    ...(snapshot.locale === undefined ? {} : { locale: snapshot.locale }),
+    summary: {
+      activeActorId: activeActor.agentId,
+      ...(snapshot.enemy.enemyId === undefined ? {} : { enemyId: snapshot.enemy.enemyId }),
+      damageType: getSummaryDamageType(attackSegments, eventResults),
+      rawTotalDamage,
+      displayTotalDamage,
+      expectedDamage,
+      critDamage: sum(attackSegments.map(segment => segment.critDamage ?? segment.rawDamage)),
+      nonCritDamage: sum(attackSegments.map(segment => segment.nonCritDamage ?? segment.rawDamage)),
+      dazeValue: sum(attackSegments.map(segment => segment.dazeValue ?? 0)),
+      anomalyBuildup: sum(attackSegments.map(segment => segment.anomalyBuildup ?? 0)),
+      disorderDamage: sum(attackSegments.filter(segment => segment.damageType === "disorder").map(segment => segment.rawDamage)),
+      trueDamage: sum(eventResults.map(event => event.rawDamage)),
+    },
+    attackSegments,
+    buckets: segmentComputations.flatMap(segment => segment.buckets),
+    modifiers: segmentComputations.flatMap(segment => segment.modifiers),
+    ...(eventResults.length === 0 ? {} : { events: eventResults }),
+    trace,
+    warnings,
+    errors,
+  }
+
+  return calcResultSchema.parse(result)
+}
+
+interface SegmentCalculation {
+  result: SegmentResult
+  buckets: BucketResult[]
+  modifiers: ModifierResult[]
+  trace: TraceEvent[]
+  warnings: Diagnostic[]
+  errors: Diagnostic[]
+}
+
+type ContributorSourceFields =
+  | { source: SourceRef }
+  | { sourceMissing: true; diagnosticRefs: string[] }
+
+function calculateSegment(
+  snapshot: BattleSnapshot,
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+  index: number,
+): SegmentCalculation {
+  const warnings: Diagnostic[] = []
+  const errors: Diagnostic[] = []
+  const damageType = segment.damageType
+  const sourceFields = getContributorSourceFields(segment.source, `attackSegments[${index}].source`, warnings)
+
+  if (isPendingAnomalyOrDisorder(damageType)) {
+    return calculatePendingAnomalyOrDisorderSegment(
+      activeActor,
+      segment,
+      index,
+      sourceFields,
+      warnings,
+      errors,
+    )
+  }
+
+  const modifierEvaluation = evaluateModifiers(snapshot, activeActor, segment, index)
+  warnings.push(...modifierEvaluation.warnings)
+  errors.push(...modifierEvaluation.errors)
+
+  const baseDamage = getBaseDamage(activeActor, segment)
+  const damageBonusValue = getDamageBonus(activeActor, segment)
+    + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("damageBonusZone"))
+  const damageBonusMultiplier = clamp(1 + damageBonusValue, 0, 6)
+  const critRate = clamp(activeActor.panel.critRate ?? 0, 0, 1)
+  const critDamageBonus = clamp(activeActor.panel.critDamage ?? 0, 0, 5)
+  const critMultiplier = getCritMultiplier(snapshot, segment, critRate, critDamageBonus)
+  const resistance = getResistance(snapshot.enemy, segment.attribute)
+  const resistanceReduction = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("resistanceZone"))
+  const resistanceMultiplier = getResistanceMultiplier(resistance, resistanceReduction)
+  const vulnerabilityBonus = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("vulnerabilityZone"))
+  const vulnerabilityMultiplier = getVulnerabilityMultiplier(
+    vulnerabilityBonus,
+    getCorruptedShieldDamageReduction(snapshot.enemy),
+  )
+  const dazeVulnerabilityBonus = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("dazeVulnerabilityZone"))
+  const dazeVulnerabilityMultiplier = getDazeVulnerabilityMultiplier(isEnemyDazed(snapshot.enemy), 0.5 + dazeVulnerabilityBonus)
+  const specialExtra = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("specialZone"))
+  const distanceDecayMultiplier = (segment.distanceDecay ?? 1) * clamp(1 + specialExtra, 0, 5)
+  const bucketInputs: BucketResult[] = [
+    makeBucket({
+      bucketId: "baseDamageZone",
+      before: 0,
+      after: baseDamage,
+      effectiveMultiplier: baseDamage,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:base-${damageType}`,
+          value: baseDamage,
+          operation: "add",
+          ...sourceFields,
+        }),
+      ],
+    }),
+    makeBucket({
+      bucketId: "damageBonusZone",
+      after: damageBonusMultiplier,
+      effectiveMultiplier: damageBonusMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:attribute-damage-bonus`,
+          value: getDamageBonus(activeActor, segment),
+          operation: "add",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "damageBonusZone"),
+      ],
+    }),
+  ]
+
+  if (usesStandardCrit(damageType)) {
+    bucketInputs.push(makeBucket({
+      bucketId: "critZone",
+      after: critMultiplier,
+      effectiveMultiplier: critMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:crit-expected`,
+          value: critMultiplier,
+          operation: "multiply",
+          ...sourceFields,
+        }),
+      ],
+    }))
+  }
+
+  if (usesDefenseZone(damageType)) {
+    const defenseReduction = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("defenseZone"))
+    const defense = getDefenseMultiplier({
+      attackerLevel: activeActor.level,
+      enemy: snapshot.enemy,
+      ...(activeActor.panel.penetrationRate === undefined ? {} : { penetrationRate: activeActor.panel.penetrationRate }),
+      ...(activeActor.panel.flatPenetration === undefined ? {} : { flatPenetration: activeActor.panel.flatPenetration }),
+      defenseReduction,
+    })
+    bucketInputs.push(makeBucket({
+      bucketId: "defenseZone",
+      after: defense.multiplier,
+      effectiveMultiplier: defense.multiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:base-defense`,
+          value: defense.baseDefense,
+          operation: "add",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "defenseZone"),
+      ],
+    }))
+  }
+
+  if (damageType === "sheer") {
+    const sheerDamageBonusValue = (activeActor.panel.sheerDamageBonus ?? 0)
+      + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("sheerDamageBonusZone"))
+    const sheerDamageBonusMultiplier = clamp(1 + sheerDamageBonusValue, 0.2, 9)
+    bucketInputs.push(makeBucket({
+      bucketId: "sheerDamageBonusZone",
+      after: sheerDamageBonusMultiplier,
+      effectiveMultiplier: sheerDamageBonusMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:sheer-damage-bonus`,
+          value: activeActor.panel.sheerDamageBonus ?? 0,
+          operation: "add",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "sheerDamageBonusZone"),
+      ],
+    }))
+  }
+
+  if (damageType === "anomaly" || damageType === "disorder") {
+    const anomalyProficiencyValue = clamp(
+      (activeActor.panel.anomalyProficiency ?? 100) / 100
+      + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("anomalyProficiencyZone")),
+      0,
+      10,
+    )
+    const damageLevelValue = getDamageLevelMultiplier(activeActor.level)
+      + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("damageLevelZone"))
+    const anomalyDamageBonusValue = 1
+      + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("anomalyDamageBonusZone"))
+    const anomalyCritValue = 1
+      + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("anomalyCritZone"))
+    bucketInputs.push(
+      makeBucket({
+        bucketId: "anomalyProficiencyZone",
+        after: anomalyProficiencyValue,
+        effectiveMultiplier: anomalyProficiencyValue,
+        contributors: [
+          makeContributor({
+            id: `${segment.id}:anomaly-proficiency`,
+            value: activeActor.panel.anomalyProficiency ?? 100,
+            operation: "multiply",
+            ...sourceFields,
+          }),
+          ...getModifierContributors(modifierEvaluation, "anomalyProficiencyZone"),
+        ],
+      }),
+      makeBucket({
+        bucketId: "damageLevelZone",
+        after: damageLevelValue,
+        effectiveMultiplier: damageLevelValue,
+        contributors: [
+          makeContributor({
+            id: `${segment.id}:damage-level`,
+            value: activeActor.level,
+            operation: "multiply",
+            ...sourceFields,
+          }),
+          ...getModifierContributors(modifierEvaluation, "damageLevelZone"),
+        ],
+      }),
+      makeBucket({
+        bucketId: "anomalyDamageBonusZone",
+        after: anomalyDamageBonusValue,
+        effectiveMultiplier: anomalyDamageBonusValue,
+        contributors: getModifierContributors(modifierEvaluation, "anomalyDamageBonusZone"),
+      }),
+      makeBucket({
+        bucketId: "anomalyCritZone",
+        after: anomalyCritValue,
+        effectiveMultiplier: anomalyCritValue,
+        contributors: getModifierContributors(modifierEvaluation, "anomalyCritZone"),
+      }),
+    )
+  }
+
+  bucketInputs.push(
+    makeBucket({
+      bucketId: "resistanceZone",
+      after: resistanceMultiplier,
+      effectiveMultiplier: resistanceMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:resistance`,
+          value: resistance,
+          operation: "add",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "resistanceZone"),
+      ],
+    }),
+    makeBucket({
+      bucketId: "vulnerabilityZone",
+      after: vulnerabilityMultiplier,
+      effectiveMultiplier: vulnerabilityMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:corrupted-shield-damage-reduction`,
+          value: -getCorruptedShieldDamageReduction(snapshot.enemy),
+          operation: "add",
+          active: snapshot.enemy.corruptedShield?.active ?? false,
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "vulnerabilityZone"),
+      ],
+    }),
+    makeBucket({
+      bucketId: "dazeVulnerabilityZone",
+      after: dazeVulnerabilityMultiplier,
+      effectiveMultiplier: dazeVulnerabilityMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:daze-vulnerability`,
+          value: dazeVulnerabilityMultiplier,
+          operation: "multiply",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "dazeVulnerabilityZone"),
+      ],
+    }),
+    makeBucket({
+      bucketId: "specialZone",
+      after: distanceDecayMultiplier,
+      effectiveMultiplier: distanceDecayMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:distance-decay`,
+          value: segment.distanceDecay ?? 1,
+          operation: "multiply",
+          ...sourceFields,
+        }),
+        ...getModifierContributors(modifierEvaluation, "specialZone"),
+      ],
+    }),
+  )
+
+  if (segment.baseDazeMultiplier !== undefined) {
+    bucketInputs.push(
+      makeBucket({
+        bucketId: "dazeValueZone",
+        after: getBaseDaze(activeActor, segment),
+        effectiveMultiplier: getBaseDaze(activeActor, segment),
+        contributors: [
+          makeContributor({
+            id: `${segment.id}:base-daze`,
+            value: getBaseDaze(activeActor, segment),
+            operation: "add",
+            ...sourceFields,
+          }),
+        ],
+      }),
+      makeBucket({
+        bucketId: "dazeInflictZone",
+        after: 1 + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("dazeInflictZone")),
+        effectiveMultiplier: 1 + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("dazeInflictZone")),
+        contributors: getModifierContributors(modifierEvaluation, "dazeInflictZone"),
+      }),
+      makeBucket({
+        bucketId: "dazeReceiveZone",
+        after: 1 + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("dazeReceiveZone")),
+        effectiveMultiplier: 1 + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("dazeReceiveZone")),
+        contributors: getModifierContributors(modifierEvaluation, "dazeReceiveZone"),
+      }),
+    )
+  }
+
+  const { buckets, trace: bucketTrace } = attachBucketContributionTrace(bucketInputs)
+  const effectiveMultiplier = buckets
+    .filter(isDamageFormulaBucket)
+    .reduce((total, bucket) => total * bucket.effectiveMultiplier, 1)
+  const rawDamage = damageType === "daze"
+    ? 0
+    : baseDamage * effectiveMultiplier
+  const segmentDisplayDamage = Math.ceil(rawDamage)
+  const trace = [
+    ...modifierEvaluation.trace,
+    ...bucketTrace,
+    makeTraceEvent({
+      kind: "formula",
+      path: `attackSegments[${index}].rawDamage`,
+      inputs: {
+        baseDamage,
+        damageType,
+        multiplier: segment.multiplier ?? 1,
+        bucketIds: buckets.map(bucket => bucket.bucketId),
+      },
+      formula: getFormulaLabel(damageType),
+      rawValue: rawDamage,
+      refs: buckets.flatMap(bucket => bucket.traceRefs),
+    }),
+    makeTraceEvent({
+      kind: "rounding",
+      path: `attackSegments[${index}].segmentDisplayDamage`,
+      rawValue: rawDamage,
+      displayValue: segmentDisplayDamage,
+      rounding: {
+        mode: "ceilPerSegment",
+        input: rawDamage,
+        output: segmentDisplayDamage,
+        reason: "Game display rounds each attack segment up before summing.",
+      },
+    }),
+  ]
+
+  if (damageType === "sheer") {
+    trace.push(makeTraceEvent({
+      kind: "formula",
+      path: "buckets[?bucketId=defenseZone]",
+      inputs: { damageType: "sheer" },
+      formula: "Sheer damage skips defenseZone.",
+      displayValue: "defenseSkipped",
+    }))
+  }
+
+  const nonCritMultiplier = buckets
+    .filter(bucket => isDamageFormulaBucket(bucket) && bucket.bucketId !== "critZone")
+    .reduce((total, bucket) => total * bucket.effectiveMultiplier, 1)
+  const nonCritDamage = damageType === "daze" ? 0 : baseDamage * nonCritMultiplier
+  const critDamage = damageType === "daze" ? 0 : nonCritDamage * (1 + critDamageBonus)
+  const dazeValue = getDazeValue(activeActor, segment, buckets)
+
+  return {
+    result: {
+      id: segment.id,
+      actorId: segment.actorId ?? activeActor.agentId,
+      attribute: segment.attribute,
+      tags: segment.tags,
+      damageType,
+      rawDamage,
+      segmentDisplayDamage,
+      roundingMode: "ceilPerSegment",
+      baseDamage,
+      expectedDamage: rawDamage,
+      critDamage,
+      nonCritDamage,
+      ...(segment.baseDazeMultiplier === undefined ? {} : { baseDaze: getBaseDaze(activeActor, segment) }),
+      ...(dazeValue === undefined ? {} : { dazeValue }),
+      ...(segment.anomalyContribution?.buildup === undefined ? {} : { anomalyBuildup: getAnomalyBuildup(activeActor, segment) }),
+      traceRefs: trace.map(event => event.id),
+    },
+    buckets,
+    modifiers: modifierEvaluation.modifiers,
+    trace,
+    warnings,
+    errors,
+  }
+}
+
+function calculatePendingAnomalyOrDisorderSegment(
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+  index: number,
+  sourceFields: ContributorSourceFields,
+  warnings: Diagnostic[],
+  errors: Diagnostic[],
+): SegmentCalculation {
+  const diagnosticKey = segment.damageType === "anomaly"
+    ? "ERR-CALC-PENDING-ANOMALY"
+    : "ERR-CALC-PENDING-DISORDER"
+  warnings.push(warning(diagnosticKey, `attackSegments[${index}].damageType`, {
+    damageType: segment.damageType,
+    followUpTask: "#27",
+  }))
+
+  const rawBuckets = [
+    makeBucket({
+      bucketId: "baseDamageZone",
+      before: 0,
+      after: 0,
+      effectiveMultiplier: 0,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:pending-${segment.damageType}`,
+          value: 0,
+          operation: "ignore",
+          active: false,
+          inactiveReason: `${segment.damageType}-formula-pending`,
+          ...sourceFields,
+        }),
+      ],
+    }),
+  ]
+  const { buckets, trace: bucketTrace } = attachBucketContributionTrace(rawBuckets)
+  const trace = [
+    ...bucketTrace,
+    makeTraceEvent({
+      kind: "warning",
+      path: `attackSegments[${index}].damageType`,
+      inputs: {
+        damageType: segment.damageType,
+        diagnosticKey,
+        followUpTask: "#27",
+      },
+      displayValue: "pending-formula",
+      refs: buckets.flatMap(bucket => bucket.traceRefs),
+    }),
+    makeTraceEvent({
+      kind: "formula",
+      path: `attackSegments[${index}].rawDamage`,
+      inputs: {
+        damageType: segment.damageType,
+        diagnosticKey,
+      },
+      formula: "pending anomaly/disorder formula: no trusted numeric damage emitted in PR #10",
+      rawValue: 0,
+      displayValue: "pending-formula",
+      refs: buckets.flatMap(bucket => bucket.traceRefs),
+    }),
+    makeTraceEvent({
+      kind: "rounding",
+      path: `attackSegments[${index}].segmentDisplayDamage`,
+      rawValue: 0,
+      displayValue: 0,
+      rounding: {
+        mode: "ceilPerSegment",
+        input: 0,
+        output: 0,
+        reason: "Pending anomaly/disorder formula emits zero display damage until task #27 implements trusted evidence.",
+      },
+    }),
+  ]
+
+  return {
+    result: {
+      id: segment.id,
+      actorId: segment.actorId ?? activeActor.agentId,
+      attribute: segment.attribute,
+      tags: segment.tags,
+      damageType: segment.damageType,
+      rawDamage: 0,
+      segmentDisplayDamage: 0,
+      roundingMode: "ceilPerSegment",
+      baseDamage: 0,
+      expectedDamage: 0,
+      traceRefs: trace.map(event => event.id),
+    },
+    buckets,
+    modifiers: [],
+    trace,
+    warnings,
+    errors,
+  }
+}
+
+interface ModifierEvaluation {
+  contributorsByBucket: Map<MultiplierBucket, BucketContributor[]>
+  modifiers: ModifierResult[]
+  trace: TraceEvent[]
+  warnings: Diagnostic[]
+  errors: Diagnostic[]
+}
+
+function evaluateModifiers(
+  snapshot: BattleSnapshot,
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+  segmentIndex: number,
+): ModifierEvaluation {
+  const contributorsByBucket = new Map<MultiplierBucket, BucketContributor[]>()
+  const modifiers: ModifierResult[] = []
+  const trace: TraceEvent[] = []
+  const warnings: Diagnostic[] = []
+  const errors: Diagnostic[] = []
+  const sortedModifiers = [...(snapshot.modifiers ?? [])].sort((left, right) => (left.priority ?? 0) - (right.priority ?? 0))
+
+  sortedModifiers.forEach((modifier, modifierIndex) => {
+    const handler = resolveHandler(modifier.handlerId)
+    const bucket = getHandlerBucket(modifier)
+    const targetMatches = doesTargetMatch(modifier.appliesTo, snapshot, activeActor, segment)
+    const conditionMatches = modifier.when === undefined || evaluateCondition(modifier.when, {
+      snapshot,
+      activeActor,
+      target: getTargetValue(modifier.appliesTo, snapshot, activeActor, segment),
+      enemy: snapshot.enemy,
+      segment,
+      modifier,
+    })
+    const inactiveReason = getModifierInactiveReason(modifier, handler !== undefined, targetMatches, conditionMatches)
+    const producedContributors: string[] = []
+    const sourceDiagnostic = modifier.source === undefined
+      ? {
+          warningKey: sourceMissingDiagnosticRef,
+          diagnosticRef: sourceMissingDiagnosticRef,
+        }
+      : undefined
+    if (sourceDiagnostic !== undefined) {
+      warnings.push(warning(sourceDiagnostic.warningKey, `modifiers[${modifierIndex}].source`, {
+        modifierId: modifier.id,
+      }))
+    }
+
+    if (inactiveReason === undefined && handler !== undefined && bucket !== undefined) {
+      const output = handler.apply({
+        modifier,
+        ...(sourceDiagnostic === undefined ? {} : { sourceDiagnostic }),
+      })
+      const bucketContributors = contributorsByBucket.get(output.bucket) ?? []
+      bucketContributors.push(...output.contributors)
+      contributorsByBucket.set(output.bucket, bucketContributors)
+      producedContributors.push(...output.contributors.map(contributor => contributor.id))
+    }
+    else if (handler === undefined) {
+      errors.push(error("ERR-DAT-004", `modifiers[${modifierIndex}].handlerId`, {
+        handlerId: modifier.handlerId,
+      }))
+    }
+
+    const activationTrace = makeTraceEvent({
+      kind: "modifierActivation",
+      path: `attackSegments[${segmentIndex}].modifiers[${modifierIndex}]`,
+      inputs: {
+        modifierId: modifier.id,
+        handlerId: modifier.handlerId,
+        appliesTo: modifier.appliesTo,
+        conditionMatches,
+        targetMatches,
+      },
+      active: inactiveReason === undefined,
+      ...(inactiveReason === undefined ? {} : { inactiveReason }),
+      ...(modifier.source === undefined ? {} : { source: modifier.source }),
+      refs: producedContributors,
+    })
+    trace.push(activationTrace)
+    modifiers.push({
+      id: modifier.id,
+      handlerId: modifier.handlerId,
+      active: inactiveReason === undefined,
+      appliesTo: modifier.appliesTo,
+      ...(bucket === undefined ? {} : { bucket }),
+      ...(modifier.source === undefined ? { sourceMissing: true } : { source: modifier.source }),
+      ...(inactiveReason === undefined ? {} : { inactiveReason }),
+      ...(producedContributors.length === 0 ? {} : { producedContributors }),
+      traceRefs: [activationTrace.id],
+    })
+  })
+
+  return {
+    contributorsByBucket,
+    modifiers,
+    trace,
+    warnings,
+    errors,
+  }
+}
+
+interface ManualEventCalculation {
+  result: ManualEventResult
+  trace: TraceEvent[]
+  warnings: Diagnostic[]
+  errors: Diagnostic[]
+}
+
+function calculateManualEvent(
+  snapshot: BattleSnapshot,
+  event: ManualEvent,
+  index: number,
+): ManualEventCalculation {
+  const warnings: Diagnostic[] = []
+  const errors: Diagnostic[] = []
+  const base = getManualEventBaseValue(snapshot, event)
+  if (base.error !== undefined)
+    errors.push(base.error)
+
+  const baseValue = base.value
+  const multiplier = getManualEventMultiplier(event)
+  const flatValue = getManualEventFlatValue(event)
+  const rawDamage = baseValue * multiplier + (flatValue ?? 0)
+  const displayDamage = Math.ceil(rawDamage)
+  const trace = [
+    makeTraceEvent({
+      kind: "formula",
+      path: `events[${index}].rawDamage`,
+      inputs: {
+        eventId: event.id,
+        kind: event.kind,
+        baseValue,
+        multiplier,
+      },
+      formula: "manualEventDamage = baseValue * multiplier + flatValue",
+      rawValue: rawDamage,
+      displayValue: displayDamage,
+      ...(event.source === undefined ? {} : { source: event.source }),
+    }),
+  ]
+
+  return {
+    result: {
+      id: event.id,
+      kind: event.kind,
+      ...(event.ruleId === undefined ? {} : { ruleId: event.ruleId }),
+      ...(event.source === undefined ? {} : { source: event.source }),
+      ...(event.basePath === undefined ? {} : { basePath: event.basePath }),
+      baseValue,
+      multiplier,
+      ...(flatValue === undefined ? {} : { flatValue }),
+      rawDamage,
+      displayDamage,
+      traceRefs: trace.map(item => item.id),
+    },
+    trace,
+    warnings,
+    errors,
+  }
+}
+
+function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment): number {
+  const multiplier = segment.multiplier ?? 1
+  if (segment.damageType === "sheer")
+    return (activeActor.panel.sheerForce ?? 0) * multiplier
+
+  if (segment.damageType === "daze")
+    return 0
+
+  return activeActor.panel.attack * multiplier
+}
+
+function getBaseDaze(activeActor: AgentSnapshot, segment: AttackSegment): number {
+  return (activeActor.panel.impact ?? 0) * (segment.baseDazeMultiplier ?? 0)
+}
+
+function getDazeValue(activeActor: AgentSnapshot, segment: AttackSegment, buckets: BucketResult[]): number | undefined {
+  if (segment.baseDazeMultiplier === undefined)
+    return undefined
+
+  const multiplier = buckets
+    .filter(bucket => bucket.bucketId === "dazeInflictZone" || bucket.bucketId === "dazeReceiveZone")
+    .reduce((total, bucket) => total * bucket.effectiveMultiplier, 1)
+
+  return getBaseDaze(activeActor, segment) * multiplier
+}
+
+function getAnomalyBuildup(activeActor: AgentSnapshot, segment: AttackSegment): number {
+  const baseBuildup = segment.anomalyContribution?.buildup ?? 0
+  return baseBuildup * ((activeActor.panel.anomalyMastery ?? 100) / 100)
+}
+
+function getDamageBonus(activeActor: AgentSnapshot, segment: AttackSegment): number {
+  if (segment.damageType === "sheer" || segment.damageType === "daze")
+    return 0
+
+  const panelRecord = activeActor.panel as unknown as Record<string, unknown>
+  const attributeBonus = getAttributeDamageBonus(panelRecord, segment.attribute)
+  return typeof attributeBonus === "number" ? attributeBonus : 0
+}
+
+function getCritMultiplier(
+  snapshot: BattleSnapshot,
+  segment: AttackSegment,
+  critRate: number,
+  critDamageBonus: number,
+): number {
+  if (segment.expectedCrit === true)
+    return 1 + critDamageBonus
+
+  if (snapshot.options?.resultMode === "nonCrit")
+    return 1
+
+  if (snapshot.options?.resultMode === "crit")
+    return 1 + critDamageBonus
+
+  return 1 + critRate * critDamageBonus
+}
+
+function getFormulaLabel(damageType: DamageType): string {
+  switch (damageType) {
+    case "sheer":
+      return "baseDamageZone * damageBonusZone * critZone * sheerDamageBonusZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone"
+    case "anomaly":
+      return "baseDamageZone * damageBonusZone * anomalyProficiencyZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * damageLevelZone * anomalyDamageBonusZone * anomalyCritZone * specialZone"
+    case "disorder":
+      return "baseDamageZone * damageBonusZone * anomalyProficiencyZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * damageLevelZone * anomalyDamageBonusZone * anomalyCritZone * specialZone"
+    case "daze":
+      return "dazeValueZone * dazeInflictZone * dazeReceiveZone"
+    case "trueDamage":
+      return "manual true damage event"
+    default:
+      return "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone"
+  }
+}
+
+function usesDefenseZone(damageType: DamageType): boolean {
+  return damageType === "regular" || damageType === "anomaly" || damageType === "disorder" || damageType === "daze"
+}
+
+function usesStandardCrit(damageType: DamageType): boolean {
+  return damageType === "regular" || damageType === "sheer"
+}
+
+function isPendingAnomalyOrDisorder(damageType: DamageType): boolean {
+  return damageType === "anomaly" || damageType === "disorder"
+}
+
+function isDamageFormulaBucket(bucket: BucketResult): boolean {
+  return bucket.bucketId !== "baseDamageZone"
+    && bucket.bucketId !== "dazeValueZone"
+    && bucket.bucketId !== "dazeInflictZone"
+    && bucket.bucketId !== "dazeReceiveZone"
+}
+
+function attachBucketContributionTrace(buckets: BucketResult[]): {
+  buckets: BucketResult[]
+  trace: TraceEvent[]
+} {
+  const trace: TraceEvent[] = []
+  const tracedBuckets = buckets.map((bucket) => {
+    const traceRefs = [...bucket.traceRefs]
+    bucket.contributors.forEach((contributor, contributorIndex) => {
+      const event = makeTraceEvent({
+        kind: "bucketContribution",
+        path: `buckets[?bucketId=${bucket.bucketId}].contributors[${contributorIndex}]`,
+        inputs: {
+          bucketId: bucket.bucketId,
+          contributorId: contributor.id,
+          operation: contributor.operation,
+          active: contributor.active,
+          modifierId: contributor.modifierId,
+          sourceMissing: contributor.sourceMissing,
+        },
+        rawValue: contributor.value,
+        displayValue: bucket.effectiveMultiplier,
+        ...(contributor.source === undefined ? {} : { source: contributor.source }),
+        ...(contributor.inactiveReason === undefined ? {} : { inactiveReason: contributor.inactiveReason }),
+        ...(contributor.diagnosticRefs === undefined ? {} : { refs: contributor.diagnosticRefs }),
+      })
+      trace.push(event)
+      traceRefs.push(event.id)
+    })
+
+    return {
+      ...bucket,
+      traceRefs,
+    }
+  })
+
+  return {
+    buckets: tracedBuckets,
+    trace,
+  }
+}
+
+function getDamageLevelMultiplier(level: number): number {
+  return clamp(1 + ((Math.min(Math.max(level, 1), 60) - 1) / 59), 1, 2)
+}
+
+interface ManualEventBaseValue {
+  value: number
+  error?: Diagnostic
+}
+
+function getManualEventBaseValue(snapshot: BattleSnapshot, event: ManualEvent): ManualEventBaseValue {
+  if (event.basePath === "enemy.maxHp") {
+    if (snapshot.enemy.maxHp !== undefined)
+      return { value: snapshot.enemy.maxHp }
+
+    return {
+      value: 0,
+      error: error("ERR-EVENT-001", "enemy.maxHp", {
+        eventId: event.id,
+        basePath: event.basePath,
+      }),
+    }
+  }
+
+  if (event.basePath === "part.maxHp") {
+    return {
+      value: 0,
+      error: error("ERR-EVENT-003", `manualEvents[?id=${event.id}].partId`, {
+        eventId: event.id,
+        partId: "partId" in event ? event.partId : "unknown",
+        enemyId: snapshot.enemy.enemyId ?? "unknown",
+      }),
+    }
+  }
+
+  return {
+    value: 0,
+    error: error("ERR-EVENT-001", `manualEvents[?id=${event.id}].basePath`, {
+      eventId: event.id,
+      basePath: event.basePath,
+    }),
+  }
+}
+
+function getManualEventMultiplier(event: ManualEvent): number {
+  if (event.multiplier !== undefined)
+    return event.multiplier
+
+  if (event.kind === "corruptedShieldCleanse") {
+    switch (event.trueDamageRule) {
+      case "pre22CorruptionPriest3Percent":
+        return 0.03
+      case "post22ShieldBoss25Permille":
+        return 0.025
+      case "default15Percent":
+      default:
+        return 0.15
+    }
+  }
+
+  return 0
+}
+
+function getManualEventFlatValue(event: ManualEvent): number | undefined {
+  return "flatValue" in event ? event.flatValue : undefined
+}
+
+function getActiveActor(snapshot: BattleSnapshot): AgentSnapshot {
+  const actor = snapshot.team.find(agent => agent.agentId === snapshot.activeActor.agentId)
+  if (actor === undefined)
+    throw new Error("activeActor.agentId must reference a team agent")
+
+  return actor
+}
+
+function getSummaryDamageType(
+  attackSegments: SegmentResult[],
+  manualEvents: ManualEventResult[],
+): DamageType {
+  if (attackSegments.length > 0)
+    return attackSegments[0]!.damageType
+
+  if (manualEvents.length > 0)
+    return "trueDamage"
+
+  return "regular"
+}
+
+function getUnsupportedFeatureWarnings(snapshot: BattleSnapshot): Diagnostic[] {
+  const warnings: Diagnostic[] = []
+  snapshot.team.forEach((agent, index) => {
+    if (agent.subordinate !== undefined) {
+      warnings.push(warning(
+        "ERR-UI-003",
+        `team[${index}].subordinate`,
+        { field: "subordinate" },
+      ))
+    }
+  })
+  return warnings
+}
+
+function getContributorSourceFields(
+  source: SourceRef | undefined,
+  path: string,
+  warnings: Diagnostic[],
+): { source: SourceRef } | { sourceMissing: true; diagnosticRefs: string[] } {
+  if (source !== undefined)
+    return { source }
+
+  warnings.push(warning(sourceMissingDiagnosticRef, path, { path }))
+  return {
+    sourceMissing: true,
+    diagnosticRefs: [sourceMissingDiagnosticRef],
+  }
+}
+
+function getModifierContributors(evaluation: ModifierEvaluation, bucket: MultiplierBucket): BucketContributor[] {
+  return evaluation.contributorsByBucket.get(bucket) ?? []
+}
+
+function sumBucketContributors(contributors: BucketContributor[] | undefined): number {
+  return sum((contributors ?? [])
+    .filter(contributor => contributor.active)
+    .map(contributor => contributor.value))
+}
+
+function getModifierInactiveReason(
+  modifier: TypedModifier,
+  handlerKnown: boolean,
+  targetMatches: boolean,
+  conditionMatches: boolean,
+): string | undefined {
+  if (modifier.active === false)
+    return "inactive-flag"
+
+  if (!handlerKnown)
+    return "unknown-handler"
+
+  if (!targetMatches)
+    return "target-not-matched"
+
+  if (!conditionMatches)
+    return "condition-not-met"
+
+  return undefined
+}
+
+function doesTargetMatch(
+  selector: TargetSelector,
+  snapshot: BattleSnapshot,
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+): boolean {
+  const actorId = segment.actorId ?? activeActor.agentId
+  switch (selector.kind) {
+    case "self":
+    case "activeActor":
+      return actorId === activeActor.agentId
+    case "agent":
+      return actorId === selector.agentId
+    case "team":
+      return selector.includeSelf === true || actorId !== activeActor.agentId
+    case "enemy":
+    case "segment":
+    case "global":
+      return true
+  }
+}
+
+function getTargetValue(
+  selector: TargetSelector,
+  snapshot: BattleSnapshot,
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+): unknown {
+  switch (selector.kind) {
+    case "enemy":
+      return snapshot.enemy
+    case "segment":
+      return segment
+    case "agent":
+      return snapshot.team.find(agent => agent.agentId === selector.agentId)
+    case "team":
+      return snapshot.team
+    case "self":
+    case "activeActor":
+    case "global":
+      return activeActor
+  }
+}

--- a/packages/core/src/engine/condition.ts
+++ b/packages/core/src/engine/condition.ts
@@ -1,0 +1,124 @@
+import type {
+  AgentSnapshot,
+  AttackSegment,
+  BattleSnapshot,
+  ConditionAst,
+  EnemySnapshot,
+  TypedModifier,
+} from "../schema"
+
+export interface ConditionContext {
+  snapshot: BattleSnapshot
+  activeActor: AgentSnapshot
+  target?: unknown
+  enemy: EnemySnapshot
+  segment: AttackSegment
+  modifier: TypedModifier
+}
+
+const missing = Symbol("missing")
+
+export function evaluateCondition(condition: ConditionAst, context: ConditionContext): boolean {
+  if ("all" in condition)
+    return condition.all.every(child => evaluateCondition(child, context))
+
+  if ("any" in condition)
+    return condition.any.some(child => evaluateCondition(child, context))
+
+  if ("not" in condition)
+    return !evaluateCondition(condition.not, context)
+
+  const resolved = resolveConditionPath(condition.field, context)
+  const exists = resolved !== missing && resolved !== null
+
+  if (condition.op === "exists")
+    return exists
+
+  if (!exists)
+    return false
+
+  switch (condition.op) {
+    case "eq":
+      return deepEqual(resolved, condition.value)
+    case "neq":
+      return !deepEqual(resolved, condition.value)
+    case "in":
+      return valueIn(resolved, condition.value)
+    case "notIn":
+      return !valueIn(resolved, condition.value)
+    case "gt":
+      return compareNumber(resolved, condition.value, (left, right) => left > right)
+    case "gte":
+      return compareNumber(resolved, condition.value, (left, right) => left >= right)
+    case "lt":
+      return compareNumber(resolved, condition.value, (left, right) => left < right)
+    case "lte":
+      return compareNumber(resolved, condition.value, (left, right) => left <= right)
+  }
+}
+
+function resolveConditionPath(path: string, context: ConditionContext): unknown | typeof missing {
+  const [root, ...segments] = path.split(".")
+  const roots: Record<string, unknown> = {
+    snapshot: context.snapshot,
+    activeActor: context.activeActor,
+    target: context.target,
+    enemy: context.enemy,
+    segment: context.segment,
+    modifier: context.modifier,
+  }
+
+  if (root === undefined || !(root in roots))
+    return missing
+
+  let current = roots[root]
+  for (const segment of segments) {
+    if (current === null || current === undefined)
+      return missing
+
+    if (Array.isArray(current) && isArrayIndex(segment)) {
+      const index = Number(segment)
+      current = current[index]
+      continue
+    }
+
+    if (typeof current !== "object")
+      return missing
+
+    const record = current as Record<string, unknown>
+    if (!(segment in record))
+      return missing
+
+    current = record[segment]
+  }
+
+  return current
+}
+
+function valueIn(resolved: unknown, expected: unknown): boolean {
+  if (Array.isArray(resolved))
+    return resolved.some(item => deepEqual(item, expected))
+
+  if (Array.isArray(expected))
+    return expected.some(item => deepEqual(item, resolved))
+
+  return false
+}
+
+function compareNumber(
+  resolved: unknown,
+  expected: unknown,
+  comparator: (left: number, right: number) => boolean,
+): boolean {
+  return typeof resolved === "number"
+    && typeof expected === "number"
+    && comparator(resolved, expected)
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function isArrayIndex(value: string): boolean {
+  return /^\d+$/.test(value)
+}

--- a/packages/core/src/engine/diagnostics.ts
+++ b/packages/core/src/engine/diagnostics.ts
@@ -1,0 +1,19 @@
+import type { Diagnostic } from "../schema"
+
+export function warning(key: string, path?: string, messageParams?: Record<string, unknown>): Diagnostic {
+  return {
+    key,
+    severity: "warning",
+    ...(path === undefined ? {} : { path }),
+    ...(messageParams === undefined ? {} : { messageParams }),
+  }
+}
+
+export function error(key: string, path?: string, messageParams?: Record<string, unknown>): Diagnostic {
+  return {
+    key,
+    severity: "error",
+    ...(path === undefined ? {} : { path }),
+    ...(messageParams === undefined ? {} : { messageParams }),
+  }
+}

--- a/packages/core/src/engine/handlers.ts
+++ b/packages/core/src/engine/handlers.ts
@@ -1,0 +1,93 @@
+import type {
+  BucketContributor,
+  MultiplierBucket,
+  TypedModifier,
+} from "../schema"
+import { makeContributor } from "./buckets"
+
+export interface HandlerDiagnostic {
+  warningKey: string
+  diagnosticRef: string
+}
+
+export interface HandlerInput {
+  modifier: TypedModifier
+  sourceDiagnostic?: HandlerDiagnostic
+}
+
+export interface HandlerOutput {
+  bucket: MultiplierBucket
+  contributors: BucketContributor[]
+}
+
+export interface ModifierHandler {
+  id: string
+  bucket: MultiplierBucket
+  apply(input: HandlerInput): HandlerOutput
+}
+
+const handlerBuckets: Record<string, MultiplierBucket> = {
+  "damage-bonus": "damageBonusZone",
+  "defense-reduction": "defenseZone",
+  "defense-ignore": "defenseZone",
+  "resistance-reduction": "resistanceZone",
+  "vulnerability-bonus": "vulnerabilityZone",
+  "daze-vulnerability-bonus": "dazeVulnerabilityZone",
+  "sheer-damage-bonus": "sheerDamageBonusZone",
+  "daze-inflict-bonus": "dazeInflictZone",
+  "daze-receive-bonus": "dazeReceiveZone",
+  "anomaly-proficiency-bonus": "anomalyProficiencyZone",
+  "anomaly-damage-bonus": "anomalyDamageBonusZone",
+  "anomaly-crit-bonus": "anomalyCritZone",
+  "damage-level-bonus": "damageLevelZone",
+  "special-multiplier": "specialZone",
+}
+
+export const defaultHandlerRegistry: ReadonlyMap<string, ModifierHandler> = new Map(
+  Object.entries(handlerBuckets).map(([id, bucket]) => [
+    id,
+    {
+      id,
+      bucket,
+      apply: ({ modifier, sourceDiagnostic }) => {
+        const value = readNumericParam(modifier)
+        const contributorId = `${modifier.id}:contribution`
+        return {
+          bucket,
+          contributors: [
+            makeContributor({
+              id: contributorId,
+              value,
+              operation: "add",
+              modifierId: modifier.id,
+              ...sourceFields(modifier, sourceDiagnostic),
+            }),
+          ],
+        }
+      },
+    },
+  ]),
+)
+
+export function resolveHandler(handlerId: string): ModifierHandler | undefined {
+  return defaultHandlerRegistry.get(handlerId)
+}
+
+export function getHandlerBucket(modifier: TypedModifier): MultiplierBucket | undefined {
+  return modifier.bucket ?? defaultHandlerRegistry.get(modifier.handlerId)?.bucket
+}
+
+function readNumericParam(modifier: TypedModifier): number {
+  const paramValue = modifier.params.value ?? modifier.params.multiplier ?? modifier.params.amount
+  return typeof paramValue === "number" ? paramValue : 0
+}
+
+function sourceFields(modifier: TypedModifier, diagnostic?: HandlerDiagnostic) {
+  if (modifier.source !== undefined)
+    return { source: modifier.source }
+
+  return {
+    sourceMissing: true,
+    diagnosticRefs: [diagnostic?.diagnosticRef ?? diagnostic?.warningKey ?? "ERR-SRC-001"],
+  }
+}

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -1,0 +1,4 @@
+export * from "./calculate"
+export * from "./condition"
+export * from "./handlers"
+export * from "./math"

--- a/packages/core/src/engine/math.ts
+++ b/packages/core/src/engine/math.ts
@@ -1,0 +1,89 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0)
+}
+
+export function getLevelBase(level: number): number {
+  if (level >= 60)
+    return 794
+
+  const table: Record<number, number> = {
+    1: 50,
+    2: 54,
+    3: 58,
+    4: 62,
+    5: 66,
+    6: 71,
+    7: 76,
+    8: 82,
+    9: 88,
+    10: 94,
+    11: 100,
+    12: 107,
+    13: 114,
+    14: 121,
+    15: 129,
+    16: 137,
+    17: 145,
+    18: 153,
+    19: 162,
+    20: 172,
+    21: 181,
+    22: 191,
+    23: 201,
+    24: 211,
+    25: 222,
+    26: 233,
+    27: 245,
+    28: 256,
+    29: 268,
+    30: 281,
+    31: 293,
+    32: 306,
+    33: 319,
+    34: 333,
+    35: 347,
+    36: 361,
+    37: 375,
+    38: 390,
+    39: 405,
+    40: 421,
+    41: 436,
+    42: 452,
+    43: 469,
+    44: 485,
+    45: 502,
+    46: 519,
+    47: 537,
+    48: 555,
+    49: 573,
+    50: 592,
+    51: 610,
+    52: 629,
+    53: 649,
+    54: 669,
+    55: 689,
+    56: 709,
+    57: 730,
+    58: 751,
+    59: 772,
+  }
+
+  return table[level] ?? 794
+}
+
+export function getDefaultEnemyBaseDefense(level: number, rank: string): number {
+  const levelBase = getLevelBase(level)
+  const baseDefenseAtLevelOne = rank === "boss"
+    ? 60
+    : rank === "elite"
+      ? 50
+      : rank === "special"
+        ? 60
+        : 40
+
+  return (baseDefenseAtLevelOne / 50) * levelBase
+}

--- a/packages/core/src/engine/trace.ts
+++ b/packages/core/src/engine/trace.ts
@@ -1,0 +1,50 @@
+import type {
+  LocalizedLabel,
+  RoundingMode,
+  SourceRef,
+  TraceEvent,
+  TraceKind,
+} from "../schema"
+
+let traceCounter = 0
+
+export function resetTraceCounter(): void {
+  traceCounter = 0
+}
+
+export function makeTraceEvent(input: {
+  kind: TraceKind
+  path: string
+  label?: LocalizedLabel
+  inputs?: Record<string, unknown>
+  formula?: string
+  rawValue?: unknown
+  displayValue?: unknown
+  rounding?: { mode: RoundingMode; input: number; output: number; reason: string }
+  source?: SourceRef
+  sourceAlias?: string
+  sourceAnchor?: string
+  active?: boolean
+  inactiveReason?: string
+  refs?: string[]
+}): TraceEvent {
+  traceCounter += 1
+
+  return {
+    id: `trace-${traceCounter}`,
+    kind: input.kind,
+    path: input.path,
+    ...(input.label === undefined ? {} : { label: input.label }),
+    ...(input.inputs === undefined ? {} : { inputs: input.inputs }),
+    ...(input.formula === undefined ? {} : { formula: input.formula }),
+    ...(input.rawValue === undefined ? {} : { rawValue: input.rawValue }),
+    ...(input.displayValue === undefined ? {} : { displayValue: input.displayValue }),
+    ...(input.rounding === undefined ? {} : { rounding: input.rounding }),
+    ...(input.source === undefined ? {} : { source: input.source }),
+    ...(input.sourceAlias === undefined ? {} : { sourceAlias: input.sourceAlias }),
+    ...(input.sourceAnchor === undefined ? {} : { sourceAnchor: input.sourceAnchor }),
+    ...(input.active === undefined ? {} : { active: input.active }),
+    ...(input.inactiveReason === undefined ? {} : { inactiveReason: input.inactiveReason }),
+    ...(input.refs === undefined ? {} : { refs: input.refs }),
+  }
+}

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -1,0 +1,62 @@
+import type {
+  AttackSegment,
+  BattleSnapshot,
+  BucketContributor,
+  BucketResult,
+  CalcResult,
+  DamageType,
+  Diagnostic,
+  ManualEvent,
+  ManualEventResult,
+  MultiplierBucket,
+  SegmentResult,
+  SourceRef,
+  TraceEvent,
+} from "../schema"
+
+export interface CalculateOptions {
+  calculationId?: string
+  snapshotId?: string
+}
+
+export interface CalculationState {
+  snapshot: BattleSnapshot
+  calculationId: string
+  snapshotId?: string
+  trace: TraceEvent[]
+  warnings: Diagnostic[]
+  errors: Diagnostic[]
+}
+
+export interface SegmentComputation {
+  segment: AttackSegment
+  result: SegmentResult
+  buckets: BucketResult[]
+}
+
+export interface BucketInput {
+  bucketId: MultiplierBucket
+  before?: number
+  after: number
+  effectiveMultiplier: number
+  contributors?: BucketContributor[]
+  traceRefs?: string[]
+}
+
+export interface DamageFormulaInput {
+  baseDamage: number
+  damageType: DamageType
+  buckets: BucketInput[]
+}
+
+export interface ManualEventComputation {
+  event: ManualEvent
+  result: ManualEventResult
+}
+
+export interface SourceAwareValue {
+  value: number
+  source?: SourceRef
+}
+
+export type CalculateResult = CalcResult

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema"
 export * from "./validators"
+export * from "./engine"


### PR DESCRIPTION
## Slock Context
- Owner: @TechLead
- Task: #23 + #24
- Reviewers: @Product, @QA, @UX
- Related decisions: D-11 / CONFIRM-1 / CONFIRM-13 / WF-1 / Product Option A for anomaly-disorder follow-up
- i18n impact: no (diagnostic keys locked here; messages resources tracked in task #28)

## Summary
- Add `@fairy/core` engine entrypoint with `calculate()` for regular, sheer, daze-value, and manual true-damage result assembly.
- Add bucket helpers, deterministic rounding trace, source-missing diagnostics, and TL-3 CalcResult-shaped output.
- Add minimal handler registry plus Condition DSL evaluator for modifier activation, target filtering, sourceMissing warning flow, and bucket contributor emission.
- Cover defense anchor math, corrupted-shield sheer defense skip, per-segment ceil round-trip, manual true damage, unsourced user modifier warnings, Condition DSL activation, daze modifier application, and bucketContribution trace refs.

## Scope Lock
- Complete in this PR: regular damage, sheer damage, manual true damage events, daze value accumulation, handler registry, Condition DSL evaluator, sourceMissing diagnostics, and bucket contribution trace.
- Deferred to task #27: full anomaly/disorder implementation, including virtual-agent weighting, overflow/Bangboo exclusion, disorder formula ids, remaining duration, anomaly trigger counts, and complete evidence for G12/G14/G15/G23.
- Current anomaly/disorder behavior: schema-compatible pending path only. It emits zero trusted damage plus pending diagnostics instead of silently producing partial numbers.

## New Diagnostic Keys
- `ERR-CALC-PENDING-ANOMALY`
- `ERR-CALC-PENDING-DISORDER`

These keys are intentionally locked in this PR. Chinese/English messages are tracked separately in task #28 and do not block this engine PR.

## Verification
- `pnpm check`
- `pnpm test` (21 tests)
- `git diff --check origin/main...HEAD`
