### PR TITLE
docs(ux): add ERR-CALC-PENDING-ANOMALY/DISORDER zh+en messages

### DIFF
--- a/docs/ux/i18n/messages.en.json
+++ b/docs/ux/i18n/messages.en.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 26,
-    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series"
+    "totalEntries": 28,
+    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series; UX-S3-1 extends ERR-CALC-PENDING-* series (locked by PR #10 commit dacf36c)"
   },
   "ERR-RNG-001": "Damage Bonus Zone exceeds the cap of 600% (Strategy PART 01.2). Truncated for display; raw accumulated value: {raw}%.",
   "ERR-RNG-002": "CRIT Rate must be within 0–100% (Strategy PART 01.3). Auto-clamped to {clamped}%.",
@@ -33,5 +33,7 @@
   "ERR-UI-001": "This attack deals no damage in this scenario. Possible causes: Resistance Zone is 0, damage reduction floored at 20%, or hit on a non-weakness attribute.",
   "ERR-UI-002": "Loading example build / data…",
   "ERR-UI-003": "Team contains unsupported field (e.g., subordinate / Bangboo). V1 does not support this feature; the corresponding field has been ignored.",
-  "ERR-OCR-000": "This tool does not parse screenshots. Screenshots are visual references only. Please fill in fields manually."
+  "ERR-OCR-000": "This tool does not parse screenshots. Screenshots are visual references only. Please fill in fields manually.",
+  "ERR-CALC-PENDING-ANOMALY": "⚠ V1 PR #10 stage: anomaly damage formula returns a schema-compatible skeleton only and does **not produce trustworthy values**. Full anomaly computation (virtual agent weighting / anomaly trigger count table / anomaly crit zone / overflow exclusion, etc.) is implemented by task #27 [TL-S3-4].",
+  "ERR-CALC-PENDING-DISORDER": "⚠ V1 PR #10 stage: disorder damage formula returns a schema-compatible skeleton only and does **not produce trustworthy values**. Full disorder computation (seven-attribute multipliers / daze level zone / disorder daze accumulation / disorderFormulaId trace evidence, etc.) is implemented by task #27 [TL-S3-4]."
 }

--- a/docs/ux/i18n/messages.zh.json
+++ b/docs/ux/i18n/messages.zh.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 26,
-    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列"
+    "totalEntries": 28,
+    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列；UX-S3-1 扩展 ERR-CALC-PENDING-* 系列（PR #10 commit dacf36c 锁定）"
   },
   "ERR-RNG-001": "增伤区已超过攻略上限 600%（PART 01.2）。已截断展示，原始累加值为 {raw}%。",
   "ERR-RNG-002": "暴击率有效范围 0~100%（攻略 PART 01.3）。已自动 clamp 为 {clamped}%。",
@@ -33,5 +33,7 @@
   "ERR-UI-001": "该攻击在此情境下不造成伤害。可能原因：抗性区为 0、减伤叠加至 20% 下限、命中无效弱点。",
   "ERR-UI-002": "正在加载示例构筑 / 数据…",
   "ERR-UI-003": "团队中存在 unsupported 字段（如 subordinate / 邦布）。V1 不支持此特性，对应字段已忽略。",
-  "ERR-OCR-000": "本工具不识别截图。截图仅作为录入时的视觉参考。请按字段对照填写。"
+  "ERR-OCR-000": "本工具不识别截图。截图仅作为录入时的视觉参考。请按字段对照填写。",
+  "ERR-CALC-PENDING-ANOMALY": "⚠ 当前 V1 PR #10 阶段：异常伤害公式仅返回 schema 兼容骨架，**未输出可信数值**。完整异常计算（虚拟代理人加权 / 异常触发计数表 / 异常暴击区 / overflow 排除等）由 task #27 [TL-S3-4] 实现。",
+  "ERR-CALC-PENDING-DISORDER": "⚠ 当前 V1 PR #10 阶段：紊乱伤害公式仅返回 schema 兼容骨架，**未输出可信数值**。完整紊乱计算（七属性倍率 / 失衡等级区 / 紊乱失衡值 / disorderFormulaId trace evidence 等）由 task #27 [TL-S3-4] 实现。"
 }


### PR DESCRIPTION
## Slock Context
- Owner: @UX
- Task: #28
- Reviewers: @TechLead, @QA
- Related decisions: D-02-rev (zh+en P0) / D-11 / Option A scope (PR #10 phase split)
- i18n impact: zh+en

## Summary
UX-S3-1: Add bilingual i18n resources for the two pending diagnostic keys locked by TechLead PR #10 (commit `dacf36c`) for the anomaly/disorder schema-compatible skeleton path.

## Changes (2 files / +10 / -6)
- `docs/ux/i18n/messages.zh.json`: 26 → 28 entries
  - `+ERR-CALC-PENDING-ANOMALY`
  - `+ERR-CALC-PENDING-DISORDER`
  - `_meta.totalEntries`: 26 → 28
  - `_meta.scope`: extended note about UX-S3-1
- `docs/ux/i18n/messages.en.json`: mirror

## Why
- PR #10 phase 1 only outputs a schema-compatible skeleton for anomaly / disorder + pending diagnostic
- Without zh/en messages, CLI / AI plugin / future UI would render bare key strings to users
- Messages explicitly warn that the skeleton output is NOT trustworthy values; full computation is task #27 [TL-S3-4]

## Verification
- `jq empty docs/ux/i18n/messages.zh.json docs/ux/i18n/messages.en.json` pass
- key sets match between zh and en (28 entries each)
- placeholder count identical