### PR TITLE
feat(core): implement anomaly and disorder formulas

### DIFF
--- a/docs/data-contract/battle-snapshot.md
+++ b/docs/data-contract/battle-snapshot.md
@@ -235,6 +235,7 @@ interface AnomalyContributionInput {
   buildup?: number
   thresholdOverride?: number
   overflowBuildup?: number
+  remainingDurationSeconds?: number
   contributors?: AnomalyContributionActorInput[]
 }
 
@@ -254,6 +255,11 @@ This input is optional. If absent, the resolver may derive contribution rows
 from `GameData` and battle state. If present, core must preserve contribution,
 overflow, and exclusion evidence in `CalcResult.trace` so golden anchors can
 assert virtual-agent behavior.
+
+`anomalyContribution.status` is required when `damageType` is `"anomaly"` or
+`"disorder"`; core must not infer a default status. `remainingDurationSeconds`
+records the remaining duration `T` used by disorder formula traces. If omitted,
+core may fall back to the current default duration for that anomaly status.
 
 ## 7. Enemy Snapshot
 

--- a/docs/data-contract/handler-spec.md
+++ b/docs/data-contract/handler-spec.md
@@ -162,6 +162,7 @@ type MultiplierBucket =
   | "damageLevelZone"
   | "anomalyDamageBonusZone"
   | "anomalyCritZone"
+  | "disorderDazeLevelZone"
   | "dazeValueZone"
   | "dazeResistanceZone"
   | "dazeInflictZone"

--- a/docs/data-contract/trace.md
+++ b/docs/data-contract/trace.md
@@ -125,6 +125,7 @@ Anomaly/disorder trace must expose:
 - overflow buildup
 - excluded Bangboo buildup
 - disorder formula id and remaining duration
+- `disorderDazeLevelZone` when disorder damage uses the daze-level multiplier
 
 ## 7. Daze Evidence
 

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -241,7 +241,7 @@ describe("calculate", () => {
     expect(result.buckets.some(bucket => bucket.bucketId === "dazeInflictZone")).toBe(true)
   })
 
-  it("does not emit trusted anomaly damage before TL-S3-4", () => {
+  it("computes anomaly damage without the standard crit bucket", () => {
     const result = calculate({
       ...baseSnapshot,
       team: [
@@ -268,29 +268,356 @@ describe("calculate", () => {
       ],
     })
 
-    expect(result.summary.rawTotalDamage).toBe(0)
-    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-ANOMALY")).toBe(true)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(5454.545, 3)
+    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-ANOMALY")).toBe(false)
     expect(result.buckets.some(bucket => bucket.bucketId === "critZone")).toBe(false)
-    expect(result.trace.some(event => event.displayValue === "pending-formula")).toBe(true)
+    expect(result.buckets.find(bucket => bucket.bucketId === "anomalyProficiencyZone")?.effectiveMultiplier).toBe(6)
+    expect(result.trace.some(event => event.path === "attackSegments[0].anomalyContribution.anomalyThreshold")).toBe(true)
   })
 
-  it("does not emit trusted disorder damage before TL-S3-4", () => {
+  it("traces the physical anomaly threshold by rank and trigger count", () => {
     const result = calculate({
       ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        anomalyTriggerCounts: { assault: 2 },
+      },
       attackSegments: [
         {
           ...baseSnapshot.attackSegments[0]!,
-          id: "seg-disorder",
-          damageType: "disorder",
+          id: "seg-physical-anomaly",
+          attribute: "physical",
+          damageType: "anomaly",
           anomalyContribution: {
-            status: "disorder",
+            status: "assault",
             buildup: 100,
           },
         },
       ],
     })
+    const thresholdTrace = result.trace.find(event =>
+      event.path === "attackSegments[0].anomalyContribution.anomalyThreshold",
+    )
 
-    expect(result.summary.rawTotalDamage).toBe(0)
-    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-DISORDER")).toBe(true)
+    expect(thresholdTrace?.inputs).toMatchObject({
+      enemyRank: "boss",
+      triggerCount: 2,
+      status: "assault",
+      physicalMultiplier: 1.2,
+    })
+    expect(thresholdTrace?.rawValue).toBeCloseTo(3745.2, 1)
+  })
+
+  it("floors anomaly mastery before emitting anomaly buildup", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            anomalyMastery: 123.9,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-anomaly-buildup",
+          damageType: "anomaly",
+          anomalyContribution: {
+            status: "shock",
+            buildup: 100,
+          },
+        },
+      ],
+    })
+    const buildupTrace = result.trace.find(event => event.path === "attackSegments[0].anomalyBuildup")
+
+    expect(result.attackSegments[0]?.anomalyBuildup).toBe(123)
+    expect(buildupTrace?.inputs).toMatchObject({
+      anomalyMastery: 123.9,
+      flooredAnomalyMastery: 123,
+    })
+    expect(buildupTrace?.displayValue).toBe("floorForFormula")
+  })
+
+  it("applies anomaly crit contributors without creating the standard crit bucket", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            critRate: 1,
+            critDamage: 2,
+            anomalyProficiency: 100,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-anomaly-crit",
+          damageType: "anomaly",
+          anomalyContribution: {
+            status: "shock",
+            buildup: 100,
+          },
+        },
+      ],
+      modifiers: [
+        {
+          id: "exclusive-anomaly-crit",
+          handlerId: "anomaly-crit-bonus",
+          params: { value: 0.5 },
+          appliesTo: { kind: "segment" },
+          source,
+        },
+      ],
+    })
+
+    expect(result.buckets.some(bucket => bucket.bucketId === "critZone")).toBe(false)
+    expect(result.buckets.find(bucket => bucket.bucketId === "anomalyCritZone")?.effectiveMultiplier).toBe(1.5)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(1363.636, 3)
+  })
+
+  it("builds virtual anomaly contributors from included buildup and overflow", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            anomalyProficiency: 100,
+            anomalyMastery: 100,
+          },
+        },
+        {
+          agentId: "nicole",
+          level: 40,
+          agentSpecialty: "support",
+          attribute: "ether",
+          panel: {
+            attack: 2000,
+            maxHp: 10000,
+            impact: 80,
+            anomalyProficiency: 300,
+            anomalyMastery: 100,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-virtual-anomaly",
+          damageType: "anomaly",
+          anomalyContribution: {
+            status: "shock",
+            buildup: 120,
+            overflowBuildup: 20,
+            contributors: [
+              { actorId: "yixuan", buildup: 60, included: true },
+              { actorId: "nicole", buildup: 60, included: true },
+              { actorId: "bangboo-a", buildup: 60, included: false, excludedReason: "bangboo" },
+            ],
+          },
+        },
+      ],
+    })
+    const virtualTrace = result.trace.find(event =>
+      event.path === "attackSegments[0].anomalyContribution.virtualAgent",
+    )
+    const rows = (virtualTrace?.inputs as { virtualAgent?: Array<Record<string, unknown>> } | undefined)?.virtualAgent ?? []
+
+    expect(result.summary.rawTotalDamage).toBeGreaterThan(0)
+    expect(virtualTrace?.inputs).toMatchObject({
+      flooredLevel: 52,
+      overflowBuildup: 20,
+    })
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ actorId: "yixuan", effectiveBuildup: 60, buildupContributionRatio: 0.6 }),
+      expect.objectContaining({ actorId: "nicole", effectiveBuildup: 40, buildupContributionRatio: 0.4 }),
+      expect.objectContaining({ actorId: "bangboo-a", effectiveBuildup: 0, excludedReason: "bangboo" }),
+    ]))
+  })
+
+  it("computes shock disorder from remaining duration and disorder daze level", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-shock-disorder",
+          attribute: "electric",
+          damageType: "disorder",
+          anomalyContribution: {
+            status: "shock",
+            buildup: 100,
+            remainingDurationSeconds: 5,
+          },
+        },
+      ],
+    })
+    const disorderTrace = result.trace.find(event => event.path === "attackSegments[0].disorderFormulaId")
+    const disorderDazeBucket = result.buckets.find(bucket => bucket.bucketId === "disorderDazeLevelZone")
+    const rawTrace = result.trace.find(event => event.path === "attackSegments[0].rawDamage")
+
+    expect(result.summary.rawTotalDamage).toBeCloseTo(14170.455, 3)
+    expect(result.summary.disorderDamage).toBeCloseTo(14170.455, 3)
+    expect(result.attackSegments[0]?.dazeValue).toBe(348)
+    expect(disorderDazeBucket?.effectiveMultiplier).toBe(1.45)
+    expect(rawTrace?.formula).toContain("disorderDazeLevelZone")
+    expect(rawTrace?.refs).toEqual(expect.arrayContaining(disorderDazeBucket?.traceRefs ?? []))
+    expect(disorderTrace?.inputs).toMatchObject({
+      disorderFormulaId: "disorder-shock",
+      remainingDurationT: 5,
+      sourceAnchor: "guide-3.4.1",
+    })
+    expect(disorderTrace?.rawValue).toBe(10.75)
+    expect(result.warnings.some(item => item.key === "ERR-CALC-PENDING-DISORDER")).toBe(false)
+  })
+
+  it("rejects anomaly and disorder segments without anomaly status before calculation", () => {
+    expect(() => calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-anomaly-missing-status",
+          damageType: "anomaly",
+        },
+      ],
+    })).toThrow(/anomalyContribution\.status/)
+
+    expect(() => calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-disorder-missing-status",
+          attribute: "electric",
+          damageType: "disorder",
+        },
+      ],
+    })).toThrow(/anomalyContribution\.status/)
+  })
+
+  it.each([
+    ["burn", "fire", 2.5, "disorder-burn", 7],
+    ["shock", "electric", 2, "disorder-shock", 7],
+    ["corruption", "ether", 2.5, "disorder-corruption", 7.625],
+    ["disorder", "auricInk", 2.5, "disorder-corruption", 7.625],
+    ["frozen", "frost", 3, "disorder-frost", 8.25],
+    ["frozen", "ice", 3, "disorder-physical-or-ice", 4.725],
+    ["assault", "physical", 3, "disorder-physical-or-ice", 4.725],
+    ["polarityDisorder", "electric", 4, "disorder-polarity", 1.425],
+  ] as const)("traces %s/%s disorder multiplier", (status, attribute, remainingDurationSeconds, formulaId, multiplier) => {
+    const result = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: `seg-${formulaId}`,
+          attribute,
+          damageType: "disorder",
+          multiplier: status === "polarityDisorder" ? undefined : 1,
+          anomalyContribution: {
+            status,
+            buildup: 100,
+            remainingDurationSeconds,
+          },
+        },
+      ],
+    })
+    const disorderTrace = result.trace.find(event => event.path === "attackSegments[0].disorderFormulaId")
+
+    expect(disorderTrace?.displayValue).toBe(formulaId)
+    expect(disorderTrace?.rawValue).toBeCloseTo(multiplier, 5)
+  })
+
+  it("traces three-agent polarity disorder providers and virtual shares", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      team: [
+        baseSnapshot.team[0]!,
+        {
+          agentId: "nicole",
+          level: 60,
+          agentSpecialty: "support",
+          attribute: "ether",
+          panel: {
+            attack: 800,
+            maxHp: 10000,
+            anomalyProficiency: 100,
+          },
+        },
+        {
+          agentId: "yanagi",
+          level: 60,
+          agentSpecialty: "anomaly",
+          attribute: "electric",
+          panel: {
+            attack: 1600,
+            maxHp: 10000,
+            anomalyProficiency: 220,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-polarity-disorder",
+          attribute: "electric",
+          damageType: "disorder",
+          multiplier: undefined,
+          anomalyContribution: {
+            status: "polarityDisorder",
+            buildup: 100,
+            remainingDurationSeconds: 5,
+            contributors: [
+              { actorId: "yixuan", buildup: 40, included: true },
+              { actorId: "yanagi", buildup: 60, included: true },
+            ],
+          },
+        },
+      ],
+      modifiers: [
+        {
+          id: "nicole-defense-reduction",
+          handlerId: "defense-reduction",
+          params: { value: 0.4 },
+          appliesTo: { kind: "enemy" },
+          source: { sourceId: "provider:Nicole", sourceVersion: "rules-v0.1" },
+        },
+        {
+          id: "yanagi-anomaly-damage",
+          handlerId: "anomaly-damage-bonus",
+          params: { value: 0.2 },
+          appliesTo: { kind: "segment" },
+          source: { sourceId: "provider:Yanagi", sourceVersion: "rules-v0.1" },
+        },
+      ],
+    })
+    const disorderTrace = result.trace.find(event => event.path === "attackSegments[0].disorderFormulaId")
+    const virtualTrace = result.trace.find(event =>
+      event.path === "attackSegments[0].anomalyContribution.virtualAgent",
+    )
+    const rows = (virtualTrace?.inputs as { virtualAgent?: Array<Record<string, unknown>> } | undefined)?.virtualAgent ?? []
+    const sourceIds = result.trace.map(event => event.source?.sourceId).filter(Boolean)
+
+    expect(disorderTrace?.displayValue).toBe("disorder-polarity")
+    expect(disorderTrace?.inputs).toMatchObject({
+      status: "polarityDisorder",
+      remainingDurationT: 5,
+    })
+    expect(disorderTrace?.rawValue).toBeCloseTo(1.6125, 4)
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ actorId: "yixuan", buildupContributionRatio: 0.4 }),
+      expect.objectContaining({ actorId: "yanagi", buildupContributionRatio: 0.6 }),
+    ]))
+    expect(sourceIds).toEqual(expect.arrayContaining(["provider:Nicole", "provider:Yanagi"]))
   })
 })

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -1,5 +1,6 @@
 import type {
   AgentSnapshot,
+  AnomalyStatus,
   AttackSegment,
   BattleSnapshot,
   BucketContributor,
@@ -7,6 +8,7 @@ import type {
   CalcResult,
   DamageType,
   Diagnostic,
+  EnemyRank,
   ManualEvent,
   ManualEventResult,
   ModifierResult,
@@ -145,24 +147,13 @@ function calculateSegment(
   const errors: Diagnostic[] = []
   const damageType = segment.damageType
   const sourceFields = getContributorSourceFields(segment.source, `attackSegments[${index}].source`, warnings)
-
-  if (isPendingAnomalyOrDisorder(damageType)) {
-    return calculatePendingAnomalyOrDisorderSegment(
-      activeActor,
-      segment,
-      index,
-      sourceFields,
-      warnings,
-      errors,
-    )
-  }
-
   const modifierEvaluation = evaluateModifiers(snapshot, activeActor, segment, index)
   warnings.push(...modifierEvaluation.warnings)
   errors.push(...modifierEvaluation.errors)
+  const formulaActor = getFormulaActor(snapshot, activeActor, segment, index)
 
-  const baseDamage = getBaseDamage(activeActor, segment)
-  const damageBonusValue = getDamageBonus(activeActor, segment)
+  const baseDamage = getBaseDamage(formulaActor.actor, segment, formulaActor.disorderMultiplier)
+  const damageBonusValue = getDamageBonus(formulaActor.actor, segment)
     + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("damageBonusZone"))
   const damageBonusMultiplier = clamp(1 + damageBonusValue, 0, 6)
   const critRate = clamp(activeActor.panel.critRate ?? 0, 0, 1)
@@ -202,7 +193,7 @@ function calculateSegment(
       contributors: [
         makeContributor({
           id: `${segment.id}:attribute-damage-bonus`,
-          value: getDamageBonus(activeActor, segment),
+          value: getDamageBonus(formulaActor.actor, segment),
           operation: "add",
           ...sourceFields,
         }),
@@ -230,10 +221,10 @@ function calculateSegment(
   if (usesDefenseZone(damageType)) {
     const defenseReduction = sumBucketContributors(modifierEvaluation.contributorsByBucket.get("defenseZone"))
     const defense = getDefenseMultiplier({
-      attackerLevel: activeActor.level,
+      attackerLevel: formulaActor.actor.level,
       enemy: snapshot.enemy,
-      ...(activeActor.panel.penetrationRate === undefined ? {} : { penetrationRate: activeActor.panel.penetrationRate }),
-      ...(activeActor.panel.flatPenetration === undefined ? {} : { flatPenetration: activeActor.panel.flatPenetration }),
+      ...(formulaActor.actor.panel.penetrationRate === undefined ? {} : { penetrationRate: formulaActor.actor.panel.penetrationRate }),
+      ...(formulaActor.actor.panel.flatPenetration === undefined ? {} : { flatPenetration: formulaActor.actor.panel.flatPenetration }),
       defenseReduction,
     })
     bucketInputs.push(makeBucket({
@@ -253,7 +244,7 @@ function calculateSegment(
   }
 
   if (damageType === "sheer") {
-    const sheerDamageBonusValue = (activeActor.panel.sheerDamageBonus ?? 0)
+    const sheerDamageBonusValue = (formulaActor.actor.panel.sheerDamageBonus ?? 0)
       + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("sheerDamageBonusZone"))
     const sheerDamageBonusMultiplier = clamp(1 + sheerDamageBonusValue, 0.2, 9)
     bucketInputs.push(makeBucket({
@@ -263,7 +254,7 @@ function calculateSegment(
       contributors: [
         makeContributor({
           id: `${segment.id}:sheer-damage-bonus`,
-          value: activeActor.panel.sheerDamageBonus ?? 0,
+          value: formulaActor.actor.panel.sheerDamageBonus ?? 0,
           operation: "add",
           ...sourceFields,
         }),
@@ -274,12 +265,12 @@ function calculateSegment(
 
   if (damageType === "anomaly" || damageType === "disorder") {
     const anomalyProficiencyValue = clamp(
-      (activeActor.panel.anomalyProficiency ?? 100) / 100
+      (formulaActor.actor.panel.anomalyProficiency ?? 100) / 100
       + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("anomalyProficiencyZone")),
       0,
       10,
     )
-    const damageLevelValue = getDamageLevelMultiplier(activeActor.level)
+    const damageLevelValue = getDamageLevelMultiplier(formulaActor.actor.level)
       + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("damageLevelZone"))
     const anomalyDamageBonusValue = 1
       + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("anomalyDamageBonusZone"))
@@ -293,7 +284,7 @@ function calculateSegment(
         contributors: [
           makeContributor({
             id: `${segment.id}:anomaly-proficiency`,
-            value: activeActor.panel.anomalyProficiency ?? 100,
+            value: formulaActor.actor.panel.anomalyProficiency ?? 100,
             operation: "multiply",
             ...sourceFields,
           }),
@@ -307,7 +298,7 @@ function calculateSegment(
         contributors: [
           makeContributor({
             id: `${segment.id}:damage-level`,
-            value: activeActor.level,
+            value: formulaActor.actor.level,
             operation: "multiply",
             ...sourceFields,
           }),
@@ -327,6 +318,23 @@ function calculateSegment(
         contributors: getModifierContributors(modifierEvaluation, "anomalyCritZone"),
       }),
     )
+  }
+
+  if (damageType === "disorder") {
+    const disorderDazeLevelMultiplier = formulaActor.disorderDazeMultiplier ?? 1
+    bucketInputs.push(makeBucket({
+      bucketId: "disorderDazeLevelZone",
+      after: disorderDazeLevelMultiplier,
+      effectiveMultiplier: disorderDazeLevelMultiplier,
+      contributors: [
+        makeContributor({
+          id: `${segment.id}:disorder-daze-level`,
+          value: disorderDazeLevelMultiplier,
+          operation: "multiply",
+          ...sourceFields,
+        }),
+      ],
+    }))
   }
 
   bucketInputs.push(
@@ -389,16 +397,16 @@ function calculateSegment(
     }),
   )
 
-  if (segment.baseDazeMultiplier !== undefined) {
+  if (segment.baseDazeMultiplier !== undefined || damageType === "disorder") {
     bucketInputs.push(
       makeBucket({
         bucketId: "dazeValueZone",
-        after: getBaseDaze(activeActor, segment),
-        effectiveMultiplier: getBaseDaze(activeActor, segment),
+        after: getBaseDaze(formulaActor.actor, segment),
+        effectiveMultiplier: getBaseDaze(formulaActor.actor, segment),
         contributors: [
           makeContributor({
             id: `${segment.id}:base-daze`,
-            value: getBaseDaze(activeActor, segment),
+            value: getBaseDaze(formulaActor.actor, segment),
             operation: "add",
             ...sourceFields,
           }),
@@ -429,6 +437,7 @@ function calculateSegment(
   const segmentDisplayDamage = Math.ceil(rawDamage)
   const trace = [
     ...modifierEvaluation.trace,
+    ...formulaActor.trace,
     ...bucketTrace,
     makeTraceEvent({
       kind: "formula",
@@ -472,7 +481,24 @@ function calculateSegment(
     .reduce((total, bucket) => total * bucket.effectiveMultiplier, 1)
   const nonCritDamage = damageType === "daze" ? 0 : baseDamage * nonCritMultiplier
   const critDamage = damageType === "daze" ? 0 : nonCritDamage * (1 + critDamageBonus)
-  const dazeValue = getDazeValue(activeActor, segment, buckets)
+  const dazeValue = getDazeValue(formulaActor.actor, segment, buckets, formulaActor.disorderDazeMultiplier)
+  const anomalyBuildup = segment.anomalyContribution?.buildup === undefined
+    ? undefined
+    : getAnomalyBuildup(formulaActor.actor, segment)
+  if (anomalyBuildup !== undefined) {
+    trace.push(makeTraceEvent({
+      kind: "formula",
+      path: `attackSegments[${index}].anomalyBuildup`,
+      inputs: {
+        buildup: segment.anomalyContribution?.buildup ?? 0,
+        anomalyMastery: formulaActor.actor.panel.anomalyMastery ?? 100,
+        flooredAnomalyMastery: Math.floor(formulaActor.actor.panel.anomalyMastery ?? 100),
+      },
+      formula: "anomalyBuildup = buildup * floor(anomalyMastery) / 100",
+      rawValue: anomalyBuildup,
+      displayValue: "floorForFormula",
+    }))
+  }
 
   return {
     result: {
@@ -488,9 +514,9 @@ function calculateSegment(
       expectedDamage: rawDamage,
       critDamage,
       nonCritDamage,
-      ...(segment.baseDazeMultiplier === undefined ? {} : { baseDaze: getBaseDaze(activeActor, segment) }),
+      ...(segment.baseDazeMultiplier === undefined && segment.damageType !== "disorder" ? {} : { baseDaze: getBaseDaze(formulaActor.actor, segment) }),
       ...(dazeValue === undefined ? {} : { dazeValue }),
-      ...(segment.anomalyContribution?.buildup === undefined ? {} : { anomalyBuildup: getAnomalyBuildup(activeActor, segment) }),
+      ...(anomalyBuildup === undefined ? {} : { anomalyBuildup }),
       traceRefs: trace.map(event => event.id),
     },
     buckets,
@@ -501,99 +527,102 @@ function calculateSegment(
   }
 }
 
-function calculatePendingAnomalyOrDisorderSegment(
+interface FormulaActorContext {
+  actor: AgentSnapshot
+  trace: TraceEvent[]
+  disorderMultiplier?: number
+  disorderDazeMultiplier?: number
+}
+
+function getFormulaActor(
+  snapshot: BattleSnapshot,
   activeActor: AgentSnapshot,
   segment: AttackSegment,
   index: number,
-  sourceFields: ContributorSourceFields,
-  warnings: Diagnostic[],
-  errors: Diagnostic[],
-): SegmentCalculation {
-  const diagnosticKey = segment.damageType === "anomaly"
-    ? "ERR-CALC-PENDING-ANOMALY"
-    : "ERR-CALC-PENDING-DISORDER"
-  warnings.push(warning(diagnosticKey, `attackSegments[${index}].damageType`, {
-    damageType: segment.damageType,
-    followUpTask: "#27",
-  }))
+): FormulaActorContext {
+  if (segment.damageType !== "anomaly" && segment.damageType !== "disorder") {
+    return {
+      actor: activeActor,
+      trace: [],
+    }
+  }
 
-  const rawBuckets = [
-    makeBucket({
-      bucketId: "baseDamageZone",
-      before: 0,
-      after: 0,
-      effectiveMultiplier: 0,
-      contributors: [
-        makeContributor({
-          id: `${segment.id}:pending-${segment.damageType}`,
-          value: 0,
-          operation: "ignore",
-          active: false,
-          inactiveReason: `${segment.damageType}-formula-pending`,
-          ...sourceFields,
-        }),
-      ],
-    }),
-  ]
-  const { buckets, trace: bucketTrace } = attachBucketContributionTrace(rawBuckets)
+  const hasContributorEvidence = (segment.anomalyContribution?.contributors?.length ?? 0) > 0
+  const formulaActor = hasContributorEvidence
+    ? getVirtualAgent(snapshot, activeActor, segment)
+    : { actor: activeActor, traceRows: [] }
+  const threshold = getAnomalyThreshold(snapshot, segment)
   const trace = [
-    ...bucketTrace,
-    makeTraceEvent({
-      kind: "warning",
-      path: `attackSegments[${index}].damageType`,
-      inputs: {
-        damageType: segment.damageType,
-        diagnosticKey,
-        followUpTask: "#27",
-      },
-      displayValue: "pending-formula",
-      refs: buckets.flatMap(bucket => bucket.traceRefs),
-    }),
+    ...(hasContributorEvidence
+      ? [
+          makeTraceEvent({
+            kind: "formula",
+            path: `attackSegments[${index}].anomalyContribution.virtualAgent`,
+            inputs: {
+              virtualAgent: formulaActor.traceRows,
+              flooredLevel: formulaActor.actor.level,
+              overflowBuildup: segment.anomalyContribution?.overflowBuildup ?? 0,
+              excludedReasons: formulaActor.traceRows
+                .filter(row => row.excludedReason !== undefined)
+                .map(row => `excludedReason:${row.excludedReason}`),
+            },
+            formula: "virtualAgent = weighted average of included buildup contributors; Bangboo and overflow are excluded",
+            rawValue: formulaActor.actor.agentId,
+            displayValue: "virtualAgent",
+          }),
+        ]
+      : []),
     makeTraceEvent({
       kind: "formula",
-      path: `attackSegments[${index}].rawDamage`,
-      inputs: {
-        damageType: segment.damageType,
-        diagnosticKey,
-      },
-      formula: "pending anomaly/disorder formula: no trusted numeric damage emitted in PR #10",
-      rawValue: 0,
-      displayValue: "pending-formula",
-      refs: buckets.flatMap(bucket => bucket.traceRefs),
-    }),
-    makeTraceEvent({
-      kind: "rounding",
-      path: `attackSegments[${index}].segmentDisplayDamage`,
-      rawValue: 0,
-      displayValue: 0,
-      rounding: {
-        mode: "ceilPerSegment",
-        input: 0,
-        output: 0,
-        reason: "Pending anomaly/disorder formula emits zero display damage until task #27 implements trusted evidence.",
-      },
+      path: `attackSegments[${index}].anomalyContribution.anomalyThreshold`,
+      inputs: threshold,
+      formula: "anomalyThreshold = rankTriggerTable[enemy.rank][triggerCount] * physicalMultiplier",
+      rawValue: threshold.threshold,
+      displayValue: "anomalyThreshold",
     }),
   ]
 
+  if (segment.damageType === "disorder") {
+    const disorder = getDisorderFormula(segment)
+    trace.push(makeTraceEvent({
+      kind: "formula",
+      path: `attackSegments[${index}].disorderFormulaId`,
+      inputs: {
+        disorderFormulaId: disorder.formulaId,
+        remainingDurationT: disorder.remainingDurationSeconds,
+        status: segment.anomalyContribution?.status,
+        attribute: segment.attribute,
+        sourceAnchor: "guide-3.4.1",
+      },
+      formula: disorder.formula,
+      rawValue: disorder.multiplier,
+      displayValue: disorder.formulaId,
+      sourceAnchor: "guide-3.4.1",
+    }))
+    trace.push(makeTraceEvent({
+      kind: "formula",
+      path: `attackSegments[${index}].disorderDazeLevelZone`,
+      inputs: {
+        level: formulaActor.actor.level,
+        dazeLevelZone: getDisorderDazeLevelMultiplier(formulaActor.actor.level),
+      },
+      formula: "disorderDazeLevelZone = 1 + 0.0075 * level",
+      rawValue: getDisorderDazeLevelMultiplier(formulaActor.actor.level),
+      displayValue: "dazeLevelZone",
+      sourceAnchor: "guide-3.4.2",
+    }))
+
+    return {
+      actor: formulaActor.actor,
+      trace,
+      disorderMultiplier: disorder.multiplier,
+      disorderDazeMultiplier: getDisorderDazeLevelMultiplier(formulaActor.actor.level),
+    }
+  }
+
   return {
-    result: {
-      id: segment.id,
-      actorId: segment.actorId ?? activeActor.agentId,
-      attribute: segment.attribute,
-      tags: segment.tags,
-      damageType: segment.damageType,
-      rawDamage: 0,
-      segmentDisplayDamage: 0,
-      roundingMode: "ceilPerSegment",
-      baseDamage: 0,
-      expectedDamage: 0,
-      traceRefs: trace.map(event => event.id),
-    },
-    buckets,
-    modifiers: [],
+    actor: formulaActor.actor,
     trace,
-    warnings,
-    errors,
   }
 }
 
@@ -758,7 +787,7 @@ function calculateManualEvent(
   }
 }
 
-function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment): number {
+function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment, disorderMultiplier?: number): number {
   const multiplier = segment.multiplier ?? 1
   if (segment.damageType === "sheer")
     return (activeActor.panel.sheerForce ?? 0) * multiplier
@@ -766,27 +795,38 @@ function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment): numb
   if (segment.damageType === "daze")
     return 0
 
+  if (segment.damageType === "disorder")
+    return activeActor.panel.attack * (disorderMultiplier ?? multiplier)
+
   return activeActor.panel.attack * multiplier
 }
 
 function getBaseDaze(activeActor: AgentSnapshot, segment: AttackSegment): number {
-  return (activeActor.panel.impact ?? 0) * (segment.baseDazeMultiplier ?? 0)
+  const multiplier = segment.damageType === "disorder"
+    ? segment.baseDazeMultiplier ?? 2
+    : segment.baseDazeMultiplier ?? 0
+  return (activeActor.panel.impact ?? 0) * multiplier
 }
 
-function getDazeValue(activeActor: AgentSnapshot, segment: AttackSegment, buckets: BucketResult[]): number | undefined {
-  if (segment.baseDazeMultiplier === undefined)
+function getDazeValue(
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+  buckets: BucketResult[],
+  extraMultiplier = 1,
+): number | undefined {
+  if (segment.baseDazeMultiplier === undefined && segment.damageType !== "disorder")
     return undefined
 
   const multiplier = buckets
     .filter(bucket => bucket.bucketId === "dazeInflictZone" || bucket.bucketId === "dazeReceiveZone")
     .reduce((total, bucket) => total * bucket.effectiveMultiplier, 1)
 
-  return getBaseDaze(activeActor, segment) * multiplier
+  return getBaseDaze(activeActor, segment) * multiplier * extraMultiplier
 }
 
 function getAnomalyBuildup(activeActor: AgentSnapshot, segment: AttackSegment): number {
   const baseBuildup = segment.anomalyContribution?.buildup ?? 0
-  return baseBuildup * ((activeActor.panel.anomalyMastery ?? 100) / 100)
+  return baseBuildup * (Math.floor(activeActor.panel.anomalyMastery ?? 100) / 100)
 }
 
 function getDamageBonus(activeActor: AgentSnapshot, segment: AttackSegment): number {
@@ -796,6 +836,256 @@ function getDamageBonus(activeActor: AgentSnapshot, segment: AttackSegment): num
   const panelRecord = activeActor.panel as unknown as Record<string, unknown>
   const attributeBonus = getAttributeDamageBonus(panelRecord, segment.attribute)
   return typeof attributeBonus === "number" ? attributeBonus : 0
+}
+
+interface VirtualAgentTraceRow {
+  actorId: string
+  included: boolean
+  buildup: number
+  effectiveBuildup: number
+  buildupContributionRatio: number
+  level: number
+  flooredLevel: number
+  excludedReason?: string
+}
+
+function getVirtualAgent(
+  snapshot: BattleSnapshot,
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+): {
+  actor: AgentSnapshot
+  traceRows: VirtualAgentTraceRow[]
+} {
+  const contribution = segment.anomalyContribution
+  const contributors = contribution?.contributors ?? [
+    {
+      actorId: segment.actorId ?? activeActor.agentId,
+      buildup: contribution?.buildup ?? 1,
+      included: true,
+    },
+  ]
+  const overflowBuildup = contribution?.overflowBuildup ?? 0
+  const effectiveBuildupByIndex = getEffectiveBuildupByContributor(contributors, overflowBuildup)
+  const rows: Array<VirtualAgentTraceRow & { attack: number; impact: number; anomalyProficiency: number; anomalyMastery: number; penetrationRate: number; flatPenetration: number }> = []
+
+  contributors.forEach((contributor, contributorIndex) => {
+    const agent = snapshot.team.find(candidate => candidate.agentId === contributor.actorId) ?? activeActor
+    const effectiveBuildup = contributor.included && contributor.excludedReason === undefined
+      ? effectiveBuildupByIndex.get(contributorIndex) ?? contributor.buildup
+      : 0
+
+    rows.push({
+      actorId: contributor.actorId,
+      included: contributor.included,
+      buildup: contributor.buildup,
+      effectiveBuildup,
+      buildupContributionRatio: 0,
+      level: contributor.level ?? agent.level,
+      flooredLevel: Math.floor(contributor.level ?? agent.level),
+      ...(contributor.excludedReason === undefined ? {} : { excludedReason: contributor.excludedReason }),
+      attack: agent.panel.attack,
+      impact: agent.panel.impact ?? 0,
+      anomalyProficiency: contributor.anomalyProficiency ?? agent.panel.anomalyProficiency ?? 100,
+      anomalyMastery: Math.floor(contributor.anomalyMastery ?? agent.panel.anomalyMastery ?? 100),
+      penetrationRate: agent.panel.penetrationRate ?? 0,
+      flatPenetration: agent.panel.flatPenetration ?? 0,
+    })
+  })
+
+  const totalEffectiveBuildup = sum(rows.map(row => row.effectiveBuildup))
+  if (totalEffectiveBuildup <= 0) {
+    return {
+      actor: activeActor,
+      traceRows: rows.map(row => ({
+        actorId: row.actorId,
+        included: row.included,
+        buildup: row.buildup,
+        effectiveBuildup: row.effectiveBuildup,
+        buildupContributionRatio: 0,
+        level: row.level,
+        flooredLevel: row.flooredLevel,
+        ...(row.excludedReason === undefined ? {} : { excludedReason: row.excludedReason }),
+      })),
+    }
+  }
+
+  rows.forEach((row) => {
+    row.buildupContributionRatio = row.effectiveBuildup / totalEffectiveBuildup
+  })
+
+  const weightedLevel = Math.floor(sum(rows.map(row => row.flooredLevel * row.buildupContributionRatio)))
+  const panel = {
+    ...activeActor.panel,
+    attack: sum(rows.map(row => row.attack * row.buildupContributionRatio)),
+    impact: sum(rows.map(row => row.impact * row.buildupContributionRatio)),
+    anomalyProficiency: sum(rows.map(row => row.anomalyProficiency * row.buildupContributionRatio)),
+    anomalyMastery: sum(rows.map(row => row.anomalyMastery * row.buildupContributionRatio)),
+    penetrationRate: sum(rows.map(row => row.penetrationRate * row.buildupContributionRatio)),
+    flatPenetration: sum(rows.map(row => row.flatPenetration * row.buildupContributionRatio)),
+  }
+
+  return {
+    actor: {
+      ...activeActor,
+      agentId: `virtual:${segment.id}`,
+      level: Math.max(1, weightedLevel),
+      panel,
+    },
+    traceRows: rows.map(row => ({
+      actorId: row.actorId,
+      included: row.included,
+      buildup: row.buildup,
+      effectiveBuildup: row.effectiveBuildup,
+      buildupContributionRatio: row.buildupContributionRatio,
+      level: row.level,
+      flooredLevel: row.flooredLevel,
+      ...(row.excludedReason === undefined ? {} : { excludedReason: row.excludedReason }),
+    })),
+  }
+}
+
+function getEffectiveBuildupByContributor(
+  contributors: Array<{ buildup: number; included: boolean; excludedReason?: string | undefined }>,
+  overflowBuildup: number,
+): Map<number, number> {
+  const effective = new Map<number, number>()
+  let remainingOverflow = Math.max(0, overflowBuildup)
+
+  for (let index = contributors.length - 1; index >= 0; index -= 1) {
+    const contributor = contributors[index]!
+    if (!contributor.included || contributor.excludedReason !== undefined)
+      continue
+
+    const overflowDeduction = Math.min(contributor.buildup, remainingOverflow)
+    effective.set(index, contributor.buildup - overflowDeduction)
+    remainingOverflow -= overflowDeduction
+  }
+
+  contributors.forEach((contributor, index) => {
+    if (contributor.included && contributor.excludedReason === undefined && !effective.has(index))
+      effective.set(index, contributor.buildup)
+  })
+
+  return effective
+}
+
+function getAnomalyThreshold(snapshot: BattleSnapshot, segment: AttackSegment): {
+  threshold: number
+  enemyRank: EnemyRank
+  triggerCount: number
+  status: AnomalyStatus | undefined
+  physicalMultiplier: number
+} {
+  const status = segment.anomalyContribution?.status
+  const triggerCount = clampTriggerCount(
+    segment.anomalyContribution?.triggerCountBefore
+    ?? (status === undefined ? 0 : snapshot.enemy.anomalyTriggerCounts?.[status] ?? 0),
+  )
+  const rank = snapshot.enemy.rank === "special" ? "boss" : snapshot.enemy.rank
+  const physicalMultiplier = isPhysicalAnomaly(segment) ? 1.2 : 1
+  const baseThreshold = anomalyThresholdTable[rank][triggerCount] ?? anomalyThresholdTable[rank][0]!
+  return {
+    threshold: segment.anomalyContribution?.thresholdOverride ?? baseThreshold * physicalMultiplier,
+    enemyRank: snapshot.enemy.rank,
+    triggerCount,
+    status,
+    physicalMultiplier,
+  }
+}
+
+const anomalyThresholdTable: Record<Exclude<EnemyRank, "special">, number[]> = {
+  normal: [600, 612, 624, 636, 648, 660, 673, 686, 699, 712],
+  elite: [2250, 2295, 2340, 2386, 2433, 2481, 2530, 2580, 2631, 2683],
+  boss: [3000, 3060, 3121, 3183, 3246, 3310, 3376, 3443, 3511, 3581],
+}
+
+function clampTriggerCount(count: number): number {
+  return Math.max(0, Math.min(9, Math.floor(count)))
+}
+
+function isPhysicalAnomaly(segment: AttackSegment): boolean {
+  return segment.attribute === "physical"
+    || segment.anomalyContribution?.status === "assault"
+    || segment.anomalyContribution?.status === "flinch"
+}
+
+function getDisorderFormula(segment: AttackSegment): {
+  formulaId: string
+  formula: string
+  multiplier: number
+  remainingDurationSeconds: number
+} {
+  const status = segment.anomalyContribution?.status ?? "disorder"
+  const remainingDurationSeconds = segment.anomalyContribution?.remainingDurationSeconds ?? getDefaultDisorderDuration(segment)
+  const formulaId = getDisorderFormulaId(segment, status)
+  switch (formulaId) {
+    case "disorder-polarity":
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "polarity disorder multiplier = electric disorder multiplier * 0.15 unless segment.multiplier overrides it",
+        multiplier: segment.multiplier ?? (4.5 + Math.floor(remainingDurationSeconds) * 1.25) * 0.15,
+      }
+    case "disorder-burn":
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "burn disorder multiplier = 4.5 + floor(T / 0.5) * 0.5",
+        multiplier: 4.5 + Math.floor(remainingDurationSeconds / 0.5) * 0.5,
+      }
+    case "disorder-shock":
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "shock disorder multiplier = 4.5 + floor(T) * 1.25",
+        multiplier: 4.5 + Math.floor(remainingDurationSeconds) * 1.25,
+      }
+    case "disorder-corruption":
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "corruption disorder multiplier = 4.5 + floor(T / 0.5) * 0.625",
+        multiplier: 4.5 + Math.floor(remainingDurationSeconds / 0.5) * 0.625,
+      }
+    case "disorder-frost":
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "frost disorder multiplier = 6 + floor(T) * 0.75",
+        multiplier: 6 + Math.floor(remainingDurationSeconds) * 0.75,
+      }
+    case "disorder-physical-or-ice":
+    default:
+      return {
+        formulaId,
+        remainingDurationSeconds,
+        formula: "physical/ice disorder multiplier = 4.5 + floor(T) * 0.075",
+        multiplier: 4.5 + Math.floor(remainingDurationSeconds) * 0.075,
+      }
+  }
+}
+
+function getDefaultDisorderDuration(segment: AttackSegment): number {
+  return segment.attribute === "frost" ? 20 : 10
+}
+
+function getDisorderFormulaId(segment: AttackSegment, status: AnomalyStatus): string {
+  if (status === "polarityDisorder")
+    return "disorder-polarity"
+  if (status === "burn")
+    return "disorder-burn"
+  if (status === "shock")
+    return "disorder-shock"
+  if (status === "corruption" || segment.attribute === "ether" || segment.attribute === "auricInk")
+    return "disorder-corruption"
+  if (segment.attribute === "frost")
+    return "disorder-frost"
+  return "disorder-physical-or-ice"
+}
+
+function getDisorderDazeLevelMultiplier(level: number): number {
+  return 1 + 0.0075 * level
 }
 
 function getCritMultiplier(
@@ -823,7 +1113,7 @@ function getFormulaLabel(damageType: DamageType): string {
     case "anomaly":
       return "baseDamageZone * damageBonusZone * anomalyProficiencyZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * damageLevelZone * anomalyDamageBonusZone * anomalyCritZone * specialZone"
     case "disorder":
-      return "baseDamageZone * damageBonusZone * anomalyProficiencyZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * damageLevelZone * anomalyDamageBonusZone * anomalyCritZone * specialZone"
+      return "baseDamageZone * damageBonusZone * anomalyProficiencyZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * damageLevelZone * anomalyDamageBonusZone * anomalyCritZone * disorderDazeLevelZone * specialZone"
     case "daze":
       return "dazeValueZone * dazeInflictZone * dazeReceiveZone"
     case "trueDamage":
@@ -839,10 +1129,6 @@ function usesDefenseZone(damageType: DamageType): boolean {
 
 function usesStandardCrit(damageType: DamageType): boolean {
   return damageType === "regular" || damageType === "sheer"
-}
-
-function isPendingAnomalyOrDisorder(damageType: DamageType): boolean {
-  return damageType === "anomaly" || damageType === "disorder"
 }
 
 function isDamageFormulaBucket(bucket: BucketResult): boolean {

--- a/packages/core/src/schema/battle-snapshot.ts
+++ b/packages/core/src/schema/battle-snapshot.ts
@@ -122,6 +122,7 @@ export const anomalyContributionInputSchema = z
     buildup: z.number().finite().optional(),
     thresholdOverride: z.number().finite().optional(),
     overflowBuildup: z.number().finite().optional(),
+    remainingDurationSeconds: z.number().finite().nonnegative().optional(),
     contributors: z.array(anomalyContributionActorInputSchema).optional(),
   })
   .strict()
@@ -144,6 +145,18 @@ export const attackSegmentSchema = z
     source: sourceRefSchema.optional(),
   })
   .strict()
+  .superRefine((segment, ctx) => {
+    if (
+      (segment.damageType === "anomaly" || segment.damageType === "disorder")
+      && segment.anomalyContribution?.status === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["anomalyContribution", "status"],
+        message: "anomalyContribution.status is required for anomaly and disorder segments",
+      })
+    }
+  })
 
 export const enemySnapshotSchema = z
   .object({

--- a/packages/core/src/schema/common.ts
+++ b/packages/core/src/schema/common.ts
@@ -167,6 +167,7 @@ export const multiplierBucketSchema = z.enum([
   "damageLevelZone",
   "anomalyDamageBonusZone",
   "anomalyCritZone",
+  "disorderDazeLevelZone",
   "dazeValueZone",
   "dazeResistanceZone",
   "dazeInflictZone",

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -212,6 +212,35 @@ describe("BattleSnapshot schema", () => {
 
     expect(result.success).toBe(false)
   })
+
+  it("requires anomaly status for anomaly and disorder segments", () => {
+    const result = battleSnapshotSchema.safeParse({
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [minimalAgent],
+      activeActor: { agentId: "yixuan" },
+      attackSegments: [
+        {
+          id: "seg-1",
+          attribute: "electric",
+          tags: ["exSpecial"],
+          damageType: "disorder",
+        },
+      ],
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.some(issue =>
+      issue.path.join(".") === "attackSegments.0.anomalyContribution.status",
+    )).toBe(true)
+  })
 })
 
 describe("CalcResult schema", () => {


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #27
- Reviewers: @Product, @QA
- Related decisions: D-11 / CONFIRM-1 / CONFIRM-13 / v2.0 §5.1 / v2.0 §5.7
- i18n impact: no new keys; uses keys already added by task #28 only as legacy resources, no pending diagnostic emitted in this PR

## Summary

- Replaces PR #10 anomaly/disorder pending path with full anomaly and disorder calculation paths.
- Adds virtual-agent contributor weighting with overflow and Bangboo/manual exclusions, anomaly threshold trace evidence, anomaly mastery floor trace, anomalyCritZone support, and disorder formula trace evidence.
- Implements disorder remaining-duration formulas, polarity disorder multiplier, `disorderDazeLevelZone` as a damage bucket, and disorder daze output.
- Extends `AnomalyContributionInput` with `remainingDurationSeconds` for disorder formula evidence and requires `anomalyContribution.status` for anomaly/disorder segments.
- Adds regression coverage for G08/G12/G14/G15/G23-style anchors plus all disorder formula variants and missing-status rejection.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test` (36 tests)
- `git diff --check origin/main...HEAD`

## Notes

- This PR does not add formal `@fairy/data`; the runtime consumes snapshot-provided contribution and duration evidence.
- Threshold/formula constants are implemented as core rule constants for the task #27 runtime slice and exposed through trace for QA assertions.
