### PR TITLE
feat(cli): add JSON command shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,10 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 
 ## Current Phase
 
-S3 core implementation. Current engineering entry points:
+S4 CLI shell and S5 data ingestion. Current engineering entry points:
 
 - `docs/architecture/naming-policy.md`
 - `docs/architecture/monorepo-development.md`
 - `docs/data-contract/`
+- `packages/core/src/engine/`
+- `packages/cli/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,12 +12,12 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)
 
-## S3 当前重点
+## S4 / S5 当前重点
 
-1. 落地 `@fairy/core` runtime schema、validators 与黄金 fixture 接入。
-2. 实现核心公式与逐乘区 trace，包括常规 / 贯穿 / 真实伤害 / 异常 / 紊乱 / 失衡值。
-3. 实现 handler registry、Condition DSL 与 source/provenance/版本双路径硬契约。
-4. 并行推进 `@fairy/data` scraper 骨架与 monorepo 开发指南。
+1. 落地 `@fairy/cli` JSON-only 命令壳，覆盖 `calc` / `compare` / `scan` / `explain` / `migrate`。
+2. CLI 通过 `@fairy/core` 固定格式入口输出三档伤害、逐乘区 trace 与中英 diagnostic。
+3. 推进 `@fairy/data` Excel reader 与爬虫接入，保留 source metadata 并清洗为 GameData schema。
+4. 将 23 个 golden fixture schema-ready 锚点接入真实数据复算，作为 V1 发布 gate。
 
 ## 关键文档
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm -r --if-present test"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,34 @@
+# @fairy/cli
+
+JSON-only command shell over `@fairy/core`.
+
+## Commands
+
+```bash
+pnpm --silent --filter @fairy/cli run cli -- calc snapshot.json --lang zh --pretty
+pnpm --silent --filter @fairy/cli run cli -- compare left.json right.json --lang en
+pnpm --silent --filter @fairy/cli run cli -- scan snapshot.json --path team[0].panel.attack --from 1000 --to 2000 --step 100
+pnpm --silent --filter @fairy/cli run cli -- explain snapshot.json
+pnpm --silent --filter @fairy/cli run cli -- migrate snapshot.json
+```
+
+Use `-` instead of a file path to read JSON from stdin.
+The package bin is `fairy` and points to `packages/cli/bin/fairy.js` in this
+workspace.
+
+## Output Contract
+
+Stdout is always JSON. `calc` returns the authoritative `CalcResult` from
+`@fairy/core`, including `summary`, `attackSegments`, `buckets`, `modifiers`,
+`trace`, `warnings`, and `errors`.
+
+Warnings and errors from `CalcResult` are also rendered to stderr as localized
+diagnostic lines selected by `--lang zh|en`. The JSON diagnostic objects remain
+unchanged and language-independent.
+
+`--result-mode expected|crit|nonCrit` is passed into the snapshot options before
+calculation so the same snapshot can produce expected, forced-crit, and
+forced-non-crit output.
+
+Invalid arguments, invalid JSON, and schema validation failures are reported as
+JSON error objects on stderr.

--- a/packages/cli/bin/fairy.js
+++ b/packages/cli/bin/fairy.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { tsImport } from "tsx/esm/api"
+
+const binDir = dirname(fileURLToPath(import.meta.url))
+const entry = resolve(binDir, "../src/index.ts")
+const mod = await tsImport(entry, import.meta.url)
+const code = await mod.runCli(process.argv.slice(2))
+process.exitCode = code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,15 @@
   "private": true,
   "type": "module",
   "bin": {
-    "fairy": "./dist/index.js"
+    "fairy": "./bin/fairy.js"
+  },
+  "scripts": {
+    "cli": "tsx src/index.ts",
+    "check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@fairy/core": "workspace:*",
+    "tsx": "^4.21.0"
   }
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest"
+import { spawnSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { runCli } from "./index"
+
+const source = {
+  sourceId: "fixture",
+  sourceVersion: "rules-v0.1",
+  sourceAnchor: "golden",
+}
+
+const baseSnapshot = {
+  schemaVersion: "1.0.0",
+  gameVersion: "ZZZ-2.2",
+  ruleSetVersion: "rules-v0.1",
+  dataVersion: "data-v0.1.0",
+  sourceVersion: "source-v0.1.0",
+  team: [
+    {
+      agentId: "yixuan",
+      level: 60,
+      agentSpecialty: "rupture",
+      attribute: "ether",
+      panel: {
+        attack: 1000,
+        maxHp: 12000,
+        sheerForce: 1000,
+        impact: 120,
+        critRate: 0,
+        critDamage: 0,
+      },
+    },
+  ],
+  activeActor: { agentId: "yixuan" },
+  attackSegments: [
+    {
+      id: "seg-1",
+      attribute: "ether",
+      tags: ["basic"],
+      damageType: "regular",
+      multiplier: 1,
+      source,
+    },
+  ],
+  enemy: {
+    level: 60,
+    rank: "boss",
+    maxHp: 1000000,
+  },
+}
+
+const messages = {
+  "ERR-SRC-001": "Modifier at {path} has no source.",
+}
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+describe("fairy cli", () => {
+  it("calculates a snapshot from stdin and writes CalcResult JSON", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const code = await runCli(["calc", "-", "--lang", "en"], io)
+    const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number }; trace: unknown[] }
+
+    expect(code).toBe(0)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
+    expect(result.trace.length).toBeGreaterThan(0)
+    expect(io.output.stderr).toBe("")
+  })
+
+  it("renders localized warning diagnostics to stderr without changing stdout JSON", async () => {
+    const snapshot = structuredClone(baseSnapshot) as Record<string, unknown> & {
+      attackSegments: Array<Record<string, unknown>>
+    }
+    snapshot.attackSegments = [
+      {
+        id: "seg-1",
+        attribute: "ether",
+        tags: ["basic"],
+        damageType: "regular",
+        multiplier: 1,
+      },
+    ]
+    const io = fakeIo({ stdin: JSON.stringify(snapshot) })
+    const code = await runCli(["calc", "-", "--lang", "en"], io)
+    const result = JSON.parse(io.output.stdout) as { warnings: Array<{ key: string }> }
+
+    expect(code).toBe(0)
+    expect(result.warnings.some(warning => warning.key === "ERR-SRC-001")).toBe(true)
+    expect(io.output.stderr).toContain("WARNING ERR-SRC-001 attackSegments[0].source")
+    expect(io.output.stderr).toContain("Modifier at attackSegments[0].source has no source.")
+  })
+
+  it("loads diagnostic messages when cwd is outside the repo root", () => {
+    const snapshot = withoutAttackSegmentSource()
+    const run = spawnSync(process.execPath, [
+      resolve(repoRoot, "packages/cli/bin/fairy.js"),
+      "calc",
+      "-",
+      "--lang",
+      "en",
+    ], {
+      cwd: tmpdir(),
+      input: JSON.stringify(snapshot),
+      encoding: "utf8",
+    })
+    const result = JSON.parse(run.stdout) as { warnings: Array<{ key: string }> }
+
+    expect(run.status).toBe(0)
+    expect(result.warnings.some(warning => warning.key === "ERR-SRC-001")).toBe(true)
+    expect(run.stderr).toContain("WARNING ERR-SRC-001")
+    expect(run.stderr).not.toContain("ENOENT")
+  })
+
+  it("keeps the documented pnpm invocation JSON-only", () => {
+    const run = spawnSync("pnpm", [
+      "--silent",
+      "--filter",
+      "@fairy/cli",
+      "run",
+      "cli",
+      "--",
+      "help",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+    const result = JSON.parse(run.stdout) as { schemaVersion: string }
+
+    expect(run.status).toBe(0)
+    expect(result.schemaVersion).toBe("fairy-cli-help-v1")
+    expect(run.stderr).toBe("")
+  })
+
+  it("shows pnpm lifecycle output without --silent, so docs must not recommend it", () => {
+    const run = spawnSync("pnpm", [
+      "--filter",
+      "@fairy/cli",
+      "run",
+      "cli",
+      "--",
+      "help",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+
+    expect(run.status).toBe(0)
+    expect(run.stdout.trimStart().startsWith("{")).toBe(false)
+  })
+
+  it("compares two snapshot files", async () => {
+    const stronger = structuredClone(baseSnapshot)
+    stronger.team[0]!.panel.attack = 1200
+    const io = fakeIo({
+      files: {
+        "/repo/left.json": JSON.stringify(baseSnapshot),
+        "/repo/right.json": JSON.stringify(stronger),
+      },
+    })
+    const code = await runCli(["compare", "left.json", "right.json"], io)
+    const result = JSON.parse(io.output.stdout) as {
+      delta: { rawTotalDamage: number }
+      left: { summary: { rawTotalDamage: number } }
+      right: { summary: { rawTotalDamage: number } }
+    }
+
+    expect(code).toBe(0)
+    expect(result.right.summary.rawTotalDamage).toBeGreaterThan(result.left.summary.rawTotalDamage)
+    expect(result.delta.rawTotalDamage).toBeCloseTo(90.909, 3)
+  })
+
+  it("passes result mode through to core calculation", async () => {
+    const snapshot = structuredClone(baseSnapshot)
+    snapshot.team[0]!.panel.critRate = 0.5
+    snapshot.team[0]!.panel.critDamage = 1
+    const io = fakeIo({ stdin: JSON.stringify(snapshot) })
+    const code = await runCli(["calc", "-", "--result-mode", "crit"], io)
+    const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
+
+    expect(code).toBe(0)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(909.091, 3)
+  })
+
+  it("accepts boolean flags before the input path", async () => {
+    const io = fakeIo({
+      files: {
+        "/repo/snapshot.json": JSON.stringify(baseSnapshot),
+      },
+    })
+    const code = await runCli(["calc", "--pretty", "snapshot.json"], io)
+    const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
+
+    expect(code).toBe(0)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
+    expect(io.output.stdout.startsWith("{\n")).toBe(true)
+  })
+
+  it("scans a numeric snapshot path into JSON rows", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const code = await runCli([
+      "scan",
+      "-",
+      "--path",
+      "team[0].panel.attack",
+      "--from",
+      "1000",
+      "--to",
+      "1100",
+      "--step",
+      "100",
+    ], io)
+    const result = JSON.parse(io.output.stdout) as {
+      scan: { path: string }
+      rows: Array<{ value: number; summary: { rawTotalDamage: number } }>
+    }
+
+    expect(code).toBe(0)
+    expect(result.scan.path).toBe("team[0].panel.attack")
+    expect(result.rows.map(row => row.value)).toEqual([1000, 1100])
+    expect(result.rows[1]!.summary.rawTotalDamage).toBeGreaterThan(result.rows[0]!.summary.rawTotalDamage)
+  })
+
+  it("returns JSON errors for invalid arguments", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const code = await runCli(["calc", "-", "--lang", "fr"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-ARG")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("returns JSON schema errors for invalid snapshots", async () => {
+    const io = fakeIo({ stdin: JSON.stringify({ schemaVersion: "1.0.0" }) })
+    const code = await runCli(["calc", "-"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; details: unknown[] } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-SCHEMA")
+    expect(error.error.details.length).toBeGreaterThan(0)
+    expect(io.output.stdout).toBe("")
+  })
+})
+
+function withoutAttackSegmentSource() {
+  const snapshot = structuredClone(baseSnapshot) as Record<string, unknown> & {
+    attackSegments: Array<Record<string, unknown>>
+  }
+  snapshot.attackSegments = [
+    {
+      id: "seg-1",
+      attribute: "ether",
+      tags: ["basic"],
+      damageType: "regular",
+      multiplier: 1,
+    },
+  ]
+  return snapshot
+}
+
+function fakeIo(input: {
+  stdin?: string
+  files?: Record<string, string>
+} = {}) {
+  const output = {
+    stdout: "",
+    stderr: "",
+  }
+
+  return {
+    cwd: "/repo",
+    output,
+    readFile: async (path: string) => {
+      const file = input.files?.[path]
+      if (file === undefined)
+        throw new Error(`missing test file: ${path}`)
+      return file
+    },
+    readStdin: async () => input.stdin ?? "",
+    stdout: (text: string) => {
+      output.stdout += text
+    },
+    stderr: (text: string) => {
+      output.stderr += text
+    },
+    loadMessages: async () => messages,
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,431 @@
+import type { CalcResult, Diagnostic } from "@fairy/core"
+import { calculate, parseBattleSnapshot } from "@fairy/core"
+import { readFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+type Lang = "zh" | "en"
+type ResultMode = "expected" | "crit" | "nonCrit"
+
+interface CliIo {
+  cwd: string
+  readFile(path: string): Promise<string>
+  readStdin(): Promise<string>
+  stdout(text: string): void
+  stderr(text: string): void
+  loadMessages(lang: Lang): Promise<MessageCatalog>
+}
+
+type MessageCatalog = Record<string, string>
+
+interface ParsedArgs {
+  command: string
+  inputs: string[]
+  flags: Map<string, string | boolean>
+}
+
+interface CliErrorBody {
+  ok: false
+  error: {
+    code: string
+    message: string
+    details?: unknown
+  }
+}
+
+const supportedCommands = ["calc", "compare", "scan", "explain", "migrate"] as const
+const booleanFlags = new Set(["help", "pretty"])
+const defaultLang: Lang = "zh"
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+export async function runCli(argv: string[], io: CliIo = nodeIo()): Promise<number> {
+  const parsed = parseArgs(argv)
+  const langResult = parseLang(parsed.flags.get("lang"))
+  const lang = langResult.ok ? langResult.lang : defaultLang
+
+  try {
+    if (!langResult.ok)
+      throw cliError("ERR-CLI-ARG", langResult.message)
+
+    if (parsed.flags.has("help") || parsed.command === "help") {
+      writeJson(io, getHelp(), parsed.flags.has("pretty"))
+      return 0
+    }
+
+    switch (parsed.command) {
+      case "calc":
+        return await runCalc(parsed, io, lang)
+      case "compare":
+        return await runCompare(parsed, io, lang)
+      case "scan":
+        return await runScan(parsed, io, lang)
+      case "explain":
+        return await runExplain(parsed, io, lang)
+      case "migrate":
+        return await runMigrate(parsed, io, lang)
+      default:
+        throw cliError("ERR-CLI-CMD", `Unsupported command: ${parsed.command}`)
+    }
+  }
+  catch (err) {
+    const body = toCliErrorBody(err)
+    io.stderr(`${JSON.stringify(body)}\n`)
+    return 1
+  }
+}
+
+async function runCalc(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
+  const snapshot = await readSnapshotInput(parsed, io, 0)
+  const result = calculate(withResultMode(snapshot, parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))))
+  await writeDiagnostics(io, result, lang)
+  writeJson(io, result, parsed.flags.has("pretty"))
+  return result.errors.length > 0 ? 1 : 0
+}
+
+async function runCompare(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
+  if (parsed.inputs.length < 2)
+    throw cliError("ERR-CLI-ARG", "compare requires two snapshot inputs")
+
+  const leftInput = await readSnapshotInput(parsed, io, 0)
+  const rightInput = await readSnapshotInput(parsed, io, 1)
+  const resultMode = parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))
+  const left = calculate(withResultMode(leftInput, resultMode), { calculationId: "left" })
+  const right = calculate(withResultMode(rightInput, resultMode), { calculationId: "right" })
+  await writeDiagnostics(io, left, lang)
+  await writeDiagnostics(io, right, lang)
+  writeJson(io, {
+    schemaVersion: "fairy-cli-compare-v1",
+    resultMode: resultMode ?? "expected",
+    left,
+    right,
+    delta: {
+      rawTotalDamage: right.summary.rawTotalDamage - left.summary.rawTotalDamage,
+      displayTotalDamage: right.summary.displayTotalDamage - left.summary.displayTotalDamage,
+      expectedDamage: (right.summary.expectedDamage ?? right.summary.rawTotalDamage)
+        - (left.summary.expectedDamage ?? left.summary.rawTotalDamage),
+      damageTypeChanged: left.summary.damageType !== right.summary.damageType,
+    },
+  }, parsed.flags.has("pretty"))
+  return left.errors.length > 0 || right.errors.length > 0 ? 1 : 0
+}
+
+async function runScan(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
+  const path = readStringFlag(parsed, "path")
+  const from = readNumberFlag(parsed, "from")
+  const to = readNumberFlag(parsed, "to")
+  const step = readNumberFlag(parsed, "step")
+  if (step <= 0)
+    throw cliError("ERR-CLI-ARG", "--step must be greater than 0")
+
+  const snapshot = await readSnapshotInput(parsed, io, 0)
+  const resultMode = parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))
+  const rows: Array<{ value: number; summary: CalcResult["summary"]; diagnostics: { warnings: number; errors: number } }> = []
+  for (let value = from; value <= to + Number.EPSILON; value += step) {
+    const scannedSnapshot = setPath(structuredClone(snapshot), path, normalizeScanValue(value))
+    const result = calculate(withResultMode(scannedSnapshot, resultMode), { calculationId: `scan-${rows.length + 1}` })
+    await writeDiagnostics(io, result, lang)
+    rows.push({
+      value: normalizeScanValue(value),
+      summary: result.summary,
+      diagnostics: {
+        warnings: result.warnings.length,
+        errors: result.errors.length,
+      },
+    })
+  }
+
+  writeJson(io, {
+    schemaVersion: "fairy-cli-scan-v1",
+    resultMode: resultMode ?? "expected",
+    scan: {
+      path,
+      from,
+      to,
+      step,
+    },
+    rows,
+  }, parsed.flags.has("pretty"))
+  return rows.some(row => row.diagnostics.errors > 0) ? 1 : 0
+}
+
+async function runExplain(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
+  const snapshot = await readSnapshotInput(parsed, io, 0)
+  const result = calculate(withResultMode(snapshot, parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))))
+  await writeDiagnostics(io, result, lang)
+  writeJson(io, {
+    schemaVersion: "fairy-cli-explain-v1",
+    summary: result.summary,
+    warnings: result.warnings,
+    errors: result.errors,
+    attackSegments: result.attackSegments,
+    buckets: result.buckets,
+    modifiers: result.modifiers,
+    trace: result.trace,
+  }, parsed.flags.has("pretty"))
+  return result.errors.length > 0 ? 1 : 0
+}
+
+async function runMigrate(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
+  const snapshot = parseBattleSnapshot(await readSnapshotInput(parsed, io, 0))
+  const messages = await io.loadMessages(lang)
+  const diagnostics: Diagnostic[] = []
+  writeDiagnosticLines(io, diagnostics, messages)
+  writeJson(io, {
+    schemaVersion: "fairy-cli-migrate-v1",
+    migrated: false,
+    reason: "No schema migration rules are registered in V1.",
+    snapshot,
+  }, parsed.flags.has("pretty"))
+  return 0
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = [...argv]
+  if (args[0] === "--")
+    args.shift()
+  const command = args.shift() ?? "help"
+  const inputs: string[] = []
+  const flags = new Map<string, string | boolean>()
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!
+    if (!arg.startsWith("--")) {
+      inputs.push(arg)
+      continue
+    }
+
+    const [rawName, inlineValue] = arg.slice(2).split("=", 2)
+    const name = rawName ?? ""
+    if (booleanFlags.has(name)) {
+      flags.set(name, true)
+      continue
+    }
+
+    if (inlineValue !== undefined) {
+      flags.set(name, inlineValue)
+      continue
+    }
+
+    const next = args[index + 1]
+    if (next !== undefined && !next.startsWith("--")) {
+      flags.set(name, next)
+      index += 1
+    }
+    else {
+      flags.set(name, true)
+    }
+  }
+
+  return {
+    command,
+    inputs,
+    flags,
+  }
+}
+
+async function readSnapshotInput(parsed: ParsedArgs, io: CliIo, index: number): Promise<unknown> {
+  const input = parsed.inputs[index] ?? "-"
+  const text = input === "-"
+    ? await io.readStdin()
+    : await io.readFile(resolve(io.cwd, input))
+  try {
+    return JSON.parse(text) as unknown
+  }
+  catch (err) {
+    throw cliError("ERR-CLI-JSON", `Invalid JSON input at ${input}`, err)
+  }
+}
+
+function withResultMode(input: unknown, resultMode: ResultMode | undefined): unknown {
+  if (resultMode === undefined || input === null || typeof input !== "object")
+    return input
+
+  const snapshot = structuredClone(input) as Record<string, unknown>
+  const options = snapshot.options !== null && typeof snapshot.options === "object"
+    ? { ...snapshot.options as Record<string, unknown> }
+    : {}
+  options.resultMode = resultMode
+  snapshot.options = options
+  return snapshot
+}
+
+function parseLang(value: string | boolean | undefined): { ok: true; lang: Lang } | { ok: false; message: string } {
+  if (value === undefined || value === false || value === true)
+    return { ok: true, lang: defaultLang }
+  if (value === "zh" || value === "en")
+    return { ok: true, lang: value }
+  return { ok: false, message: "--lang must be zh or en" }
+}
+
+function parseResultMode(value: string | boolean | undefined): ResultMode | undefined {
+  if (value === undefined || value === false || value === true)
+    return undefined
+  if (value === "expected" || value === "crit" || value === "nonCrit")
+    return value
+  throw cliError("ERR-CLI-ARG", "--result-mode must be expected, crit, or nonCrit")
+}
+
+function readStringFlag(parsed: ParsedArgs, name: string): string {
+  const value = parsed.flags.get(name)
+  if (typeof value !== "string" || value.length === 0)
+    throw cliError("ERR-CLI-ARG", `--${name} is required`)
+  return value
+}
+
+function readNumberFlag(parsed: ParsedArgs, name: string): number {
+  const rawValue = readStringFlag(parsed, name)
+  const value = Number(rawValue)
+  if (!Number.isFinite(value))
+    throw cliError("ERR-CLI-ARG", `--${name} must be a number`)
+  return value
+}
+
+function setPath(input: unknown, path: string, value: unknown): unknown {
+  const parts = path.match(/[^[.\]]+/g)
+  if (parts === null || parts.length === 0)
+    throw cliError("ERR-CLI-ARG", `Invalid scan path: ${path}`)
+
+  let cursor = input as Record<string, unknown> | unknown[]
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const part = parts[index]!
+    const next = Array.isArray(cursor) ? cursor[Number(part)] : cursor[part]
+    if (next === null || typeof next !== "object")
+      throw cliError("ERR-CLI-ARG", `Cannot scan missing path segment: ${parts.slice(0, index + 1).join(".")}`)
+    cursor = next as Record<string, unknown> | unknown[]
+  }
+
+  const finalPart = parts[parts.length - 1]!
+  if (Array.isArray(cursor))
+    cursor[Number(finalPart)] = value
+  else
+    cursor[finalPart] = value
+  return input
+}
+
+function normalizeScanValue(value: number): number {
+  return Number(value.toFixed(12))
+}
+
+async function writeDiagnostics(io: CliIo, result: CalcResult, lang: Lang): Promise<void> {
+  if (result.warnings.length === 0 && result.errors.length === 0)
+    return
+
+  const messages = await io.loadMessages(lang)
+  writeDiagnosticLines(io, [...result.warnings, ...result.errors], messages)
+}
+
+function writeDiagnosticLines(io: CliIo, diagnostics: Diagnostic[], messages: MessageCatalog): void {
+  for (const diagnostic of diagnostics) {
+    const level = diagnostic.severity.toUpperCase()
+    const path = diagnostic.path === undefined ? "" : ` ${diagnostic.path}`
+    io.stderr(`${level} ${diagnostic.key}${path}: ${renderDiagnostic(diagnostic, messages)}\n`)
+  }
+}
+
+function renderDiagnostic(diagnostic: Diagnostic, messages: MessageCatalog): string {
+  const template = messages[diagnostic.key] ?? diagnostic.key
+  return template.replace(/\{([^}]+)\}/g, (_, key: string) => {
+    const value = diagnostic.messageParams?.[key]
+    return value === undefined ? `{${key}}` : String(value)
+  })
+}
+
+function writeJson(io: CliIo, value: unknown, pretty: boolean): void {
+  io.stdout(`${JSON.stringify(value, null, pretty ? 2 : 0)}\n`)
+}
+
+function getHelp() {
+  return {
+    schemaVersion: "fairy-cli-help-v1",
+    commands: supportedCommands,
+    flags: {
+      "--lang": ["zh", "en"],
+      "--result-mode": ["expected", "crit", "nonCrit"],
+      "--pretty": true,
+      "--path": "scan target path",
+      "--from": "scan start number",
+      "--to": "scan end number",
+      "--step": "scan step number",
+    },
+    input: "Use a JSON file path or '-' for stdin. calc/explain/migrate accept one input; compare accepts two; scan accepts one plus --path/--from/--to/--step.",
+  }
+}
+
+function cliError(code: string, message: string, details?: unknown): Error & { code: string; details?: unknown } {
+  const err = new Error(message) as Error & { code: string; details?: unknown }
+  err.code = code
+  if (details !== undefined)
+    err.details = details
+  return err
+}
+
+function toCliErrorBody(err: unknown): CliErrorBody {
+  if (isZodErrorLike(err)) {
+    return {
+      ok: false,
+      error: {
+        code: "ERR-CLI-SCHEMA",
+        message: "Input does not match BattleSnapshot schema.",
+        details: err.issues,
+      },
+    }
+  }
+
+  if (err instanceof Error) {
+    const maybeCoded = err as Error & { code?: string; details?: unknown }
+    return {
+      ok: false,
+      error: {
+        code: maybeCoded.code ?? "ERR-CLI-UNCAUGHT",
+        message: err.message,
+        ...(maybeCoded.details === undefined ? {} : { details: maybeCoded.details }),
+      },
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: "ERR-CLI-UNCAUGHT",
+      message: String(err),
+    },
+  }
+}
+
+function isZodErrorLike(err: unknown): err is { issues: unknown[] } {
+  return err !== null
+    && typeof err === "object"
+    && Array.isArray((err as { issues?: unknown }).issues)
+}
+
+function nodeIo(): CliIo {
+  return {
+    cwd: process.cwd(),
+    readFile: path => readFile(path, "utf8"),
+    readStdin: () => new Promise((resolveInput, reject) => {
+      let input = ""
+      process.stdin.setEncoding("utf8")
+      process.stdin.on("data", chunk => {
+        input += chunk
+      })
+      process.stdin.on("end", () => resolveInput(input))
+      process.stdin.on("error", reject)
+    }),
+    stdout: text => process.stdout.write(text),
+    stderr: text => process.stderr.write(text),
+    loadMessages: async (lang) => {
+      const path = resolve(repoRoot, "docs", "ux", "i18n", `messages.${lang}.json`)
+      const raw = await readFile(path, "utf8")
+      return JSON.parse(raw) as MessageCatalog
+    },
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli(process.argv.slice(2)).then((code) => {
+    process.exitCode = code
+  }).catch((err: unknown) => {
+    process.stderr.write(`${JSON.stringify(toCliErrorBody(err))}\n`)
+    process.exitCode = 1
+  })
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,14 +8,24 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(vite@8.0.10)
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
 
-  packages/cli: {}
+  packages/cli:
+    dependencies:
+      '@fairy/core':
+        specifier: workspace:*
+        version: link:../core
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   packages/core:
     dependencies:
@@ -35,6 +45,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -161,6 +327,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -208,6 +377,11 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -228,6 +402,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -328,6 +505,9 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -364,10 +544,18 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -479,6 +667,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -557,6 +823,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -566,13 +836,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10)':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -608,6 +878,35 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -620,6 +919,10 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -690,6 +993,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  resolve-pkg-maps@1.0.0: {}
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -733,9 +1038,18 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@6.0.3: {}
 
-  vite@8.0.10:
+  undici-types@7.19.2: {}
+
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -743,12 +1057,15 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@4.1.5(vite@8.0.10):
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10)
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -765,8 +1082,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #30 [TL-S4]
- Reviewers: @Product, @QA
- Related decisions: D-02-rev / D-11 / CONFIRM-8 / FR-11 / FR-12 / FR-15 / FR-19
- i18n impact: consumes existing `docs/ux/i18n/messages.{zh,en}.json`; no new diagnostic keys in this PR. ERR-CLI-* catalog rendering is split to task #33/#34.

## Summary

- Adds the `@fairy/cli` command shell for `calc`, `compare`, `scan`, `explain`, and `migrate`.
- Keeps stdout JSON-only; localized core diagnostics are emitted on stderr through `--lang zh|en`.
- Supports `--result-mode expected|crit|nonCrit` for three damage modes and preserves core `CalcResult` trace/bucket output.
- Adds CLI README, package bin wrapper, TypeScript config, and Vitest coverage.
- Updates `CLAUDE.md` and `docs/index.md` from S3 core implementation to S4/S5 current phase.

## QA Blocker Fixes

- Loads i18n message catalogs relative to the CLI module/repo root instead of `process.cwd()`.
- Documents `pnpm --silent --filter @fairy/cli run cli -- ...` so README commands remain JSON-only.
- Parses boolean flags (`--pretty`, `--help`) without consuming following positional inputs, so `fairy calc --pretty snapshot.json` works.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test` (core 36 tests + cli 11 tests)
- `git diff --check origin/main...HEAD`
- `packages/cli/bin/fairy.js help >/tmp/fairy-cli-help.json && jq empty /tmp/fairy-cli-help.json`
- Manual QA repro checks: cwd outside repo root warning diagnostic, README `pnpm --silent` invocation piped to `jq empty`, and `calc --pretty snapshot.json`.

## Notes

- `scan` returns JSON rows rather than CSV/PNG because S4 is locked to JSON-only output. CSV/PNG renderers stay outside this PR.
- Invalid arguments, invalid JSON, and schema validation failures return JSON error objects on stderr. Their catalog-localized messages are handled by follow-up task #33/#34.
