### PR TITLE
docs(ux): add ERR-CLI-* bilingual messages + i18n README (UX-S4-1)

### DIFF
--- a/docs/ux/i18n/README.md
+++ b/docs/ux/i18n/README.md
@@ -1,0 +1,71 @@
+# UX i18n 资源说明
+
+Owner: @UX
+Status: v0.1（伴随 UX-S4-1 落地：Product 决策选 A，CLI ERR-CLI-* 全套双语化）
+Inputs: D-02-rev / D-11 / Product CLI ERR-CLI-* 决策（A，2026-05-05）
+
+## 资源文件
+
+- `messages.zh.json`：中文（默认 `--lang zh`）
+- `messages.en.json`：英文（`--lang en` 切换）
+
+两个文件 key 集与 placeholder 集**严格一致**；新增 / 修改 key 必须同步更新两侧 + `_meta.totalEntries`。
+
+## i18n 范围（V1）
+
+V1 双语覆盖 **core engine 业务侧 diagnostic** + **CLI shell / argument validation 错误**（Product 决策 A，2026-05-05），共 **33 条**。
+
+### 双语条目分组
+
+| 系列 | 数量 | 含义 | 引入版本 |
+|---|---|---|---|
+| `ERR-RNG-*` | 9 | 乘区数值越界 | v0.3 |
+| `ERR-DAT-*` | 4 | 内置 / data 包数据缺失 | v0.3 |
+| `ERR-SRC-001` | 1 | 无来源 modifier（user / temporary contributor） | v0.3 / v0.4 重写 |
+| `ERR-VER-*` | 4 | 版本不匹配双路径（重算 / 只读 / 二次确认）含 4 个 `original*` | v0.3 / v0.4 |
+| `ERR-EVENT-*` | 4 | 真实伤害手动事件（partBreak / corruptedShieldCleanse 等） | v0.4 |
+| `ERR-UI-*` | 3 | 空结果 / 加载 / unsupported feature | v0.3 / v0.4 |
+| `ERR-OCR-000` | 1 | 不识别截图 | v0.3 |
+| `ERR-CALC-PENDING-*` | 2 | anomaly / disorder PR #10 阶段 schema 骨架占位（TL-S3-4 实装后实际不再 emit，但保留资源） | UX-S3-1 |
+| **`ERR-CLI-*`** | **5** | **CLI argument / schema 错误**（A 决策双语化） | **UX-S4-1** |
+
+合计 33 条。
+
+### Placeholder 约定（v0.4 + UX-S4-1）
+
+| Key | Placeholders |
+|---|---|
+| `ERR-RNG-001` | `{raw}` |
+| `ERR-RNG-002` / `ERR-RNG-003` | `{clamped}` |
+| `ERR-DAT-003` | `{agentId}` |
+| `ERR-EVENT-001` / `ERR-EVENT-004` | `{eventId}` / `{kind}` |
+| `ERR-EVENT-003` | `{eventId}` / `{partId}` / `{enemyId}` |
+| `ERR-VER-001~004` | `{originalRuleSetVersion}` / `{originalDataVersion}` / `{originalSourceVersion}` / `{originalGameVersion}` / `{currentRuleSetVersion}` |
+| `ERR-SRC-001` | `{path}` |
+| **`ERR-CLI-ARG`** | **`{message}`** |
+| **`ERR-CLI-CMD`** | **`{command}`** |
+| **`ERR-CLI-JSON`** | **`{input}`** |
+| **`ERR-CLI-SCHEMA`** | （无 placeholder；schema 详情保持在 JSON `error.details` 字段） |
+| **`ERR-CLI-UNCAUGHT`** | **`{message}`** |
+
+ERR-CLI-* placeholder 由 TL（task #33 [TL-S4-follow]）锁定，本文件以此为权威；后续若新增 ERR-CLI-* 系列条目，TL/UX 协作锁 placeholder 后再增。
+
+## 文件维护规则
+
+1. **添加新 key**：必须同时改 zh + en + `_meta.totalEntries`
+2. **修改文案**：保持 placeholder 集一致（同一 key 在两语言下用相同的 `{x}`）
+3. **删除 key**：标 deprecated 而非直接删（防止存量 build.json / fixture 引用）
+4. **PR 验证**：`jq empty messages.zh.json messages.en.json` + `diff <(jq -r 'keys[]' messages.zh.json | sort) <(jq -r 'keys[]' messages.en.json | sort)` 必须空
+
+## 引用方
+
+- `@fairy/core`：`Diagnostic.key` + `Diagnostic.messageParams`，core **不**输出本地化字符串
+- `@fairy/cli`：
+  - 业务 diagnostic：`renderDiagnostic(diagnostic, messages)` 按 `--lang` 加载对应 catalog 渲染
+  - CLI shell 错误（ERR-CLI-*）：cliError 保留稳定 `code` + 通过 catalog 渲染本地化 `message`；catalog 缺 key 时用英文 fallback 常量表（task #33 [TL-S4-follow]）
+- AI plugin / Web UI（V1.1+）：从 catalog 反序列化 + 模板填充，遵循 prompt-templates.md 4 档输出粒度
+
+## 决策与历史
+
+- 2026-05-05：Product 初始决策 B（CLI 错误英文 only），后基于"P1 玩家高频场景（snapshot.json schema 错）"反馈撤回，最终决策 A（CLI 错误也双语化）
+- v0.4 / UX-S3-1 / UX-S4-1 累积，资源在 main 分支按 PR 流入

--- a/docs/ux/i18n/messages.en.json
+++ b/docs/ux/i18n/messages.en.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 28,
-    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series; UX-S3-1 extends ERR-CALC-PENDING-* series (locked by PR #10 commit dacf36c)"
+    "totalEntries": 33,
+    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series; UX-S3-1 extends ERR-CALC-PENDING-* series; UX-S4-1 extends ERR-CLI-* series (CLI argument / schema errors; Product decided Option A bilingual 2026-05-05)"
   },
   "ERR-RNG-001": "Damage Bonus Zone exceeds the cap of 600% (Strategy PART 01.2). Truncated for display; raw accumulated value: {raw}%.",
   "ERR-RNG-002": "CRIT Rate must be within 0–100% (Strategy PART 01.3). Auto-clamped to {clamped}%.",
@@ -35,5 +35,10 @@
   "ERR-UI-003": "Team contains unsupported field (e.g., subordinate / Bangboo). V1 does not support this feature; the corresponding field has been ignored.",
   "ERR-OCR-000": "This tool does not parse screenshots. Screenshots are visual references only. Please fill in fields manually.",
   "ERR-CALC-PENDING-ANOMALY": "⚠ V1 PR #10 stage: anomaly damage formula returns a schema-compatible skeleton only and does **not produce trustworthy values**. Full anomaly computation (virtual agent weighting / anomaly trigger count table / anomaly crit zone / overflow exclusion, etc.) is implemented by task #27 [TL-S3-4].",
-  "ERR-CALC-PENDING-DISORDER": "⚠ V1 PR #10 stage: disorder damage formula returns a schema-compatible skeleton only and does **not produce trustworthy values**. Full disorder computation (seven-attribute multipliers / daze level zone / disorder daze accumulation / disorderFormulaId trace evidence, etc.) is implemented by task #27 [TL-S3-4]."
+  "ERR-CALC-PENDING-DISORDER": "⚠ V1 PR #10 stage: disorder damage formula returns a schema-compatible skeleton only and does **not produce trustworthy values**. Full disorder computation (seven-attribute multipliers / daze level zone / disorder daze accumulation / disorderFormulaId trace evidence, etc.) is implemented by task #27 [TL-S3-4].",
+  "ERR-CLI-ARG": "Command argument error: {message}. Run `fairy help <command>` for usage.",
+  "ERR-CLI-CMD": "Unknown subcommand: {command}. Available: calc / compare / scan / explain / migrate / help.",
+  "ERR-CLI-JSON": "Failed to parse input JSON: {input}. Check the file format or run `fairy explain` for an example.",
+  "ERR-CLI-SCHEMA": "Input does not match BattleSnapshot schema. See JSON `error.details` for specifics; refer to docs/data-contract/battle-snapshot.md.",
+  "ERR-CLI-UNCAUGHT": "Uncaught error: {message}. Please file an issue with the input and command."
 }

--- a/docs/ux/i18n/messages.zh.json
+++ b/docs/ux/i18n/messages.zh.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 28,
-    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列；UX-S3-1 扩展 ERR-CALC-PENDING-* 系列（PR #10 commit dacf36c 锁定）"
+    "totalEntries": 33,
+    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列；UX-S3-1 扩展 ERR-CALC-PENDING-* 系列；UX-S4-1 扩展 ERR-CLI-* 系列（CLI 参数 / schema 错误，Product 决策选 A 双语化 2026-05-05）"
   },
   "ERR-RNG-001": "增伤区已超过攻略上限 600%（PART 01.2）。已截断展示，原始累加值为 {raw}%。",
   "ERR-RNG-002": "暴击率有效范围 0~100%（攻略 PART 01.3）。已自动 clamp 为 {clamped}%。",
@@ -35,5 +35,10 @@
   "ERR-UI-003": "团队中存在 unsupported 字段（如 subordinate / 邦布）。V1 不支持此特性，对应字段已忽略。",
   "ERR-OCR-000": "本工具不识别截图。截图仅作为录入时的视觉参考。请按字段对照填写。",
   "ERR-CALC-PENDING-ANOMALY": "⚠ 当前 V1 PR #10 阶段：异常伤害公式仅返回 schema 兼容骨架，**未输出可信数值**。完整异常计算（虚拟代理人加权 / 异常触发计数表 / 异常暴击区 / overflow 排除等）由 task #27 [TL-S3-4] 实现。",
-  "ERR-CALC-PENDING-DISORDER": "⚠ 当前 V1 PR #10 阶段：紊乱伤害公式仅返回 schema 兼容骨架，**未输出可信数值**。完整紊乱计算（七属性倍率 / 失衡等级区 / 紊乱失衡值 / disorderFormulaId trace evidence 等）由 task #27 [TL-S3-4] 实现。"
+  "ERR-CALC-PENDING-DISORDER": "⚠ 当前 V1 PR #10 阶段：紊乱伤害公式仅返回 schema 兼容骨架，**未输出可信数值**。完整紊乱计算（七属性倍率 / 失衡等级区 / 紊乱失衡值 / disorderFormulaId trace evidence 等）由 task #27 [TL-S3-4] 实现。",
+  "ERR-CLI-ARG": "命令行参数错误：{message}。运行 `fairy help <command>` 查看用法。",
+  "ERR-CLI-CMD": "未知子命令：{command}。可用命令：calc / compare / scan / explain / migrate / help。",
+  "ERR-CLI-JSON": "输入 JSON 解析失败：{input}。请检查文件格式或使用 `fairy explain` 查看示例。",
+  "ERR-CLI-SCHEMA": "输入不符合 BattleSnapshot schema。详情见 JSON `error.details` 字段；请参考 docs/data-contract/battle-snapshot.md。",
+  "ERR-CLI-UNCAUGHT": "未捕获错误：{message}。请提交 issue 附上输入与命令。"
 }


### PR DESCRIPTION
## Slock Context
- Owner: @UX
- Task: #34 (UX-S4-1)
- Reviewers: @TechLead (placeholder lock), @QA (key/placeholder consistency)
- Related decisions: D-02-rev / D-11 / Product CLI ERR-CLI-* Option A 2026-05-05
- i18n impact: zh+en

## Summary
Per Product Option A decision (2026-05-05): CLI argument/schema errors are also bilingual since `ERR-CLI-SCHEMA` / `ERR-CLI-JSON` are P1 player high-frequency errors (snapshot.json format issues).

## Changes (3 files / +87 / -6)
- `docs/ux/i18n/messages.zh.json`: 28 → 33 entries (+5 ERR-CLI-*)
- `docs/ux/i18n/messages.en.json`: mirror
- `docs/ux/i18n/README.md` (new): scope, placeholder conventions, maintenance rules

## Placeholder set (locked by TL task #33)
| Key | Placeholders |
|---|---|
| `ERR-CLI-ARG` | `{message}` |
| `ERR-CLI-CMD` | `{command}` |
| `ERR-CLI-JSON` | `{input}` |
| `ERR-CLI-SCHEMA` | (none — schema details kept in JSON `error.details`) |
| `ERR-CLI-UNCAUGHT` | `{message}` |

## Verification
- `jq empty docs/ux/i18n/messages.zh.json docs/ux/i18n/messages.en.json` pass
- key sets match between zh and en (33 entries each, 34 incl. _meta)
- placeholder convention aligned with TL's task #33 spec