### PR TITLE
fix(cli): localize shell error messages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,4 +31,6 @@ calculation so the same snapshot can produce expected, forced-crit, and
 forced-non-crit output.
 
 Invalid arguments, invalid JSON, and schema validation failures are reported as
-JSON error objects on stderr.
+JSON error objects on stderr. Their stable `error.code` stays language-independent,
+while `error.message` is rendered through the same `--lang zh|en` catalog with
+English fallback strings.

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,13 @@
+export const cliErrorFallbackMessages = {
+  "ERR-CLI-ARG": "Command argument error: {message}. Run `fairy help <command>` for usage.",
+  "ERR-CLI-CMD": "Unknown subcommand: {command}. Available: calc / compare / scan / explain / migrate / help.",
+  "ERR-CLI-JSON": "Failed to parse input JSON: {input}. Check the file format or run `fairy explain` for an example.",
+  "ERR-CLI-SCHEMA": "Input does not match BattleSnapshot schema. See JSON `error.details` for specifics; refer to docs/data-contract/battle-snapshot.md.",
+  "ERR-CLI-UNCAUGHT": "Uncaught error: {message}. Please file an issue with the input and command.",
+} as const
+
+export type CliErrorCode = keyof typeof cliErrorFallbackMessages
+
+export function isCliErrorCode(code: string): code is CliErrorCode {
+  return code in cliErrorFallbackMessages
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -52,6 +52,11 @@ const baseSnapshot = {
 }
 
 const messages = {
+  "ERR-CLI-ARG": "Localized argument problem: {message}",
+  "ERR-CLI-CMD": "Localized command problem: {command}",
+  "ERR-CLI-JSON": "Localized JSON problem: {input}",
+  "ERR-CLI-SCHEMA": "Localized schema problem.",
+  "ERR-CLI-UNCAUGHT": "Localized uncaught problem: {message}",
   "ERR-SRC-001": "Modifier at {path} has no source.",
 }
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
@@ -224,22 +229,96 @@ describe("fairy cli", () => {
   it("returns JSON errors for invalid arguments", async () => {
     const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
     const code = await runCli(["calc", "-", "--lang", "fr"], io)
-    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string } }
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
 
     expect(code).toBe(1)
     expect(error.error.code).toBe("ERR-CLI-ARG")
+    expect(error.error.message).toBe("Localized argument problem: --lang must be zh or en")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("renders unknown command errors through the catalog", async () => {
+    const io = fakeIo()
+    const code = await runCli(["unknown"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-CMD")
+    expect(error.error.message).toBe("Localized command problem: unknown")
     expect(io.output.stdout).toBe("")
   })
 
   it("returns JSON schema errors for invalid snapshots", async () => {
     const io = fakeIo({ stdin: JSON.stringify({ schemaVersion: "1.0.0" }) })
     const code = await runCli(["calc", "-"], io)
-    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; details: unknown[] } }
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string; details: unknown[] } }
 
     expect(code).toBe(1)
     expect(error.error.code).toBe("ERR-CLI-SCHEMA")
+    expect(error.error.message).toBe("Localized schema problem.")
     expect(error.error.details.length).toBeGreaterThan(0)
     expect(io.output.stdout).toBe("")
+  })
+
+  it("renders JSON parse errors through the catalog and preserves details", async () => {
+    const io = fakeIo({
+      files: {
+        "/repo/broken.json": "{",
+      },
+    })
+    const code = await runCli(["calc", "broken.json"], io)
+    const error = JSON.parse(io.output.stderr) as {
+      ok: false
+      error: { code: string; message: string; details: { cause: string } }
+    }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-JSON")
+    expect(error.error.message).toBe("Localized JSON problem: broken.json")
+    expect(error.error.details.cause).toContain("Expected")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("falls back to English CLI errors when catalog keys are missing", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot), messages: {} })
+    const code = await runCli(["calc", "-", "--lang", "fr"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-ARG")
+    expect(error.error.message).toContain("Command argument error: --lang must be zh or en")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("renders uncaught CLI errors through the catalog", async () => {
+    const io = fakeIo()
+    const code = await runCli(["calc", "missing.json"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-UNCAUGHT")
+    expect(error.error.message).toContain("Localized uncaught problem: missing test file: /repo/missing.json")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("uses the real zh catalog for CLI schema errors", () => {
+    const run = spawnSync(process.execPath, [
+      resolve(repoRoot, "packages/cli/bin/fairy.js"),
+      "calc",
+      "-",
+      "--lang",
+      "zh",
+    ], {
+      cwd: tmpdir(),
+      input: JSON.stringify({ schemaVersion: "1.0.0" }),
+      encoding: "utf8",
+    })
+    const error = JSON.parse(run.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(run.status).toBe(1)
+    expect(run.stdout).toBe("")
+    expect(error.error.code).toBe("ERR-CLI-SCHEMA")
+    expect(error.error.message).toContain("输入不符合 BattleSnapshot schema")
   })
 })
 
@@ -262,6 +341,7 @@ function withoutAttackSegmentSource() {
 function fakeIo(input: {
   stdin?: string
   files?: Record<string, string>
+  messages?: Record<string, string>
 } = {}) {
   const output = {
     stdout: "",
@@ -284,6 +364,6 @@ function fakeIo(input: {
     stderr: (text: string) => {
       output.stderr += text
     },
-    loadMessages: async () => messages,
+    loadMessages: async () => input.messages ?? messages,
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { calculate, parseBattleSnapshot } from "@fairy/core"
 import { readFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import { cliErrorFallbackMessages, isCliErrorCode, type CliErrorCode } from "./errors"
 
 type Lang = "zh" | "en"
 type ResultMode = "expected" | "crit" | "nonCrit"
@@ -17,6 +18,7 @@ interface CliIo {
 }
 
 type MessageCatalog = Record<string, string>
+type MessageParams = Record<string, unknown>
 
 interface ParsedArgs {
   command: string
@@ -45,7 +47,7 @@ export async function runCli(argv: string[], io: CliIo = nodeIo()): Promise<numb
 
   try {
     if (!langResult.ok)
-      throw cliError("ERR-CLI-ARG", langResult.message)
+      throw cliError("ERR-CLI-ARG", { message: langResult.message })
 
     if (parsed.flags.has("help") || parsed.command === "help") {
       writeJson(io, getHelp(), parsed.flags.has("pretty"))
@@ -64,11 +66,11 @@ export async function runCli(argv: string[], io: CliIo = nodeIo()): Promise<numb
       case "migrate":
         return await runMigrate(parsed, io, lang)
       default:
-        throw cliError("ERR-CLI-CMD", `Unsupported command: ${parsed.command}`)
+        throw cliError("ERR-CLI-CMD", { command: parsed.command })
     }
   }
   catch (err) {
-    const body = toCliErrorBody(err)
+    const body = await toCliErrorBody(err, io, lang)
     io.stderr(`${JSON.stringify(body)}\n`)
     return 1
   }
@@ -84,7 +86,7 @@ async function runCalc(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<numbe
 
 async function runCompare(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
   if (parsed.inputs.length < 2)
-    throw cliError("ERR-CLI-ARG", "compare requires two snapshot inputs")
+    throw cliError("ERR-CLI-ARG", { message: "compare requires two snapshot inputs" })
 
   const leftInput = await readSnapshotInput(parsed, io, 0)
   const rightInput = await readSnapshotInput(parsed, io, 1)
@@ -115,7 +117,7 @@ async function runScan(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<numbe
   const to = readNumberFlag(parsed, "to")
   const step = readNumberFlag(parsed, "step")
   if (step <= 0)
-    throw cliError("ERR-CLI-ARG", "--step must be greater than 0")
+    throw cliError("ERR-CLI-ARG", { message: "--step must be greater than 0" })
 
   const snapshot = await readSnapshotInput(parsed, io, 0)
   const resultMode = parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))
@@ -232,7 +234,7 @@ async function readSnapshotInput(parsed: ParsedArgs, io: CliIo, index: number): 
     return JSON.parse(text) as unknown
   }
   catch (err) {
-    throw cliError("ERR-CLI-JSON", `Invalid JSON input at ${input}`, err)
+    throw cliError("ERR-CLI-JSON", { input }, describeUnknownError(err))
   }
 }
 
@@ -262,13 +264,13 @@ function parseResultMode(value: string | boolean | undefined): ResultMode | unde
     return undefined
   if (value === "expected" || value === "crit" || value === "nonCrit")
     return value
-  throw cliError("ERR-CLI-ARG", "--result-mode must be expected, crit, or nonCrit")
+  throw cliError("ERR-CLI-ARG", { message: "--result-mode must be expected, crit, or nonCrit" })
 }
 
 function readStringFlag(parsed: ParsedArgs, name: string): string {
   const value = parsed.flags.get(name)
   if (typeof value !== "string" || value.length === 0)
-    throw cliError("ERR-CLI-ARG", `--${name} is required`)
+    throw cliError("ERR-CLI-ARG", { message: `--${name} is required` })
   return value
 }
 
@@ -276,21 +278,21 @@ function readNumberFlag(parsed: ParsedArgs, name: string): number {
   const rawValue = readStringFlag(parsed, name)
   const value = Number(rawValue)
   if (!Number.isFinite(value))
-    throw cliError("ERR-CLI-ARG", `--${name} must be a number`)
+    throw cliError("ERR-CLI-ARG", { message: `--${name} must be a number` })
   return value
 }
 
 function setPath(input: unknown, path: string, value: unknown): unknown {
   const parts = path.match(/[^[.\]]+/g)
   if (parts === null || parts.length === 0)
-    throw cliError("ERR-CLI-ARG", `Invalid scan path: ${path}`)
+    throw cliError("ERR-CLI-ARG", { message: `Invalid scan path: ${path}` })
 
   let cursor = input as Record<string, unknown> | unknown[]
   for (let index = 0; index < parts.length - 1; index += 1) {
     const part = parts[index]!
     const next = Array.isArray(cursor) ? cursor[Number(part)] : cursor[part]
     if (next === null || typeof next !== "object")
-      throw cliError("ERR-CLI-ARG", `Cannot scan missing path segment: ${parts.slice(0, index + 1).join(".")}`)
+      throw cliError("ERR-CLI-ARG", { message: `Cannot scan missing path segment: ${parts.slice(0, index + 1).join(".")}` })
     cursor = next as Record<string, unknown> | unknown[]
   }
 
@@ -324,8 +326,12 @@ function writeDiagnosticLines(io: CliIo, diagnostics: Diagnostic[], messages: Me
 
 function renderDiagnostic(diagnostic: Diagnostic, messages: MessageCatalog): string {
   const template = messages[diagnostic.key] ?? diagnostic.key
+  return renderMessageTemplate(template, diagnostic.messageParams)
+}
+
+function renderMessageTemplate(template: string, params: MessageParams = {}): string {
   return template.replace(/\{([^}]+)\}/g, (_, key: string) => {
-    const value = diagnostic.messageParams?.[key]
+    const value = params[key]
     return value === undefined ? `{${key}}` : String(value)
   })
 }
@@ -351,44 +357,98 @@ function getHelp() {
   }
 }
 
-function cliError(code: string, message: string, details?: unknown): Error & { code: string; details?: unknown } {
-  const err = new Error(message) as Error & { code: string; details?: unknown }
+function cliError(code: CliErrorCode, messageParams: MessageParams = {}, details?: unknown): Error & {
+  code: CliErrorCode
+  messageParams: MessageParams
+  details?: unknown
+} {
+  const err = new Error(renderMessageTemplate(cliErrorFallbackMessages[code], messageParams)) as Error & {
+    code: CliErrorCode
+    messageParams: MessageParams
+    details?: unknown
+  }
   err.code = code
+  err.messageParams = messageParams
   if (details !== undefined)
     err.details = details
   return err
 }
 
-function toCliErrorBody(err: unknown): CliErrorBody {
+async function toCliErrorBody(err: unknown, io?: CliIo, lang: Lang = defaultLang): Promise<CliErrorBody> {
+  const normalized = normalizeCliError(err)
+  const message = await renderCliErrorMessage(normalized.code, normalized.messageParams, io, lang)
+  return {
+    ok: false,
+    error: {
+      code: normalized.code,
+      message,
+      ...(normalized.details === undefined ? {} : { details: normalized.details }),
+    },
+  }
+}
+
+interface NormalizedCliError {
+  code: CliErrorCode
+  messageParams: MessageParams
+  details?: unknown
+}
+
+function normalizeCliError(err: unknown): NormalizedCliError {
   if (isZodErrorLike(err)) {
     return {
-      ok: false,
-      error: {
-        code: "ERR-CLI-SCHEMA",
-        message: "Input does not match BattleSnapshot schema.",
-        details: err.issues,
-      },
+      code: "ERR-CLI-SCHEMA",
+      messageParams: {},
+      details: err.issues,
     }
   }
 
   if (err instanceof Error) {
-    const maybeCoded = err as Error & { code?: string; details?: unknown }
-    return {
-      ok: false,
-      error: {
-        code: maybeCoded.code ?? "ERR-CLI-UNCAUGHT",
-        message: err.message,
+    const maybeCoded = err as Error & { code?: string; messageParams?: MessageParams; details?: unknown }
+    if (maybeCoded.code !== undefined && isCliErrorCode(maybeCoded.code)) {
+      return {
+        code: maybeCoded.code,
+        messageParams: maybeCoded.messageParams ?? { message: err.message },
         ...(maybeCoded.details === undefined ? {} : { details: maybeCoded.details }),
-      },
+      }
+    }
+
+    return {
+      code: "ERR-CLI-UNCAUGHT",
+      messageParams: { message: err.message },
+      ...(maybeCoded.details === undefined ? {} : { details: maybeCoded.details }),
     }
   }
 
   return {
-    ok: false,
-    error: {
-      code: "ERR-CLI-UNCAUGHT",
-      message: String(err),
-    },
+    code: "ERR-CLI-UNCAUGHT",
+    messageParams: { message: String(err) },
+  }
+}
+
+async function renderCliErrorMessage(
+  code: CliErrorCode,
+  messageParams: MessageParams,
+  io: CliIo | undefined,
+  lang: Lang,
+): Promise<string> {
+  if (io !== undefined) {
+    try {
+      const messages = await io.loadMessages(lang)
+      const template = messages[code]
+      if (template !== undefined)
+        return renderMessageTemplate(template, messageParams)
+    }
+    catch {
+      // Fall through to stable English fallback when catalog loading fails.
+    }
+  }
+
+  return renderMessageTemplate(cliErrorFallbackMessages[code], messageParams)
+}
+
+function describeUnknownError(err: unknown): { cause: string } {
+  return {
+    cause: err instanceof Error ? err.message : String(err),
   }
 }
 
@@ -425,7 +485,17 @@ if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.a
   runCli(process.argv.slice(2)).then((code) => {
     process.exitCode = code
   }).catch((err: unknown) => {
-    process.stderr.write(`${JSON.stringify(toCliErrorBody(err))}\n`)
+    toCliErrorBody(err).then((body) => {
+      process.stderr.write(`${JSON.stringify(body)}\n`)
+    }).catch((fallbackErr: unknown) => {
+      process.stderr.write(`${JSON.stringify({
+        ok: false,
+        error: {
+          code: "ERR-CLI-UNCAUGHT",
+          message: String(fallbackErr),
+        },
+      })}\n`)
+    })
     process.exitCode = 1
   })
 }


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #33 [TL-S4-follow]
- Reviewers: @Product, @QA
- Related decisions: Product Option A for ERR-CLI-* i18n (2026-05-05), D-02-rev
- i18n impact: consumes PR #15 `ERR-CLI-*` catalog keys in `docs/ux/i18n/messages.{zh,en}.json`; no new keys

## Summary

- Adds a stable English fallback table for `ERR-CLI-*` in `packages/cli/src/errors.ts`.
- Renders CLI shell error `message` through `messages.{zh,en}.json` based on `--lang`, while keeping JSON `error.code` stable and language-independent.
- Keeps fallback behavior when catalog keys or catalog loading fail.
- Preserves JSON `error.details`, including Zod schema issues and JSON parse causes.
- Updates CLI README to document localized CLI error messages.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test` (core 36 tests + cli 16 tests)
- `git diff --check origin/main...HEAD`
- Manual smoke: `ERR-CLI-JSON` in `--lang en`, `ERR-CLI-SCHEMA` in `--lang zh`, and `ERR-CLI-CMD` in `--lang en` all emit JSON stderr with localized `message` and stable `code`.

## Notes

- This PR intentionally does not localize Zod issue internals in `error.details`; those remain machine-readable validation evidence.
