### PR TITLE
feat(data): add S5 source ingestion skeleton

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,12 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 
 ## Current Phase
 
-S4 CLI shell and S5 data ingestion. Current engineering entry points:
+S5 data ingestion. Current engineering entry points:
 
 - `docs/architecture/naming-policy.md`
 - `docs/architecture/monorepo-development.md`
 - `docs/data-contract/`
+- `docs/data-source/`
 - `packages/core/src/engine/`
 - `packages/cli/`
+- `packages/data/`

--- a/docs/data-source/README.md
+++ b/docs/data-source/README.md
@@ -1,0 +1,55 @@
+# Data Source Ingestion
+
+Status: S5 segment 1 baseline
+Owner: @TechLead
+Inputs: CONFIRM-4, CONFIRM-11, task #31, TL-4 scraper preparation
+
+This directory records the source-ingestion boundary for `@fairy/data`.
+Segment 1 is intentionally a skeleton: it defines source descriptors, adapter
+interfaces, metadata rules, and crawler compliance notes before any formal game
+data is generated.
+
+## Segment 1 Scope
+
+- Define `@fairy/data` source descriptors for the lo-user Excel workbook,
+  Mihoyo ZZZ wiki Critical Assault page, and buhflipexplode Deadly Assault page.
+- Provide adapter interfaces for future Excel/crawler readers.
+- Validate `SourceDocument` and empty `GameData` metadata against
+  `@fairy/core`.
+- Record robots.txt / ToS observations and conservative fetch rules.
+
+## Out Of Scope For This PR
+
+- No Excel workbook is committed.
+- No formal `GameData` rows are hand-written.
+- No production crawler performs network fetching.
+- No cleaned agent, skill, W-Engine, Drive Disc, enemy, or rule data is
+  published.
+
+Formal V1 data must be generated from reviewed source documents and keep
+`sourceId`, `sourceVersion`, `parsedAt` / `fetchedAt`, `parserVersion`, and row
+anchors. Hand-written values may exist only in QA fixtures, not in
+`@fairy/data` published data.
+
+## Source Registry
+
+| Source ID | Kind | Current status | Formal data ready | Notes |
+|---|---|---:|---:|---|
+| `lo-user-excel` | `excel` | waiting for upload | no | Workbook path/version/hash to be recorded after lo-user provides the file. |
+| `mihoyo-zzz-critical-assault` | `mihoyoWiki` | discovery only | no | Public wiki page reachable; robots.txt not found on 2026-05-05. |
+| `buhflipexplode-zzz-da` | `thirdPartySite` | discovery only | no | Public page reachable; data asset endpoints identified; redistribution requires review. |
+
+Implementation entry: `packages/data/src/sources.ts`.
+
+## Next Segment
+
+Once the Excel file is available and Product/human review accepts the source
+usage policy, S5 segment 2 should add:
+
+- Excel reader with sheet/column discovery and workbook hash versioning.
+- Mihoyo and buhflipexplode fetchers with cached snapshots and conditional
+  request support.
+- Raw record schemas and transforms into `GameData`.
+- Golden-anchor source coverage for the 23 fixture cases.
+- Negative validation that formal modifiers and formal rows cannot miss source
+  metadata.

--- a/docs/data-source/robots-tos-check.md
+++ b/docs/data-source/robots-tos-check.md
@@ -1,0 +1,108 @@
+# Robots / ToS Check Log
+
+Status: S5 segment 1 evidence
+Owner: @TechLead
+Checked: 2026-05-05
+
+This is an engineering evidence log, not legal advice. Missing robots.txt or a
+public HTTP 200 response does not by itself grant redistribution rights. Formal
+data publication still needs Product/human review before V1 release.
+
+## Mihoyo ZZZ Wiki
+
+Target:
+`https://baike.mihoyo.com/zzz/wiki/channel/map/13/108`
+
+Commands:
+
+```bash
+curl -L -sS -o /tmp/fairy-mihoyo-robots.txt \
+  -w '%{http_code} %{content_type} %{url_effective}\n' \
+  https://baike.mihoyo.com/robots.txt
+
+curl -I -L -sS https://baike.mihoyo.com/zzz/wiki/channel/map/13/108
+```
+
+Observed on 2026-05-05:
+
+- `https://baike.mihoyo.com/robots.txt` returned HTTP 404 with body `Not Found`.
+- The target page returned HTTP 200.
+- Response headers included `cache-control: max-age=300`, `etag:
+  "0E83857DC32EB629AC2FE1208C88796E"`, and `last-modified: Fri, 19 Dec 2025
+  10:38:45 GMT`.
+- The page is Nuxt HTML for `绳网情报站-绝区零WIKI` and references Mihoyo static /
+  API hosts such as `webstatic.mihoyo.com`, `api-takumi.mihoyo.com`, and
+  `act-api-takumi.mihoyo.com`.
+
+Engineering policy for segment 2:
+
+- Fetch only public wiki responses needed for live-server data.
+- Do not use authenticated endpoints, private APIs, beta-only data, or bypass
+  mechanisms.
+- Cache fetched payloads and prefer conditional requests using ETag /
+  Last-Modified.
+- Default automated fetch rate: no more than 12 requests per minute, lower if a
+  target response indicates tighter cache or rate expectations.
+- Publish only cleaned structures allowed by CONFIRM-16.
+
+## buhflipexplode Deadly Assault
+
+Target:
+`https://www.buhflipexplode.org/zzz/da/`
+
+Commands:
+
+```bash
+curl -L -sS -o /tmp/fairy-buh-robots.html \
+  -w '%{http_code} %{content_type} %{url_effective}\n' \
+  https://www.buhflipexplode.org/robots.txt
+
+curl -I -L -sS https://www.buhflipexplode.org/zzz/da/
+
+curl -L -sS https://www.buhflipexplode.org/zzz/da/da.js | rg 'fetch|da-versions|enemies|buffs'
+```
+
+Observed on 2026-05-05:
+
+- `https://www.buhflipexplode.org/robots.txt` returned HTTP 404 with the site's
+  custom 404 HTML page.
+- The target page returned HTTP 200 from GitHub Pages.
+- Response headers included `cache-control: max-age=600`, `etag:
+  "69f8c67e-13c0"`, and `last-modified: Mon, 04 May 2026 16:17:02 GMT`.
+- `da.js` fetches:
+  - `https://www.buhflipexplode.org/zzz/da/da-versions.json`
+  - `https://www.buhflipexplode.org/assets/zzz/enemies.json`
+  - `https://www.buhflipexplode.org/assets/zzz/buffs.json`
+- The about page describes the site as fan-created, non-commercial, and not
+  affiliated with miHoYo.
+- The about page links the source repository:
+  `https://github.com/spiritfxxxx/buhflipexplode-src`.
+- The source repository has a `LICENSE` file with GPL-3.0 text, which covers
+  code reuse but does not by itself settle data/image redistribution rights.
+- The about page says most images/data are officially sourced from in-game and
+  public fandoms.
+- No explicit data redistribution license was found in this check.
+
+Engineering policy for segment 2:
+
+- Treat this as a third-party source that requires human/Product review before
+  redistributing cleaned values.
+- Cache each asset snapshot and record hashes separately.
+- Prefer one request per asset per manual run; automated mode must respect the
+  same 12 requests/minute ceiling and conditional-request policy.
+- Do not copy images or site presentation assets into `@fairy/data`.
+- Preserve source attribution and mark derived rows with `sourceId:
+  "buhflipexplode-zzz-da"`.
+
+## Excel Workbook
+
+Target: pending lo-user upload.
+
+Current policy:
+
+- Do not commit the workbook to public git until lo-user confirms the storage
+  path and redistribution constraints.
+- Use workbook hash as the source version if the workbook has no explicit
+  version field.
+- Keep raw workbook snapshots out of generated cleaned data artifacts unless a
+  release task explicitly approves publication.

--- a/docs/data-source/source-metadata-contract.md
+++ b/docs/data-source/source-metadata-contract.md
@@ -1,0 +1,95 @@
+# Source Metadata Contract
+
+Status: S5 segment 1 baseline
+Owner: @TechLead
+Related contracts: `docs/data-contract/game-data.md`
+
+`@fairy/data` publishes cleaned `GameData`, not raw source files. Every cleaned
+row must retain enough metadata to reconstruct where it came from and which
+parser/version produced it.
+
+## SourceDocument
+
+Each source snapshot is represented as a `SourceDocument`:
+
+```ts
+interface SourceDocument {
+  id: string
+  kind: "excel" | "mihoyoWiki" | "thirdPartySite" | "manualReview"
+  url?: string
+  fileName?: string
+  gameVersion?: string
+  sourceVersion: string
+  fetchedAt?: string
+  parsedAt: string
+  parserVersion: string
+  licenseNote?: string
+}
+```
+
+Rules:
+
+- `id` must match a registered source descriptor.
+- `sourceVersion` must be stable for the source snapshot. Prefer workbook hash,
+  HTTP ETag, HTTP Last-Modified, or payload hash.
+- `parsedAt` is required for every source. `fetchedAt` is required for network
+  sources once real fetchers exist.
+- `parserVersion` must change when parser logic changes in a way that can alter
+  cleaned output.
+- `licenseNote` records usage constraints; it is not a legal clearance.
+
+## SourceRef
+
+Every formal data row and formal modifier must point back to a `SourceRef`:
+
+```ts
+interface SourceRef {
+  sourceId: string
+  sourceAnchor?: string
+  sourceVersion?: string
+  dataPath?: string
+}
+```
+
+Rules:
+
+- `sourceId` must match a `SourceDocument.id`.
+- `sourceVersion` should be copied when a row can survive across multiple source
+  snapshots.
+- `sourceAnchor` should be the closest source-local row/cell/asset path, such as
+  `Agents!A42`, `da-versions.json#versionEnemies[0]`, or a wiki page slug.
+- `dataPath` should point to the cleaned destination path, such as
+  `agents.yixuan.skillIds[0]`.
+
+## Formal Data Boundary
+
+Formal data is any row that ships from `@fairy/data` as canonical game data:
+
+- agents
+- skills and skill segments
+- W-Engines
+- Drive Discs
+- enemies
+- Resonium
+- modifier templates
+- rule tables
+- aliases derived from source terms
+
+Formal data must not be typed by hand. A row can enter `@fairy/data` only after
+the parser has linked it to a source document and source anchor. Manual review
+may approve or reject source-derived rows, but `manualReview` is not a source for
+inventing values.
+
+QA fixtures under `fixtures/golden/` are separate. They may be hand-authored and
+reviewed because they are test assertions, not published game data.
+
+## Segment 1 Implementation
+
+`packages/data` currently exposes:
+
+- source descriptors with fetch/compliance policy;
+- helpers for building `SourceDocument` and `SourceRef`;
+- a discovery-only empty `GameData` generator that validates the metadata shape;
+- adapter interfaces for future Excel/crawler implementations.
+
+This package intentionally contains no formal rows until S5 segment 2.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,11 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)
 
-## S4 / S5 当前重点
+## S5 当前重点
 
-1. 落地 `@fairy/cli` JSON-only 命令壳，覆盖 `calc` / `compare` / `scan` / `explain` / `migrate`。
-2. CLI 通过 `@fairy/core` 固定格式入口输出三档伤害、逐乘区 trace 与中英 diagnostic。
-3. 推进 `@fairy/data` Excel reader 与爬虫接入，保留 source metadata 并清洗为 GameData schema。
+1. 推进 `@fairy/data` Excel reader 与爬虫接入，保留 source metadata 并清洗为 GameData schema。
+2. 先完成不阻塞 Excel 的 schema discovery、importer/crawler adapter skeleton、source metadata contract、robots/ToS 记录。
+3. 等 lo-user Excel 到位后接入实际 reader / cleaning，并补齐 golden 所需数据。
 4. 将 23 个 golden fixture schema-ready 锚点接入真实数据复算，作为 V1 发布 gate。
 
 ## 关键文档
@@ -24,3 +24,5 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - 命名策略：[architecture/naming-policy.md](architecture/naming-policy.md)
 - Monorepo 开发指南：[architecture/monorepo-development.md](architecture/monorepo-development.md)
 - Pending 术语表：[data-contract/pending-term-resolution-table.md](data-contract/pending-term-resolution-table.md)
+- Source metadata contract：[data-source/source-metadata-contract.md](data-source/source-metadata-contract.md)
+- Robots / ToS check：[data-source/robots-tos-check.md](data-source/robots-tos-check.md)

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -2,5 +2,15 @@
   "name": "@fairy/data",
   "version": "0.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@fairy/core": "workspace:*"
+  }
 }

--- a/packages/data/src/adapters.ts
+++ b/packages/data/src/adapters.ts
@@ -1,0 +1,65 @@
+import type { DataSourceDescriptor } from "./sources"
+
+export interface SourceFetchContext {
+  now: string
+  cacheDir?: string
+  userAgent?: string
+}
+
+export interface RawSourceFetchResult<TPayload = unknown> {
+  sourceId: string
+  sourceVersion: string
+  fetchedAt: string
+  payload: TPayload
+  url?: string
+  fileName?: string
+  contentType?: string
+}
+
+export interface ParsedSourceRecord {
+  id: string
+  sourceAnchor?: string
+  dataPath?: string
+  raw: unknown
+}
+
+export interface ParsedSourceBatch {
+  sourceId: string
+  sourceVersion: string
+  formalDataReady: boolean
+  records: readonly ParsedSourceRecord[]
+  notes: readonly string[]
+}
+
+export interface SourceAdapter<TPayload = unknown> {
+  sourceId: string
+  fetch(context: SourceFetchContext): Promise<RawSourceFetchResult<TPayload>>
+  parse(
+    raw: RawSourceFetchResult<TPayload>,
+    context: SourceFetchContext,
+  ): Promise<ParsedSourceBatch>
+}
+
+export function createDiscoveryOnlyAdapter(
+  descriptor: DataSourceDescriptor,
+): SourceAdapter<never> {
+  return {
+    sourceId: descriptor.id,
+    async fetch() {
+      throw new Error(
+        `Data source ${descriptor.id} is discovery-only; implement a real fetcher after source review.`,
+      )
+    },
+    async parse() {
+      return {
+        sourceId: descriptor.id,
+        sourceVersion: "discovery-only",
+        formalDataReady: false,
+        records: [],
+        notes: [
+          "No formal data was parsed because this adapter is a skeleton.",
+        ],
+      }
+    },
+  }
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./adapters"
+export * from "./ingest"
+export * from "./metadata"
+export * from "./sources"

--- a/packages/data/src/ingest.ts
+++ b/packages/data/src/ingest.ts
@@ -1,0 +1,63 @@
+import { parseGameData, type GameData, type SourceDocument } from "@fairy/core"
+
+export interface CreateEmptyGameDataOptions {
+  gameVersion: string
+  dataVersion: string
+  sourceVersion: string
+  generatedAt: string
+  sources: readonly SourceDocument[]
+  schemaVersion?: string
+}
+
+export function createEmptyGameData(
+  options: CreateEmptyGameDataOptions,
+): GameData {
+  return parseGameData({
+    schemaVersion: options.schemaVersion ?? "game-data-v1",
+    gameVersion: options.gameVersion,
+    dataVersion: options.dataVersion,
+    sourceVersion: options.sourceVersion,
+    generatedAt: options.generatedAt,
+    sources: [...options.sources],
+    agents: {},
+    skills: {},
+    wEngines: {},
+    driveDiscs: {},
+    enemies: {},
+    resonium: {},
+    modifiers: {},
+    rules: {},
+    aliases: {
+      fields: {},
+      enumValues: {},
+      sourceTerms: {},
+    },
+  })
+}
+
+export function assertDiscoveryOnlyGameData(gameData: GameData): void {
+  const formalRecordCounts = {
+    agents: Object.keys(gameData.agents).length,
+    skills: Object.keys(gameData.skills).length,
+    wEngines: Object.keys(gameData.wEngines).length,
+    driveDiscs: Object.keys(gameData.driveDiscs).length,
+    enemies: Object.keys(gameData.enemies).length,
+    resonium: Object.keys(gameData.resonium).length,
+    modifiers: Object.keys(gameData.modifiers).length,
+    rules: Object.keys(gameData.rules).length,
+    "aliases.fields": Object.keys(gameData.aliases.fields).length,
+    "aliases.enumValues": Object.keys(gameData.aliases.enumValues).length,
+    "aliases.sourceTerms": Object.keys(gameData.aliases.sourceTerms).length,
+  }
+
+  const populated = Object.entries(formalRecordCounts).filter(
+    ([, count]) => count > 0,
+  )
+
+  if (populated.length > 0) {
+    const details = populated
+      .map(([name, count]) => `${name}=${count}`)
+      .join(", ")
+    throw new Error(`Discovery-only GameData must not contain formal data: ${details}`)
+  }
+}

--- a/packages/data/src/metadata.ts
+++ b/packages/data/src/metadata.ts
@@ -1,0 +1,71 @@
+import {
+  sourceDocumentSchema,
+  sourceRefSchema,
+  type SourceDocument,
+  type SourceRef,
+} from "@fairy/core"
+import type { DataSourceDescriptor } from "./sources"
+
+export const DATA_SOURCE_SKELETON_PARSER_VERSION =
+  "@fairy/data-source-skeleton-v0.1.0"
+
+export interface BuildSourceDocumentOptions {
+  sourceVersion: string
+  parsedAt: string
+  fetchedAt?: string
+  parserVersion?: string
+  gameVersion?: string
+  fileName?: string
+  licenseNote?: string
+}
+
+export interface BuildSourceRefOptions {
+  sourceVersion?: string
+  sourceAnchor?: string
+  dataPath?: string
+}
+
+export function buildSourceDocument(
+  descriptor: DataSourceDescriptor,
+  options: BuildSourceDocumentOptions,
+): SourceDocument {
+  const candidate: Record<string, unknown> = {
+    id: descriptor.id,
+    kind: descriptor.kind,
+    sourceVersion: options.sourceVersion,
+    parsedAt: options.parsedAt,
+    parserVersion:
+      options.parserVersion ?? DATA_SOURCE_SKELETON_PARSER_VERSION,
+  }
+
+  if (descriptor.url !== undefined)
+    candidate.url = descriptor.url
+  if (options.fileName !== undefined)
+    candidate.fileName = options.fileName
+  if (options.gameVersion !== undefined)
+    candidate.gameVersion = options.gameVersion
+  if (options.fetchedAt !== undefined)
+    candidate.fetchedAt = options.fetchedAt
+  if (options.licenseNote !== undefined)
+    candidate.licenseNote = options.licenseNote
+
+  return sourceDocumentSchema.parse(candidate)
+}
+
+export function buildSourceRef(
+  descriptor: Pick<DataSourceDescriptor, "id">,
+  options: BuildSourceRefOptions = {},
+): SourceRef {
+  const candidate: Record<string, unknown> = {
+    sourceId: descriptor.id,
+  }
+
+  if (options.sourceVersion !== undefined)
+    candidate.sourceVersion = options.sourceVersion
+  if (options.sourceAnchor !== undefined)
+    candidate.sourceAnchor = options.sourceAnchor
+  if (options.dataPath !== undefined)
+    candidate.dataPath = options.dataPath
+
+  return sourceRefSchema.parse(candidate)
+}

--- a/packages/data/src/sources.test.ts
+++ b/packages/data/src/sources.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+import {
+  assertDiscoveryOnlyGameData,
+  buildSourceDocument,
+  buildSourceRef,
+  createEmptyGameData,
+  dataSourceDescriptors,
+  getDataSourceDescriptor,
+} from "./index"
+
+const parsedAt = "2026-05-05T03:30:00.000Z"
+
+function createDiscoveryGameData() {
+  const sources = dataSourceDescriptors.map((descriptor, index) => {
+    const options = {
+      sourceVersion: `discovery-${index}`,
+      parsedAt,
+    }
+
+    if (descriptor.kind !== "excel")
+      return buildSourceDocument(descriptor, options)
+
+    return buildSourceDocument(descriptor, {
+      ...options,
+      fileName: "pending-lo-user-upload.xlsx",
+    })
+  })
+
+  return createEmptyGameData({
+    gameVersion: "ZZZ-live",
+    dataVersion: "data-discovery-v0.1.0",
+    sourceVersion: "source-discovery-v0.1.0",
+    generatedAt: parsedAt,
+    sources,
+  })
+}
+
+describe("@fairy/data source discovery skeleton", () => {
+  it("keeps source descriptor ids unique", () => {
+    const ids = dataSourceDescriptors.map(source => source.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("marks every current source as not formal-data ready", () => {
+    expect(dataSourceDescriptors).not.toHaveLength(0)
+    expect(dataSourceDescriptors.every(source => !source.formalDataReady)).toBe(true)
+  })
+
+  it("builds SourceDocument metadata that validates against @fairy/core", () => {
+    const descriptor = getDataSourceDescriptor("mihoyo-zzz-critical-assault")
+    const sourceDocument = buildSourceDocument(descriptor, {
+      sourceVersion: "etag:0E83857DC32EB629AC2FE1208C88796E",
+      fetchedAt: "2026-05-05T03:03:12.000Z",
+      parsedAt,
+      gameVersion: "ZZZ-live",
+      licenseNote: "cleaned data only; source review required before redistribution",
+    })
+
+    expect(sourceDocument).toMatchObject({
+      id: "mihoyo-zzz-critical-assault",
+      kind: "mihoyoWiki",
+      url: "https://baike.mihoyo.com/zzz/wiki/channel/map/13/108",
+      parserVersion: "@fairy/data-source-skeleton-v0.1.0",
+    })
+  })
+
+  it("builds SourceRef anchors for future cleaned rows", () => {
+    const sourceRef = buildSourceRef(
+      getDataSourceDescriptor("buhflipexplode-zzz-da"),
+      {
+        sourceVersion: "etag:69f8c67e-13c0",
+        sourceAnchor: "da-versions.json#versionEnemies[0]",
+        dataPath: "enemies.deadlyAssault[0]",
+      },
+    )
+
+    expect(sourceRef).toEqual({
+      sourceId: "buhflipexplode-zzz-da",
+      sourceVersion: "etag:69f8c67e-13c0",
+      sourceAnchor: "da-versions.json#versionEnemies[0]",
+      dataPath: "enemies.deadlyAssault[0]",
+    })
+  })
+
+  it("creates schema-valid discovery-only GameData without formal rows", () => {
+    const gameData = createDiscoveryGameData()
+
+    expect(gameData.sources).toHaveLength(dataSourceDescriptors.length)
+    expect(() => assertDiscoveryOnlyGameData(gameData)).not.toThrow()
+  })
+
+  it.each([
+    [
+      "formal row",
+      (gameData: ReturnType<typeof createDiscoveryGameData>) => {
+        gameData.agents.handWrittenAgent = {} as (typeof gameData.agents)[string]
+      },
+      "agents=1",
+    ],
+    [
+      "rule table",
+      (gameData: ReturnType<typeof createDiscoveryGameData>) => {
+        gameData.rules.manualRule = { multiplier: 1.2 }
+      },
+      "rules=1",
+    ],
+    [
+      "field alias",
+      (gameData: ReturnType<typeof createDiscoveryGameData>) => {
+        gameData.aliases.fields.hpMax = "maxHp"
+      },
+      "aliases.fields=1",
+    ],
+    [
+      "enum alias",
+      (gameData: ReturnType<typeof createDiscoveryGameData>) => {
+        gameData.aliases.enumValues.physicalAnomaly = "assault"
+      },
+      "aliases.enumValues=1",
+    ],
+    [
+      "source term alias",
+      (gameData: ReturnType<typeof createDiscoveryGameData>) => {
+        gameData.aliases.sourceTerms["暴击率"] = "critRate"
+      },
+      "aliases.sourceTerms=1",
+    ],
+  ])("rejects discovery-only GameData with a %s", (_, mutate, detail) => {
+    const gameData = createDiscoveryGameData()
+
+    mutate(gameData)
+
+    expect(() => assertDiscoveryOnlyGameData(gameData)).toThrow(detail)
+  })
+
+  it("documents buhflipexplode public data asset endpoints for the next adapter", () => {
+    const descriptor = getDataSourceDescriptor("buhflipexplode-zzz-da")
+
+    expect(descriptor.discoveredAssets).toEqual(
+      expect.arrayContaining([
+        "https://www.buhflipexplode.org/zzz/da/da-versions.json",
+        "https://www.buhflipexplode.org/assets/zzz/enemies.json",
+        "https://www.buhflipexplode.org/assets/zzz/buffs.json",
+      ]),
+    )
+  })
+})

--- a/packages/data/src/sources.ts
+++ b/packages/data/src/sources.ts
@@ -1,0 +1,160 @@
+import type { SourceDocument } from "@fairy/core"
+
+export type DataSourceKind = Extract<
+  SourceDocument["kind"],
+  "excel" | "mihoyoWiki" | "thirdPartySite"
+>
+
+export type DataSourceStatus =
+  | "awaitingFile"
+  | "discoveryOnly"
+  | "readyForAdapter"
+  | "requiresReview"
+
+export interface FetchPolicy {
+  mode: "manualUpload" | "httpGet"
+  maxRequestsPerMinute: number
+  cacheRequired: boolean
+  conditionalRequestsPreferred: boolean
+  requiresUserAgent: boolean
+}
+
+export interface SourceComplianceNote {
+  robotsTxt: "notApplicable" | "notFound" | "found" | "notChecked"
+  termsStatus: "notApplicable" | "notFound" | "found" | "requiresHumanReview"
+  redistribution: "privateUntilReviewed" | "cleanedDataOnly" | "requiresHumanReview"
+  notes: readonly string[]
+}
+
+export interface DataSourceDescriptor {
+  id: string
+  kind: DataSourceKind
+  label: string
+  url?: string
+  fileNameHint?: string
+  status: DataSourceStatus
+  formalDataReady: boolean
+  parserTargets: readonly string[]
+  sourceVersionStrategy: string
+  discoveredAssets?: readonly string[]
+  fetchPolicy: FetchPolicy
+  compliance: SourceComplianceNote
+}
+
+export const dataSourceDescriptors = [
+  {
+    id: "lo-user-excel",
+    kind: "excel",
+    label: "lo-user provided ZZZ data workbook",
+    fileNameHint: "pending-lo-user-upload.xlsx",
+    status: "awaitingFile",
+    formalDataReady: false,
+    parserTargets: [
+      "agent skill multipliers",
+      "daze multipliers",
+      "W-Engine passives",
+      "Drive Disc set effects",
+      "agent enhancement / potential activation fields",
+    ],
+    sourceVersionStrategy:
+      "Use the workbook file hash plus any workbook-provided game version once the file is uploaded.",
+    fetchPolicy: {
+      mode: "manualUpload",
+      maxRequestsPerMinute: 0,
+      cacheRequired: true,
+      conditionalRequestsPreferred: false,
+      requiresUserAgent: false,
+    },
+    compliance: {
+      robotsTxt: "notApplicable",
+      termsStatus: "requiresHumanReview",
+      redistribution: "privateUntilReviewed",
+      notes: [
+        "No Excel file is present in this PR.",
+        "Formal data rows must not be typed by hand while the source workbook is pending.",
+        "Keep the workbook outside public git unless lo-user confirms redistribution is allowed.",
+      ],
+    },
+  },
+  {
+    id: "mihoyo-zzz-critical-assault",
+    kind: "mihoyoWiki",
+    label: "Mihoyo ZZZ wiki Critical Assault map",
+    url: "https://baike.mihoyo.com/zzz/wiki/channel/map/13/108",
+    status: "discoveryOnly",
+    formalDataReady: false,
+    parserTargets: [
+      "critical assault stage list",
+      "enemy identifiers",
+      "official wiki source anchors",
+    ],
+    sourceVersionStrategy:
+      "Use HTTP ETag/Last-Modified when present, otherwise hash the fetched HTML/API payload.",
+    fetchPolicy: {
+      mode: "httpGet",
+      maxRequestsPerMinute: 12,
+      cacheRequired: true,
+      conditionalRequestsPreferred: true,
+      requiresUserAgent: true,
+    },
+    compliance: {
+      robotsTxt: "notFound",
+      termsStatus: "requiresHumanReview",
+      redistribution: "cleanedDataOnly",
+      notes: [
+        "robots.txt returned HTTP 404 on 2026-05-05.",
+        "The target page returned HTTP 200 with cache-control max-age=300.",
+        "Do not crawl authenticated or private APIs; use public wiki responses only.",
+      ],
+    },
+  },
+  {
+    id: "buhflipexplode-zzz-da",
+    kind: "thirdPartySite",
+    label: "buhflipexplode Deadly Assault data",
+    url: "https://www.buhflipexplode.org/zzz/da/",
+    status: "discoveryOnly",
+    formalDataReady: false,
+    parserTargets: [
+      "deadly assault version entries",
+      "enemy HP/daze/anomaly multipliers",
+      "boss buff metadata",
+    ],
+    sourceVersionStrategy:
+      "Use the page ETag/Last-Modified plus hashes for da-versions.json, enemies.json, and buffs.json.",
+    discoveredAssets: [
+      "https://www.buhflipexplode.org/zzz/da/da-versions.json",
+      "https://www.buhflipexplode.org/assets/zzz/enemies.json",
+      "https://www.buhflipexplode.org/assets/zzz/buffs.json",
+    ],
+    fetchPolicy: {
+      mode: "httpGet",
+      maxRequestsPerMinute: 12,
+      cacheRequired: true,
+      conditionalRequestsPreferred: true,
+      requiresUserAgent: true,
+    },
+    compliance: {
+      robotsTxt: "notFound",
+      termsStatus: "requiresHumanReview",
+      redistribution: "requiresHumanReview",
+      notes: [
+        "robots.txt returned HTTP 404 on 2026-05-05.",
+        "The site describes itself as fan-created and non-commercial.",
+        "The about page links source code at https://github.com/spiritfxxxx/buhflipexplode-src.",
+        "The source repository has a GPL-3.0 LICENSE for code, but data redistribution still needs review.",
+        "The about page says most images/data are officially sourced from in-game and public fandoms.",
+      ],
+    },
+  },
+] as const satisfies readonly DataSourceDescriptor[]
+
+export type DataSourceId = (typeof dataSourceDescriptors)[number]["id"]
+
+export function getDataSourceDescriptor(id: string): DataSourceDescriptor {
+  const descriptor = dataSourceDescriptors.find(source => source.id === id)
+  if (descriptor === undefined)
+    throw new Error(`Unknown data source descriptor: ${id}`)
+
+  return descriptor
+}

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,11 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
-  packages/data: {}
+  packages/data:
+    dependencies:
+      '@fairy/core':
+        specifier: workspace:*
+        version: link:../core
 
 packages:
 


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #31
- Reviewers: @Product, @QA
- Related decisions: CONFIRM-4 / CONFIRM-11 / CONFIRM-16 / D-11
- i18n impact: no

## Summary

- Adds the first `@fairy/data` runtime slice: source descriptors, `SourceDocument` / `SourceRef` helpers, discovery-only `GameData` validation, and future source adapter interfaces.
- Documents S5 segment 1 source boundaries in `docs/data-source/`, including metadata rules and robots / ToS observations for the Mihoyo ZZZ wiki and buhflipexplode Deadly Assault page.
- Updates agent/docs entry points from S4/S5 to S5-focused status.

## Scope Boundary

This PR intentionally does **not** add formal game data. No Excel file, cleaned agent/skill/enemy rows, or production crawler fetcher is committed. Formal data remains blocked on lo-user's Excel and source usage review.

## Source Discovery Evidence

- Mihoyo robots: `https://baike.mihoyo.com/robots.txt` returned HTTP 404 on 2026-05-05; target page returned HTTP 200 with ETag / Last-Modified headers.
- buhflipexplode robots: `https://www.buhflipexplode.org/robots.txt` returned HTTP 404 on 2026-05-05; target page returned HTTP 200 from GitHub Pages.
- buhflipexplode `da.js` fetches `da-versions.json`, `assets/zzz/enemies.json`, and `assets/zzz/buffs.json`; source repo has GPL-3.0 code license, but data/image redistribution remains review-required.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test` (core 36 + cli 16 + data 6)
- `git diff --check`
- `curl` robots/header checks recorded in `docs/data-source/robots-tos-check.md`
