### PR TITLE
docs(ux): ERR-DAT-005 / ERR-DAT-006 catalog (UX-S5-2-err-catalog, #52)

### DIFF
--- a/docs/ux/i18n/README.md
+++ b/docs/ux/i18n/README.md
@@ -1,8 +1,8 @@
 # UX i18n 资源说明
 
 Owner: @UX
-Status: v0.1（伴随 UX-S4-1 落地：Product 决策选 A，CLI ERR-CLI-* 全套双语化）
-Inputs: D-02-rev / D-11 / Product CLI ERR-CLI-* 决策（A，2026-05-05）
+Status: v0.2（UX-S5-2 落地：cleaned data pipeline diagnostics ERR-DAT-005 / ERR-DAT-006，D-16 锁定 2026-05-05）
+Inputs: D-02-rev / D-11 / Product CLI ERR-CLI-* 决策（A，2026-05-05）/ D-13 / D-14 / D-16 / cleaned-schema-spec.md §6.5 + §7
 
 ## 资源文件
 
@@ -13,23 +13,25 @@ Inputs: D-02-rev / D-11 / Product CLI ERR-CLI-* 决策（A，2026-05-05）
 
 ## i18n 范围（V1）
 
-V1 双语覆盖 **core engine 业务侧 diagnostic** + **CLI shell / argument validation 错误**（Product 决策 A，2026-05-05），共 **33 条**。
+V1 双语覆盖 **core engine 业务侧 diagnostic** + **CLI shell / argument validation 错误**（Product 决策 A，2026-05-05）+ **cleaned data pipeline diagnostics**（D-16 锁定 UX-S5-2），共 **35 条**。
 
 ### 双语条目分组
 
 | 系列 | 数量 | 含义 | 引入版本 |
 |---|---|---|---|
 | `ERR-RNG-*` | 9 | 乘区数值越界 | v0.3 |
-| `ERR-DAT-*` | 4 | 内置 / data 包数据缺失 | v0.3 |
+| `ERR-DAT-001~004` | 4 | 内置 / data 包数据缺失 | v0.3 |
 | `ERR-SRC-001` | 1 | 无来源 modifier（user / temporary contributor） | v0.3 / v0.4 重写 |
 | `ERR-VER-*` | 4 | 版本不匹配双路径（重算 / 只读 / 二次确认）含 4 个 `original*` | v0.3 / v0.4 |
 | `ERR-EVENT-*` | 4 | 真实伤害手动事件（partBreak / corruptedShieldCleanse 等） | v0.4 |
 | `ERR-UI-*` | 3 | 空结果 / 加载 / unsupported feature | v0.3 / v0.4 |
 | `ERR-OCR-000` | 1 | 不识别截图 | v0.3 |
 | `ERR-CALC-PENDING-*` | 2 | anomaly / disorder PR #10 阶段 schema 骨架占位（TL-S3-4 实装后实际不再 emit，但保留资源） | UX-S3-1 |
-| **`ERR-CLI-*`** | **5** | **CLI argument / schema 错误**（A 决策双语化） | **UX-S4-1** |
+| `ERR-CLI-*` | 5 | CLI argument / schema 错误（A 决策双语化） | UX-S4-1 |
+| **`ERR-DAT-005`** | **1** | **cleaned data 阻断发布的未解析效果（多源冲突 / 未知 bucket / 未知 handler / 模糊条件 / 模糊目标 / 未知文本模式）— blocking** | **UX-S5-2** |
+| **`ERR-DAT-006`** | **1** | **cleaned data 本地化映射未解析（米游社 / Excel / buhflipexplode 之间 zh/en 对应缺失）— non-blocking warning** | **UX-S5-2** |
 
-合计 33 条。
+合计 35 条。
 
 ### Placeholder 约定（v0.4 + UX-S4-1）
 
@@ -42,13 +44,26 @@ V1 双语覆盖 **core engine 业务侧 diagnostic** + **CLI shell / argument va
 | `ERR-EVENT-003` | `{eventId}` / `{partId}` / `{enemyId}` |
 | `ERR-VER-001~004` | `{originalRuleSetVersion}` / `{originalDataVersion}` / `{originalSourceVersion}` / `{originalGameVersion}` / `{currentRuleSetVersion}` |
 | `ERR-SRC-001` | `{path}` |
-| **`ERR-CLI-ARG`** | **`{message}`** |
-| **`ERR-CLI-CMD`** | **`{command}`** |
-| **`ERR-CLI-JSON`** | **`{input}`** |
-| **`ERR-CLI-SCHEMA`** | （无 placeholder；schema 详情保持在 JSON `error.details` 字段） |
-| **`ERR-CLI-UNCAUGHT`** | **`{message}`** |
+| `ERR-CLI-ARG` | `{message}` |
+| `ERR-CLI-CMD` | `{command}` |
+| `ERR-CLI-JSON` | `{input}` |
+| `ERR-CLI-SCHEMA` | （无 placeholder；schema 详情保持在 JSON `error.details` 字段） |
+| `ERR-CLI-UNCAUGHT` | `{message}` |
+| **`ERR-DAT-005`** | **`{reason}` / `{effectId}` / `{sourceText}`** |
+| **`ERR-DAT-006`** | **`{language}` / `{path}`** |
 
-ERR-CLI-* placeholder 由 TL（task #33 [TL-S4-follow]）锁定，本文件以此为权威；后续若新增 ERR-CLI-* 系列条目，TL/UX 协作锁 placeholder 后再增。
+ERR-CLI-* placeholder 由 TL（task #33 [TL-S4-follow]）锁定。ERR-DAT-005 / ERR-DAT-006 placeholder 由 UX 基于 cleaned-schema-spec.md §6.5 `UnparsedEffect.reason` enum + §7 diagnostic open items 锁定（task #52 [UX-S5-2-err-catalog]，2026-05-05）。
+
+**ERR-DAT-005 `{reason}` 取值**（与 cleaned-schema-spec.md §6.5 `UnparsedEffect.reason` 严格一致）：
+- `unknownTextPattern` — 文本模式未注册
+- `unknownBucket` — bucket 不在 D-11 enum 中
+- `unknownHandler` — handler 未注册到 registry
+- `ambiguousCondition` — Condition DSL 条件歧义
+- `ambiguousTarget` — `appliesTo` 目标歧义
+- `sourceConflict` — 多源同字段冲突
+（`localeMappingUnresolved` 单独走 ERR-DAT-006，不进 ERR-DAT-005）
+
+**ERR-DAT-006 `{language}` 取值**：`zh` / `en`
 
 ## 文件维护规则
 
@@ -68,4 +83,5 @@ ERR-CLI-* placeholder 由 TL（task #33 [TL-S4-follow]）锁定，本文件以�
 ## 决策与历史
 
 - 2026-05-05：Product 初始决策 B（CLI 错误英文 only），后基于"P1 玩家高频场景（snapshot.json schema 错）"反馈撤回，最终决策 A（CLI 错误也双语化）
-- v0.4 / UX-S3-1 / UX-S4-1 累积，资源在 main 分支按 PR 流入
+- 2026-05-05：D-13 / D-14 / D-16 锁定 cleaned data pipeline；UX-S5-2 加 ERR-DAT-005（blocking unparsed / multi-source conflict）+ ERR-DAT-006（locale mapping unresolved）；reason enum 严格对齐 cleaned-schema-spec.md §6.5
+- v0.4 / UX-S3-1 / UX-S4-1 / UX-S5-2 累积，资源在 main 分支按 PR 流入

--- a/docs/ux/i18n/messages.en.json
+++ b/docs/ux/i18n/messages.en.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 33,
-    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series; UX-S3-1 extends ERR-CALC-PENDING-* series; UX-S4-1 extends ERR-CLI-* series (CLI argument / schema errors; Product decided Option A bilingual 2026-05-05)"
+    "totalEntries": 35,
+    "scope": "P0 required — runtime error messages for damage calculator; v0.4 extends ERR-VER-* / ERR-EVENT-* series; UX-S3-1 extends ERR-CALC-PENDING-* series; UX-S4-1 extends ERR-CLI-* series (CLI argument / schema errors; Product decided Option A bilingual 2026-05-05); UX-S5-2 extends ERR-DAT-005 / ERR-DAT-006 (cleaned data pipeline diagnostics — D-16 locked)"
   },
   "ERR-RNG-001": "Damage Bonus Zone exceeds the cap of 600% (Strategy PART 01.2). Truncated for display; raw accumulated value: {raw}%.",
   "ERR-RNG-002": "CRIT Rate must be within 0–100% (Strategy PART 01.3). Auto-clamped to {clamped}%.",
@@ -40,5 +40,7 @@
   "ERR-CLI-CMD": "Unknown subcommand: {command}. Available: calc / compare / scan / explain / migrate / help.",
   "ERR-CLI-JSON": "Failed to parse input JSON: {input}. Check the file format or run `fairy explain` for an example.",
   "ERR-CLI-SCHEMA": "Input does not match BattleSnapshot schema. See JSON `error.details` for specifics; refer to docs/data-contract/battle-snapshot.md.",
-  "ERR-CLI-UNCAUGHT": "Uncaught error: {message}. Please file an issue with the input and command."
+  "ERR-CLI-UNCAUGHT": "Uncaught error: {message}. Please file an issue with the input and command.",
+  "ERR-DAT-005": "⚠ Blocking unparsed effect detected in cleaned data (reason: {reason}, effectId: {effectId}). Source text: \"{sourceText}\". This effect affects calculation / matching / source traceability and must be resolved by manual audit + handler/template registration or data update before release. See docs/data-contract/cleaned-schema-spec.md §6.5.",
+  "ERR-DAT-006": "⚠ Locale mapping unresolved for {language} (path: {path}). The data package could not establish a stable zh/en mapping across sources (Mihoyo / Excel / buhflipexplode); display falls back to source text. Please add the mapping in the next data audit cycle."
 }

--- a/docs/ux/i18n/messages.zh.json
+++ b/docs/ux/i18n/messages.zh.json
@@ -5,8 +5,8 @@
     "ruleSetVersion": "rules-v0.1-attached-2026-05-04",
     "schemaVersion": "v1",
     "generatedBy": "@UX",
-    "totalEntries": 33,
-    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列；UX-S3-1 扩展 ERR-CALC-PENDING-* 系列；UX-S4-1 扩展 ERR-CLI-* 系列（CLI 参数 / schema 错误，Product 决策选 A 双语化 2026-05-05）"
+    "totalEntries": 35,
+    "scope": "P0 必填 — 伤害计算器实际触发的错误文案；v0.4 扩展 ERR-VER-* / ERR-EVENT-* 系列；UX-S3-1 扩展 ERR-CALC-PENDING-* 系列；UX-S4-1 扩展 ERR-CLI-* 系列（CLI 参数 / schema 错误，Product 决策选 A 双语化 2026-05-05）；UX-S5-2 扩展 ERR-DAT-005 / ERR-DAT-006（cleaned data pipeline 诊断 — D-16 锁定）"
   },
   "ERR-RNG-001": "增伤区已超过攻略上限 600%（PART 01.2）。已截断展示，原始累加值为 {raw}%。",
   "ERR-RNG-002": "暴击率有效范围 0~100%（攻略 PART 01.3）。已自动 clamp 为 {clamped}%。",
@@ -40,5 +40,7 @@
   "ERR-CLI-CMD": "未知子命令：{command}。可用命令：calc / compare / scan / explain / migrate / help。",
   "ERR-CLI-JSON": "输入 JSON 解析失败：{input}。请检查文件格式或使用 `fairy explain` 查看示例。",
   "ERR-CLI-SCHEMA": "输入不符合 BattleSnapshot schema。详情见 JSON `error.details` 字段；请参考 docs/data-contract/battle-snapshot.md。",
-  "ERR-CLI-UNCAUGHT": "未捕获错误：{message}。请提交 issue 附上输入与命令。"
+  "ERR-CLI-UNCAUGHT": "未捕获错误：{message}。请提交 issue 附上输入与命令。",
+  "ERR-DAT-005": "⚠ cleaned data 检测到阻断发布的未解析效果（reason: {reason}，effectId: {effectId}）。原文片段：「{sourceText}」。该效果影响计算 / 匹配 / 来源追溯，需人工 audit 后注册 handler / template 或更新 data 包再发布。详见 docs/data-contract/cleaned-schema-spec.md §6.5。",
+  "ERR-DAT-006": "⚠ {language} 本地化映射未解析（path: {path}）。data 包未能在源之间（米游社 / Excel / buhflipexplode）建立稳定 zh/en 对应；展示侧已 fallback 到 sourceText 原文层。请在下次 data audit 阶段补 mapping。"
 }


### PR DESCRIPTION
## Summary

UX-S5-2-err-catalog (task #52). Closes the ERR catalog open item flagged in PR #20 D-16 and PR #21 cleaned-schema-spec.md §7. Aligns the UX runtime error catalog with the cleaned data pipeline diagnostics locked at the 2026-05-05 cleaned schema discussion.

### New entries (totalEntries 33 → 35)

| Key | Severity | Trigger | Placeholders |
|---|---|---|---|
| `ERR-DAT-005` | blocking | `UnparsedEffect.reason ∈ {sourceConflict, unknownTextPattern, unknownBucket, unknownHandler, ambiguousCondition, ambiguousTarget}` (cleaned-schema-spec.md §6.5) — blocks cleaned release | `{reason}` / `{effectId}` / `{sourceText}` |
| `ERR-DAT-006` | non-blocking warning | locale mapping unresolved across sources (Mihoyo / Excel / buhflipexplode); display falls back to source text | `{language}` / `{path}` |

### Why two keys, not one-per-reason

Splitting per-reason would inflate the catalog and force renderers to maintain 7+ near-duplicate templates. Keeping `{reason}` as a placeholder gives the same diagnostic information with stable display structure — render layer can localize the reason value separately if/when needed (V1 ships with raw enum values, which are already specified in `cleaned-schema-spec.md` §6.5).

`localeMappingUnresolved` is split out because it is non-blocking + has a different placeholder set (`{path}` is a JSON pointer or label key, not an effect ID), and Product called it out as the canonical example of "纯展示缺失" warning in D-16.

### Files

- `docs/ux/i18n/messages.zh.json` (+2 entries, totalEntries 33→35, scope description updated)
- `docs/ux/i18n/messages.en.json` (+2 entries, totalEntries 33→35, scope description updated)
- `docs/ux/i18n/README.md` (v0.1→v0.2; series table + placeholder table + decisions/history updated)

## Slock Context
- Owner: @UX
- Task: #52 (UX-S5-2-err-catalog)
- Reviewers: @lo-user, @Product, @TechLead, @QA
- Related decisions: D-13, D-14, D-16; cleaned-schema-spec.md §6.5 + §7
- i18n impact: yes — UX runtime error catalog only (data game labels remain at `packages/data/src/i18n/`, untouched per D-15 boundary)
- Follow-up dependency: TL implementations of #40 / #42 / #43 will emit these diagnostics once cleaned data parser pipeline is wired.

## Verification
- `jq empty messages.{zh,en}.json` — passed (valid JSON)
- `diff <(jq -r 'keys[]' messages.zh.json | sort) <(jq -r 'keys[]' messages.en.json | sort)` — empty (key sets match)
- Placeholder set per new key — identical across zh/en
- `pnpm check` — passed (core / cli / data tsc --noEmit)
- `pnpm test` — passed (core 36 + cli 16 + data 19)
- `git diff --check` — clean
- Manual review: README placeholder table + decisions/history + series table consistent with D-16 framing

## Out of scope
- Wiring the keys into runtime emit paths (data parser pipeline). That belongs to TL implementation tasks #40 / #42 / #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)