### PR TITLE
feat(data): clear golden harness pending anchors

### DIFF
--- a/data/cleaned/golden/v1-replay-report.json
+++ b/data/cleaned/golden/v1-replay-report.json
@@ -36,8 +36,8 @@
   ],
   "summary": {
     "v1AnchorCount": 19,
-    "passed": 14,
-    "pendingHarness": 3,
+    "passed": 17,
+    "pendingHarness": 0,
     "blocked": 2,
     "deferred": 4,
     "blockingDiagnostics": 3,
@@ -98,10 +98,16 @@
     },
     {
       "id": "G04",
-      "status": "pendingHarness",
-      "sourceRefs": [],
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123"
+        }
+      ],
       "notes": [
-        "Source coverage is not blocked, but the executable bucket-scan assertion still needs a CLI/core replay representation."
+        "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
       ]
     },
     {
@@ -172,7 +178,7 @@
     },
     {
       "id": "G09",
-      "status": "pendingHarness",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "buhflipexplode-zzz-da",
@@ -186,12 +192,12 @@
         }
       ],
       "notes": [
-        "buhflipexplode DA source exposes baseDaze/versionDazeMult; executable daze ratio display-floor assertion still needs a replay representation."
+        "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
       ]
     },
     {
       "id": "G10",
-      "status": "pendingHarness",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "lo-user-excel",
@@ -200,8 +206,7 @@
         }
       ],
       "notes": [
-        "Resistance mapping is asserted: frost uses enemy.resistance.ice and auricInk uses enemy.resistance.ether.",
-        "Anomaly-buildup-resistance mapping is still pending because current core replay does not consume enemy.anomalyBuildupResistance."
+        "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
       ]
     },
     {

--- a/docs/data-contract/calc-result.md
+++ b/docs/data-contract/calc-result.md
@@ -84,6 +84,8 @@ interface SegmentResult {
   critDamage?: number
   nonCritDamage?: number
   dazeValue?: number
+  dazeRatioRaw?: number
+  dazeRatioDisplay?: number
   anomalyBuildup?: number
   traceRefs: string[]
 }

--- a/docs/data-contract/cleaned-schema-spec.md
+++ b/docs/data-contract/cleaned-schema-spec.md
@@ -580,10 +580,10 @@ The first replay harness baseline writes:
 
 `verify:golden-v1` verifies those artifacts against retained Excel and DA source
 snapshots. The baseline intentionally keeps G22/G23 blocked by `ERR-DAT-005`
-until manual acceptance records exist, and keeps G04/G09/G10 as
-`pendingHarness` until their executable replay assertions are complete. G10
-already asserts frost/auric resistance lanes, but anomaly-buildup-resistance
-mapping is not yet consumed by the core replay harness.
+until manual acceptance records exist. G04/G09/G10 now have executable replay
+assertions: G04 reproduces the guide breakpoint scan, G09 asserts sourced DA
+daze ratio display flooring, and G10 asserts frost/auric resistance plus
+anomaly-buildup-resistance lane mapping.
 
 ## 11. Review Checklist
 

--- a/docs/data-contract/snapshot-schema.md
+++ b/docs/data-contract/snapshot-schema.md
@@ -152,7 +152,7 @@ interface CalcSummary {
 - `tiny`：`expectedDamage` / `critDamage` / `nonCritDamage` 三档
 - `brief`：tiny + `damageType` + warnings 摘要
 - `verbose`：brief + `rawTotalDamage` vs `displayTotalDamage`（多段取整差异）
-- `debug`：完整字段 + dazeValue / anomalyBuildup / disorderDamage / trueDamage 副输出
+- `debug`：完整字段 + dazeValue / dazeRatioRaw / dazeRatioDisplay / anomalyBuildup / disorderDamage / trueDamage 副输出
 
 **易混淆**：
 - `rawTotalDamage` 是**理论**总伤（不取整）；`displayTotalDamage` 是**游戏内显示**总伤（每段向上取整后求和）。**两者通常不相等**（攻略 PART 01 开头硬规则）。

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 2. 保留 Excel 与 raw crawler source archive，但 V1 不要求全量清洗 Excel enemy；Excel enemy 作为后备 / V1.x 扩展源。
 3. 米游社用于危局强袭战中文详情正文、3 个可选 buff、3 个 boss 房间机制文本、zh/en source-text 对照；buhflipexplode 用于 DA period / boss slot / buff / multiplier overlay 和英文源文本。
 4. V1 golden fixture 真数据复算收窄到 19 个锚点；G13 异常阈值规则组合、部位破坏与非 DA enemy 失衡恢复锚点推迟到 V1.x。
-5. 当前 #43 replay baseline 已生成 `data/cleaned/audit/v1-agent-source-candidates.json` 与 `data/cleaned/golden/v1-replay-report.json`；14 个锚点已跑通，G04/G09/G10 保持 pending harness（G10 已断言 resistance lane，异常积蓄抗性待补），G22/G23 因人工接受缺失保持 `ERR-DAT-005` blocking。
+5. 当前 #43 replay baseline 已生成 `data/cleaned/audit/v1-agent-source-candidates.json` 与 `data/cleaned/golden/v1-replay-report.json`；17 个锚点已跑通，G04/G09/G10 executable harness 已清零，G22/G23 因人工接受缺失保持 `ERR-DAT-005` blocking。
 
 ## 关键文档
 

--- a/docs/qa/golden-source-coverage.md
+++ b/docs/qa/golden-source-coverage.md
@@ -138,16 +138,15 @@ The current baseline intentionally reports:
 
 | Status | Anchors | Meaning |
 |---|---|---|
-| `passed` | 14 anchors | Core calculation replay ran with sourced Excel/DA refs. |
-| `pendingHarness` | G04, G09, G10 | Source coverage is available, but the executable bucket-scan / daze-display / anomaly-buildup-resistance assertion still needs a concrete replay representation. G10 already asserts frost/auric resistance lanes, but its anomaly-buildup-resistance half is pending. |
+| `passed` | 17 anchors | Core calculation replay ran with sourced Excel/DA refs. G04/G09/G10 now have executable assertions. |
+| `pendingHarness` | none | No V1 anchors are pending harness after the G04/G09/G10 replay patch. |
 | `blocked` | G22, G23 | Excel source text is extracted and hashed, but trusted modifier replay needs manual acceptance or deterministic template support. |
 | `deferred` | G13, G18-G20 | Explicit V1.x scope. |
 
 `pnpm --filter @fairy/data verify:golden-v1` is an offline freshness and shape
 gate. It verifies the artifacts are regenerated from the retained sources and
 that the blocking/pending statuses stay explicit. It does not mark V1
-`releaseReady` until G04/G09 executable assertions are implemented and G22/G23
-blocking `ERR-DAT-005` diagnostics are cleared.
+`releaseReady` until G22/G23 blocking `ERR-DAT-005` diagnostics are cleared.
 
 ## Product / Human Decisions Needed
 

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -220,6 +220,10 @@ describe("calculate", () => {
   it("applies daze modifiers to regular attack segments with baseDazeMultiplier", () => {
     const result = calculate({
       ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        dazeCap: 1000,
+      },
       attackSegments: [
         {
           ...baseSnapshot.attackSegments[0]!,
@@ -238,6 +242,8 @@ describe("calculate", () => {
     })
 
     expect(result.attackSegments[0]?.dazeValue).toBe(180)
+    expect(result.attackSegments[0]?.dazeRatioRaw).toBe(18)
+    expect(result.attackSegments[0]?.dazeRatioDisplay).toBe(18)
     expect(result.buckets.some(bucket => bucket.bucketId === "dazeInflictZone")).toBe(true)
   })
 
@@ -340,6 +346,70 @@ describe("calculate", () => {
       flooredAnomalyMastery: 123,
     })
     expect(buildupTrace?.displayValue).toBe("floorForFormula")
+  })
+
+  it("maps frost and auric ink anomaly buildup resistance to ice and ether", () => {
+    const frost = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            anomalyMastery: 100,
+          },
+        },
+      ],
+      enemy: {
+        ...baseSnapshot.enemy,
+        anomalyBuildupResistance: { ice: 0.15, ether: 0.35 },
+      },
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-frost-buildup",
+          attribute: "frost",
+          damageType: "anomaly",
+          anomalyContribution: { status: "frozen", buildup: 100 },
+        },
+      ],
+    })
+    const auric = calculate({
+      ...baseSnapshot,
+      team: [
+        {
+          ...baseSnapshot.team[0]!,
+          panel: {
+            ...baseSnapshot.team[0]!.panel,
+            anomalyMastery: 100,
+          },
+        },
+      ],
+      enemy: {
+        ...baseSnapshot.enemy,
+        anomalyBuildupResistance: { ice: 0.15, ether: 0.35 },
+      },
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-auric-buildup",
+          attribute: "auricInk",
+          damageType: "anomaly",
+          anomalyContribution: { status: "corruption", buildup: 100 },
+        },
+      ],
+    })
+
+    expect(frost.attackSegments[0]?.anomalyBuildup).toBe(85)
+    expect(auric.attackSegments[0]?.anomalyBuildup).toBe(65)
+    expect(frost.trace.find(event => event.path === "attackSegments[0].anomalyBuildup")?.inputs).toMatchObject({
+      resistanceAttribute: "ice",
+      anomalyBuildupResistance: 0.15,
+    })
+    expect(auric.trace.find(event => event.path === "attackSegments[0].anomalyBuildup")?.inputs).toMatchObject({
+      resistanceAttribute: "ether",
+      anomalyBuildupResistance: 0.35,
+    })
   })
 
   it("applies anomaly crit contributors without creating the standard crit bucket", () => {

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -26,6 +26,7 @@ import {
   getDazeVulnerabilityMultiplier,
   getDefenseMultiplier,
   getResistance,
+  getResistanceAttribute,
   getResistanceMultiplier,
   getVulnerabilityMultiplier,
   isEnemyDazed,
@@ -482,10 +483,45 @@ function calculateSegment(
   const nonCritDamage = damageType === "daze" ? 0 : baseDamage * nonCritMultiplier
   const critDamage = damageType === "daze" ? 0 : nonCritDamage * (1 + critDamageBonus)
   const dazeValue = getDazeValue(formulaActor.actor, segment, buckets, formulaActor.disorderDazeMultiplier)
+  const dazeRatio = dazeValue === undefined || snapshot.enemy.dazeCap === undefined || snapshot.enemy.dazeCap <= 0
+    ? undefined
+    : {
+        raw: (dazeValue / snapshot.enemy.dazeCap) * 100,
+        display: Math.floor((dazeValue / snapshot.enemy.dazeCap) * 100),
+      }
+  if (dazeRatio !== undefined) {
+    trace.push(
+      makeTraceEvent({
+        kind: "formula",
+        path: `attackSegments[${index}].dazeRatioRaw`,
+        inputs: {
+          dazeValue,
+          enemyDazeCap: snapshot.enemy.dazeCap,
+        },
+        formula: "dazeRatioRaw = dazeValue / enemy.dazeCap * 100",
+        rawValue: dazeRatio.raw,
+      }),
+      makeTraceEvent({
+        kind: "rounding",
+        path: `attackSegments[${index}].dazeRatioDisplay`,
+        rawValue: dazeRatio.raw,
+        displayValue: dazeRatio.display,
+        rounding: {
+          mode: "floorForDisplay",
+          input: dazeRatio.raw,
+          output: dazeRatio.display,
+          reason: "Daze ratio display floors the percentage value.",
+        },
+      }),
+    )
+  }
+
   const anomalyBuildup = segment.anomalyContribution?.buildup === undefined
     ? undefined
-    : getAnomalyBuildup(formulaActor.actor, segment)
+    : getAnomalyBuildup(snapshot, formulaActor.actor, segment)
   if (anomalyBuildup !== undefined) {
+    const resistanceAttribute = getResistanceAttribute(segment.attribute)
+    const anomalyBuildupResistance = snapshot.enemy.anomalyBuildupResistance?.[resistanceAttribute] ?? 0
     trace.push(makeTraceEvent({
       kind: "formula",
       path: `attackSegments[${index}].anomalyBuildup`,
@@ -493,8 +529,11 @@ function calculateSegment(
         buildup: segment.anomalyContribution?.buildup ?? 0,
         anomalyMastery: formulaActor.actor.panel.anomalyMastery ?? 100,
         flooredAnomalyMastery: Math.floor(formulaActor.actor.panel.anomalyMastery ?? 100),
+        resistanceAttribute,
+        anomalyBuildupResistance,
+        anomalyBuildupResistanceMultiplier: getAnomalyBuildupResistanceMultiplier(anomalyBuildupResistance),
       },
-      formula: "anomalyBuildup = buildup * floor(anomalyMastery) / 100",
+      formula: "anomalyBuildup = buildup * floor(anomalyMastery) / 100 * anomalyBuildupResistanceMultiplier",
       rawValue: anomalyBuildup,
       displayValue: "floorForFormula",
     }))
@@ -516,6 +555,7 @@ function calculateSegment(
       nonCritDamage,
       ...(segment.baseDazeMultiplier === undefined && segment.damageType !== "disorder" ? {} : { baseDaze: getBaseDaze(formulaActor.actor, segment) }),
       ...(dazeValue === undefined ? {} : { dazeValue }),
+      ...(dazeRatio === undefined ? {} : { dazeRatioRaw: dazeRatio.raw, dazeRatioDisplay: dazeRatio.display }),
       ...(anomalyBuildup === undefined ? {} : { anomalyBuildup }),
       traceRefs: trace.map(event => event.id),
     },
@@ -824,9 +864,17 @@ function getDazeValue(
   return getBaseDaze(activeActor, segment) * multiplier * extraMultiplier
 }
 
-function getAnomalyBuildup(activeActor: AgentSnapshot, segment: AttackSegment): number {
+function getAnomalyBuildup(snapshot: BattleSnapshot, activeActor: AgentSnapshot, segment: AttackSegment): number {
   const baseBuildup = segment.anomalyContribution?.buildup ?? 0
-  return baseBuildup * (Math.floor(activeActor.panel.anomalyMastery ?? 100) / 100)
+  const resistanceAttribute = getResistanceAttribute(segment.attribute)
+  const buildupResistance = snapshot.enemy.anomalyBuildupResistance?.[resistanceAttribute] ?? 0
+  return baseBuildup
+    * (Math.floor(activeActor.panel.anomalyMastery ?? 100) / 100)
+    * getAnomalyBuildupResistanceMultiplier(buildupResistance)
+}
+
+function getAnomalyBuildupResistanceMultiplier(resistance: number): number {
+  return clamp(1 - resistance, 0, 2)
 }
 
 function getDamageBonus(activeActor: AgentSnapshot, segment: AttackSegment): number {

--- a/packages/core/src/schema/calc-result.ts
+++ b/packages/core/src/schema/calc-result.ts
@@ -47,6 +47,8 @@ export const segmentResultSchema = z
     critDamage: z.number().finite().optional(),
     nonCritDamage: z.number().finite().optional(),
     dazeValue: z.number().finite().optional(),
+    dazeRatioRaw: z.number().finite().optional(),
+    dazeRatioDisplay: z.number().finite().optional(),
     anomalyBuildup: z.number().finite().optional(),
     traceRefs: z.array(z.string().min(1)),
   })

--- a/packages/data/cleaned/golden/v1-replay-report.json
+++ b/packages/data/cleaned/golden/v1-replay-report.json
@@ -36,8 +36,8 @@
   ],
   "summary": {
     "v1AnchorCount": 19,
-    "passed": 14,
-    "pendingHarness": 3,
+    "passed": 17,
+    "pendingHarness": 0,
     "blocked": 2,
     "deferred": 4,
     "blockingDiagnostics": 3,
@@ -98,10 +98,16 @@
     },
     {
       "id": "G04",
-      "status": "pendingHarness",
-      "sourceRefs": [],
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123"
+        }
+      ],
       "notes": [
-        "Source coverage is not blocked, but the executable bucket-scan assertion still needs a CLI/core replay representation."
+        "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
       ]
     },
     {
@@ -172,7 +178,7 @@
     },
     {
       "id": "G09",
-      "status": "pendingHarness",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "buhflipexplode-zzz-da",
@@ -186,12 +192,12 @@
         }
       ],
       "notes": [
-        "buhflipexplode DA source exposes baseDaze/versionDazeMult; executable daze ratio display-floor assertion still needs a replay representation."
+        "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
       ]
     },
     {
       "id": "G10",
-      "status": "pendingHarness",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "lo-user-excel",
@@ -200,8 +206,7 @@
         }
       ],
       "notes": [
-        "Resistance mapping is asserted: frost uses enemy.resistance.ice and auricInk uses enemy.resistance.ether.",
-        "Anomaly-buildup-resistance mapping is still pending because current core replay does not consume enemy.anomalyBuildupResistance."
+        "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
       ]
     },
     {

--- a/packages/data/scripts/golden-v1-replay.ts
+++ b/packages/data/scripts/golden-v1-replay.ts
@@ -220,6 +220,14 @@ function sourceRef(sourceAnchor: string): Record<string, string> {
   }
 }
 
+function guideSourceRef(sourceAnchor: string): Record<string, string> {
+  return {
+    sourceId: "zzz-data-introduction",
+    sourceVersion: "2026-05-05",
+    sourceAnchor,
+  }
+}
+
 function buildAgentCandidates(workbook: XLSX.WorkBook) {
   const rows = rowsForSheet(workbook, "代理人属性")
   const headers = headerMap(rows[0] ?? [])
@@ -667,6 +675,43 @@ function assertClose(actual: number | undefined, expected: number, tolerance: nu
     throw new Error(`${label}: expected ${expected}, got ${actual}`)
 }
 
+function defensePenetrationBreakpoint(
+  snapshot: ReturnType<typeof baseSnapshot>,
+  input: { basePenetrationRate?: number; addedPenetrationRate: number; defenseReduction?: number },
+): number {
+  const source = guideSourceRef("docs/reference/zzz-data-introduction.txt:121-123")
+  const modifiers = input.defenseReduction === undefined
+    ? []
+    : [
+        {
+          id: "g04-defense-reduction",
+          handlerId: "defense-reduction",
+          params: { value: input.defenseReduction },
+          appliesTo: { kind: "activeActor" },
+          source,
+        },
+      ]
+
+  const withPenetration = (penetrationRate: number) => calculate({
+    ...snapshot,
+    team: [
+      {
+        ...snapshot.team[0]!,
+        panel: {
+          ...snapshot.team[0]!.panel,
+          penetrationRate,
+        },
+      },
+    ],
+    modifiers,
+  })
+
+  const baseline = withPenetration(input.basePenetrationRate ?? 0)
+  const increased = withPenetration((input.basePenetrationRate ?? 0) + input.addedPenetrationRate)
+  const penetrationGain = increased.summary.rawTotalDamage / baseline.summary.rawTotalDamage - 1
+  return 0.3 / penetrationGain
+}
+
 function passedAnchor(id: string, sourceRefs: Array<Record<string, string>>, notes: string[] = []): AnchorReport {
   return { id, status: "passed", sourceRefs, notes }
 }
@@ -713,14 +758,30 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     anchors.push(passedAnchor("G03", [sourceRef("代理人属性!A37:AF37")], ["Crit expected value uses 1 + critRate * critDamage."]))
   }
 
-  anchors.push({
-    id: "G04",
-    status: "pendingHarness",
-    sourceRefs: [],
-    notes: [
-      "Source coverage is not blocked, but the executable bucket-scan assertion still needs a CLI/core replay representation.",
-    ],
-  })
+  {
+    const guideRef = guideSourceRef("docs/reference/zzz-data-introduction.txt:121-123")
+    assertClose(
+      defensePenetrationBreakpoint(snapshot, { addedPenetrationRate: 0.24 }),
+      1.9917,
+      0.0005,
+      "G04 default penetration breakpoint",
+    )
+    assertClose(
+      defensePenetrationBreakpoint(snapshot, { addedPenetrationRate: 0.24, defenseReduction: 0.4 }),
+      2.6861,
+      0.0005,
+      "G04 Nicole defense-reduction penetration breakpoint",
+    )
+    assertClose(
+      defensePenetrationBreakpoint(snapshot, { basePenetrationRate: 0.3, addedPenetrationRate: 0.24 }),
+      1.6167,
+      0.0005,
+      "G04 Rina penetration breakpoint",
+    )
+    anchors.push(passedAnchor("G04", [guideRef], [
+      "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints.",
+    ]))
+  }
 
   {
     const regular = calculate({
@@ -822,14 +883,29 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     anchors.push(passedAnchor("G08", [sourceRef("代理人属性!A37:AF37")], ["Anomaly Mastery floors before buildup."]))
   }
 
-  anchors.push({
-    id: "G09",
-    status: "pendingHarness",
-    sourceRefs: enemy.sourceRefs,
-    notes: [
-      "buhflipexplode DA source exposes baseDaze/versionDazeMult; executable daze ratio display-floor assertion still needs a replay representation.",
-    ],
-  })
+  {
+    const dazeCap = Number(snapshot.enemy.dazeCap)
+    const result = calculate({
+      ...snapshot,
+      attackSegments: [
+        {
+          ...snapshot.attackSegments[0]!,
+          id: "seg-daze-ratio",
+          damageType: "daze",
+          baseDazeMultiplier: (dazeCap * 0.12345) / Number(snapshot.team[0]!.panel.impact),
+        },
+      ],
+    })
+    assertClose(result.attackSegments[0]?.dazeValue, dazeCap * 0.12345, 0.00001, "G09 sourced DA daze value")
+    assertClose(result.attackSegments[0]?.dazeRatioRaw, 12.345, 0.00001, "G09 daze ratio raw")
+    if (result.attackSegments[0]?.dazeRatioDisplay !== 12)
+      throw new Error(`G09 daze ratio display expected 12, got ${result.attackSegments[0]?.dazeRatioDisplay}`)
+    if (trace(result, "attackSegments[0].dazeRatioDisplay").rounding?.mode !== "floorForDisplay")
+      throw new Error("G09 missing floorForDisplay trace")
+    anchors.push(passedAnchor("G09", enemy.sourceRefs, [
+      "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value.",
+    ]))
+  }
 
   {
     const frost = calculate({
@@ -882,19 +958,65 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
         anomalyBuildupResistance: { ice: 0.15, ether: 0.35 },
       },
     })
+    const frostBuildup = calculate({
+      ...snapshot,
+      team: [
+        {
+          ...snapshot.team[0]!,
+          panel: {
+            ...snapshot.team[0]!.panel,
+            anomalyMastery: 100,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...snapshot.attackSegments[0]!,
+          id: "seg-frost-buildup",
+          attribute: "frost",
+          damageType: "anomaly",
+          anomalyContribution: { status: "frozen", buildup: 100 },
+        },
+      ],
+      enemy: {
+        ...snapshot.enemy,
+        anomalyBuildupResistance: { ice: 0.15, ether: 0.35 },
+      },
+    })
+    const auricBuildup = calculate({
+      ...snapshot,
+      team: [
+        {
+          ...snapshot.team[0]!,
+          panel: {
+            ...snapshot.team[0]!.panel,
+            anomalyMastery: 100,
+          },
+        },
+      ],
+      attackSegments: [
+        {
+          ...snapshot.attackSegments[0]!,
+          id: "seg-auric-buildup",
+          attribute: "auricInk",
+          damageType: "anomaly",
+          anomalyContribution: { status: "corruption", buildup: 100 },
+        },
+      ],
+      enemy: {
+        ...snapshot.enemy,
+        anomalyBuildupResistance: { ice: 0.15, ether: 0.35 },
+      },
+    })
     assertClose(bucket(frost, "resistanceZone").effectiveMultiplier, 0.8, 0.00001, "G10 frost resistance")
     assertClose(bucket(auric, "resistanceZone").effectiveMultiplier, 0.6, 0.00001, "G10 auric resistance")
+    assertClose(frostBuildup.attackSegments[0]?.anomalyBuildup, 85, 0.00001, "G10 frost anomaly buildup resistance")
+    assertClose(auricBuildup.attackSegments[0]?.anomalyBuildup, 65, 0.00001, "G10 auric anomaly buildup resistance")
     assertClose(bucket(frost, "damageBonusZone").effectiveMultiplier, 1.2, 0.00001, "G11 frost damage bonus")
     assertClose(bucket(auric, "damageBonusZone").effectiveMultiplier, 1.4, 0.00001, "G11 auric damage bonus")
-    anchors.push({
-      id: "G10",
-      status: "pendingHarness",
-      sourceRefs: [sourceRef("代理人属性!A37:AF37")],
-      notes: [
-        "Resistance mapping is asserted: frost uses enemy.resistance.ice and auricInk uses enemy.resistance.ether.",
-        "Anomaly-buildup-resistance mapping is still pending because current core replay does not consume enemy.anomalyBuildupResistance.",
-      ],
-    })
+    anchors.push(passedAnchor("G10", [sourceRef("代理人属性!A37:AF37")], [
+      "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance.",
+    ]))
     anchors.push(passedAnchor("G11", [sourceRef("代理人属性!A37:AF37")], ["Frost/Auric use Ice/Ether damage-bonus panel fields."]))
   }
 
@@ -1150,8 +1272,8 @@ function verifyCommand(): void {
     throw new Error(`Expected 19 V1 anchors, got ${report.summary.v1AnchorCount}`)
   if (report.summary.blocked !== 2)
     throw new Error(`Expected G22/G23 to be blocked by manual acceptance, got ${report.summary.blocked} blocked anchors`)
-  if (report.summary.pendingHarness !== 3)
-    throw new Error(`Expected G04/G09/G10 pending harness entries, got ${report.summary.pendingHarness}`)
+  if (report.summary.pendingHarness !== 0)
+    throw new Error(`Expected no pending harness entries after G04/G09/G10 executable assertions, got ${report.summary.pendingHarness}`)
 }
 
 async function main(): Promise<void> {

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -70,8 +70,8 @@ describe("V1 golden true-data replay baseline", () => {
     expect(report.deferredAnchorIds).toEqual(["G13", "G18", "G19", "G20"])
     expect(report.summary).toMatchObject({
       v1AnchorCount: 19,
-      passed: 14,
-      pendingHarness: 3,
+      passed: 17,
+      pendingHarness: 0,
       blocked: 2,
       blockingDiagnostics: 3,
       releaseReady: false,
@@ -79,10 +79,15 @@ describe("V1 golden true-data replay baseline", () => {
 
     const g13 = report.anchors.find(anchor => anchor.id === "G13")
     expect(g13?.status).toBe("deferred")
+    const g04 = report.anchors.find(anchor => anchor.id === "G04")
+    expect(g04?.status).toBe("passed")
+    expect(g04?.notes.join("\n")).toContain("199.17%, 268.61%, and 161.67%")
+    const g09 = report.anchors.find(anchor => anchor.id === "G09")
+    expect(g09?.status).toBe("passed")
+    expect(g09?.notes.join("\n")).toContain("daze ratio display floors")
     const g10 = report.anchors.find(anchor => anchor.id === "G10")
-    expect(g10?.status).toBe("pendingHarness")
-    expect(g10?.notes.join("\n")).toContain("Resistance mapping is asserted")
-    expect(g10?.notes.join("\n")).toContain("Anomaly-buildup-resistance mapping is still pending")
+    expect(g10?.status).toBe("passed")
+    expect(g10?.notes.join("\n")).toContain("both resistanceZone and anomaly-buildup-resistance")
     const g11 = report.anchors.find(anchor => anchor.id === "G11")
     expect(g11?.status).toBe("passed")
     const g22 = report.anchors.find(anchor => anchor.id === "G22")


### PR DESCRIPTION
## Summary
- clear G04 by replaying the guide penetration-vs-damage-bonus breakpoint scan (199.17%, 268.61%, 161.67%)
- clear G09 by adding daze ratio raw/display floor support and asserting sourced DA daze cap replay
- clear G10 by applying anomaly-buildup-resistance through the same frost->ice / auricInk->ether lane mapping as resistance/damage bonus
- update V1 replay report/docs/tests to passed=17, pendingHarness=0, blocked=2, releaseReady=false

## Verification
- pnpm --filter @fairy/core test
- pnpm --filter @fairy/data audit:golden-v1
- pnpm --filter @fairy/data sync-cleaned
- pnpm --filter @fairy/data verify:golden-v1
- pnpm --filter @fairy/data test
- pnpm check
- pnpm test
- pnpm --filter @fairy/data verify:excel
- pnpm --filter @fairy/data verify:buhflipexplode-da
- pnpm --filter @fairy/data verify:mihoyo-da
- jq empty data/cleaned/audit/v1-agent-source-candidates.json data/cleaned/golden/v1-replay-report.json packages/data/cleaned/audit/v1-agent-source-candidates.json packages/data/cleaned/golden/v1-replay-report.json data/source/source-manifest.json
- git diff --check
- pnpm --filter @fairy/data pack --pack-destination /tmp --json

## Notes
Baseline remains not release-ready because G22/G23 still block on ERR-DAT-005 manual acceptance/template support.