### PR TITLE
feat(data): accept G22/G23 golden modifiers

### DIFF
--- a/data/cleaned/README.md
+++ b/data/cleaned/README.md
@@ -18,4 +18,6 @@ Current generated artifacts:
 
 - `audit/v1-agent-source-candidates.json` — minimal Excel-derived source
   candidates for V1 team-modifier replay.
-- `golden/v1-replay-report.json` — source-backed V1 golden replay baseline.
+- `audit/nicole.acceptance.json` and `audit/yanagi.acceptance.json` —
+  lo-user manual acceptance records for G22/G23 source-text mappings.
+- `golden/v1-replay-report.json` — source-backed V1 golden replay report.

--- a/data/cleaned/audit/nicole.acceptance.json
+++ b/data/cleaned/audit/nicole.acceptance.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "fairy-manual-acceptance-v1",
+  "parserVersion": "golden-v1-replay-v0.1.0",
+  "generatedAt": "2026-05-05T18:20:00+08:00",
+  "agentId": "nicole",
+  "records": [
+    {
+      "agentId": "nicole",
+      "effectId": "nicole-defense-reduction",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D4:J4"
+        }
+      ],
+      "sourceTextHash": "07f9d239f43d3deafd4a001cdae349a6f10325cb3bbae090181a00f48e293549",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-core-passive-defense-reduction-v1",
+        "handlerId": "defense-reduction",
+        "bucket": "defenseZone",
+        "appliesTo": {
+          "kind": "enemy"
+        },
+        "params": {
+          "value": 0.4,
+          "corePassiveLevel": 7,
+          "durationSeconds": 3.5
+        },
+        "requiresActivation": true,
+        "activationModel": "snapshotActiveFlag",
+        "inactiveStateMustHaveNoEffect": true
+      }
+    }
+  ]
+}

--- a/data/cleaned/audit/yanagi.acceptance.json
+++ b/data/cleaned/audit/yanagi.acceptance.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": "fairy-manual-acceptance-v1",
+  "parserVersion": "golden-v1-replay-v0.1.0",
+  "generatedAt": "2026-05-05T18:20:00+08:00",
+  "agentId": "yanagi",
+  "records": [
+    {
+      "agentId": "yanagi",
+      "effectId": "yanagi-disorder-boost",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D23:J23"
+        }
+      ],
+      "sourceTextHash": "1d5b17072f8389b59b4f0083ac99c84d2c0e9dd68467a32909c8a5e0938b1462",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-core-passive-disorder-boost-v1",
+        "handlerId": "anomaly-damage-bonus",
+        "bucket": "anomalyDamageBonusZone",
+        "appliesTo": {
+          "kind": "segment"
+        },
+        "params": {
+          "value": 2.5,
+          "corePassiveLevel": 7,
+          "durationSeconds": 15
+        },
+        "requiresActivation": true,
+        "activationModel": "snapshotActiveFlag",
+        "inactiveStateMustHaveNoEffect": true
+      }
+    },
+    {
+      "agentId": "yanagi",
+      "effectId": "yanagi-polarity-disorder-ex-special",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人技能描述!C298"
+        }
+      ],
+      "sourceTextHash": "4ac89b99d4fead4a8cb78d2dfdf84f32a93864cb11c4307e0474d5087bb25f5b",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-yanagi-polarity-disorder-v1",
+        "templateKind": "attackSegment.anomalyContribution.polarityDisorder",
+        "handlerId": "polarity-disorder-template",
+        "appliesTo": {
+          "kind": "segment"
+        },
+        "params": {
+          "providerActorId": "yanagi",
+          "skillLevelKey": "special",
+          "originalDisorderDamageRatio": 0.15,
+          "anomalyProficiencyBasePercent": 5,
+          "anomalyProficiencyPerSkillLevelPercent": 2.25,
+          "clearsOriginalAnomaly": false
+        },
+        "supportedSkillLevels": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "requiresActivation": true,
+        "activationModel": "snapshotAttackSegmentTemplate"
+      }
+    }
+  ]
+}

--- a/data/cleaned/golden/v1-replay-report.json
+++ b/data/cleaned/golden/v1-replay-report.json
@@ -5,7 +5,7 @@
   "policy": {
     "scope": "V1 true-data replay harness baseline after DD-002: 19 anchors in V1, G13/G18/G19/G20 deferred.",
     "releaseGate": "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
-    "manualAcceptance": "G22/G23 must emit ERR-DAT-005 until lo-user manual acceptance records exist for the sourceTextHash values in v1-agent-source-candidates.json."
+    "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
   "v1AnchorIds": [
     "G01",
@@ -36,12 +36,12 @@
   ],
   "summary": {
     "v1AnchorCount": 19,
-    "passed": 17,
+    "passed": 19,
     "pendingHarness": 0,
-    "blocked": 2,
+    "blocked": 0,
     "deferred": 4,
-    "blockingDiagnostics": 3,
-    "releaseReady": false
+    "blockingDiagnostics": 0,
+    "releaseReady": true
   },
   "anchors": [
     {
@@ -324,7 +324,7 @@
     },
     {
       "id": "G22",
-      "status": "blocked",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "lo-user-excel",
@@ -332,30 +332,20 @@
           "sourceAnchor": "代理人核心技描述!D4:J4"
         }
       ],
-      "diagnostics": [
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "ambiguousCondition",
-          "effectId": "nicole-defense-reduction",
-          "sourceTextHash": "07f9d239f43d3deafd4a001cdae349a6f10325cb3bbae090181a00f48e293549",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人核心技描述!D4:J4"
-            }
-          ]
-        }
-      ],
       "notes": [
-        "Source text is extracted and hashed, but replay must not apply inferred Nicole/Yanagi modifiers before manual acceptance."
+        "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+        "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
       ]
     },
     {
       "id": "G23",
-      "status": "blocked",
+      "status": "passed",
       "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D4:J4"
+        },
         {
           "sourceId": "lo-user-excel",
           "sourceVersion": "2.6.0_R14028417",
@@ -367,38 +357,10 @@
           "sourceAnchor": "代理人技能描述!C298"
         }
       ],
-      "diagnostics": [
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "ambiguousCondition",
-          "effectId": "yanagi-disorder-boost",
-          "sourceTextHash": "1d5b17072f8389b59b4f0083ac99c84d2c0e9dd68467a32909c8a5e0938b1462",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人核心技描述!D23:J23"
-            }
-          ]
-        },
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "unknownHandler",
-          "effectId": "yanagi-polarity-disorder-ex-special",
-          "sourceTextHash": "4ac89b99d4fead4a8cb78d2dfdf84f32a93864cb11c4307e0474d5087bb25f5b",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人技能描述!C298"
-            }
-          ]
-        }
-      ],
       "notes": [
-        "Source text is extracted and hashed, but replay must not apply inferred Nicole/Yanagi modifiers before manual acceptance."
+        "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+        "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+        "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
       ]
     },
     {

--- a/docs/data-contract/cleaned-schema-spec.md
+++ b/docs/data-contract/cleaned-schema-spec.md
@@ -538,8 +538,9 @@ V1 cleaned-data implementation must add tests for these gates:
 - V1 golden true-data replay uses the 19-anchor scope and records anchors 13,
   18, 19, and 20 as V1.x deferred, not skipped accidentally.
 - `verify:golden-v1` passes as an offline freshness gate for the generated V1
-  agent source candidates and replay report; V1 release remains blocked until
-  its report has zero `ERR-DAT-005` diagnostics and no `pendingHarness` anchors.
+  agent source candidates, manual acceptance records, and replay report; V1
+  release requires zero `ERR-DAT-005` diagnostics, no `pendingHarness` anchors,
+  and `releaseReady=true`.
 
 ## 10. Implementation Impact
 
@@ -576,14 +577,21 @@ missing QA coverage.
 The first replay harness baseline writes:
 
 - `data/cleaned/audit/v1-agent-source-candidates.json`;
+- `data/cleaned/audit/nicole.acceptance.json`;
+- `data/cleaned/audit/yanagi.acceptance.json`;
 - `data/cleaned/golden/v1-replay-report.json`.
 
 `verify:golden-v1` verifies those artifacts against retained Excel and DA source
-snapshots. The baseline intentionally keeps G22/G23 blocked by `ERR-DAT-005`
-until manual acceptance records exist. G04/G09/G10 now have executable replay
-assertions: G04 reproduces the guide breakpoint scan, G09 asserts sourced DA
-daze ratio display flooring, and G10 asserts frost/auric resistance plus
-anomaly-buildup-resistance lane mapping.
+snapshots. The current baseline has 19 V1 anchors passed, zero blocking
+diagnostics, and `releaseReady=true`. G04 reproduces the guide breakpoint scan,
+G09 asserts sourced DA daze ratio display flooring, G10 asserts frost/auric
+resistance plus anomaly-buildup-resistance lane mapping, and G22/G23 use
+lo-user manual acceptance records for Nicole/Yanagi active-state and
+polarity-disorder template semantics. The polarity-disorder template requires an
+explicit provider agent in `team` and an explicit supported skill level
+(`skillLevels[skillLevelKey]` in 1-16) plus provider `panel.anomalyProficiency`;
+missing or out-of-range inputs are validation failures, not silent level-1 or
+zero-proficiency fallbacks.
 
 ## 11. Review Checklist
 

--- a/docs/data-source/excel/README.md
+++ b/docs/data-source/excel/README.md
@@ -24,11 +24,14 @@ cleaned game data and does not infer typed modifiers from text.
 The V1 replay baseline uses a narrower generated artifact:
 
 - `data/cleaned/audit/v1-agent-source-candidates.json`
+- `data/cleaned/audit/nicole.acceptance.json`
+- `data/cleaned/audit/yanagi.acceptance.json`
 
 That artifact extracts only Yixuan / Nicole / Yanagi identity rows and
 calculation-relevant source text candidates needed by the DD-002 19-anchor
-golden scope. It does not read Excel enemy rows and does not publish trusted
-typed modifiers without manual acceptance.
+golden scope. The acceptance artifacts record lo-user-approved G22/G23 mappings.
+The reader does not read Excel enemy rows and does not publish trusted typed
+modifiers without deterministic template support or manual acceptance.
 
 ## V1 Candidate Sheets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 2. 保留 Excel 与 raw crawler source archive，但 V1 不要求全量清洗 Excel enemy；Excel enemy 作为后备 / V1.x 扩展源。
 3. 米游社用于危局强袭战中文详情正文、3 个可选 buff、3 个 boss 房间机制文本、zh/en source-text 对照；buhflipexplode 用于 DA period / boss slot / buff / multiplier overlay 和英文源文本。
 4. V1 golden fixture 真数据复算收窄到 19 个锚点；G13 异常阈值规则组合、部位破坏与非 DA enemy 失衡恢复锚点推迟到 V1.x。
-5. 当前 #43 replay baseline 已生成 `data/cleaned/audit/v1-agent-source-candidates.json` 与 `data/cleaned/golden/v1-replay-report.json`；17 个锚点已跑通，G04/G09/G10 executable harness 已清零，G22/G23 因人工接受缺失保持 `ERR-DAT-005` blocking。
+5. 当前 #43 replay 已生成 `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json`；19 个 V1 锚点全部跑通，`releaseReady=true`，G13/G18/G19/G20 仍作为 V1.x deferred 可见。
 
 ## 关键文档
 

--- a/docs/qa/golden-source-coverage.md
+++ b/docs/qa/golden-source-coverage.md
@@ -37,13 +37,13 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | G01 | Core defense formula + guide reference | Covered by core rules. | Replay fixture only. |
 | G02 | Core defense formula + corrupted-shield state | Covered by core rules; DA boss can provide real boss context if needed. | Replay fixture can use DA boss from buhflipexplode. |
 | G03 | Core crit expected-value formula | Covered by core rules. | Replay fixture only. |
-| G04 | Core bucket scan / marginal breakpoint formula | Formula representation still marked `pending-formula` in QA fixture. | Decide exact executable scan representation before release gate. Not source-blocked. |
+| G04 | Core bucket scan / marginal breakpoint formula | Covered by executable replay against guide breakpoints. | Passed. |
 | G05 | Core sheer formula + corrupted-shield boss context | DA boss data available from buhflipexplode/Mihoyo. | Replay fixture should pick a DA corrupted-shield-compatible boss and preserve source refs. |
 | G06 | Core sheer formula + default 60+ boss context | DA boss data available from buhflipexplode/Mihoyo. | Replay fixture can use same DA boss with shield inactive or another DA boss. |
 | G07 | Core per-segment rounding | Covered by core rules. | Replay fixture only. |
 | G08 | Core anomaly mastery floor | Covered by core rules. | Replay fixture only. |
-| G09 | Base daze value + display-floor behavior | buhflipexplode DA enemies expose `baseDaze[]` and DA periods expose `versionDazeMult[]`. | Cleaned DA boss slot must expose sourced base daze/effective daze. |
-| G10 | Attribute alias mapping (frost/auric -> ice/ether) | Covered by glossary/naming policy/core mapping. | Replay fixture only. |
+| G09 | Base daze value + display-floor behavior | buhflipexplode DA enemies expose `baseDaze[]` and DA periods expose `versionDazeMult[]`; replay verifies raw/display floor behavior. | Passed. |
+| G10 | Attribute alias mapping (frost/auric -> ice/ether) | Covered by glossary/naming policy/core mapping; replay verifies resistance and anomaly-buildup-resistance lanes. | Passed. |
 | G11 | Attribute damage-bonus alias mapping | Covered by glossary/naming policy/core mapping. | Replay fixture only. |
 | G12 | Core anomaly threshold table | Covered by core rules. | Replay fixture only. |
 | G13 | Special enemy + Deadly Assault anomaly-threshold modifiers | Deferred to V1.x by @lo-user on 2026-05-05. Reference guide / Product v2.0 documents the rule; core currently supports only explicit `thresholdOverride`, not data-driven threshold-rule composition. | V1.x should implement sourced threshold-rule support and replay this anchor. |
@@ -52,8 +52,8 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | G16 | Disorder daze-level zone | Covered by core rules. | Replay fixture only. |
 | G17 | Corrupted-shield cleanse true damage | Core rules covered; DA boss max HP available from buhflipexplode. | Cleaned DA boss slot must expose sourced max HP/effective max HP. |
 | G21 | 1-agent Yixuan sheer | Excel has Yixuan agent row; panel values remain user snapshot. | Minimal Excel agent mapping for Yixuan id/attribute/specialty/label/source refs. |
-| G22 | Yixuan + Nicole defense reduction | Excel has Nicole rows/descriptions. | Minimal Excel agent mapping plus manually accepted typed modifier for Nicole defense reduction; unresolved if source text cannot be mapped confidently. |
-| G23 | Yixuan + Nicole + Yanagi polarity disorder | Excel has Yanagi rows/descriptions; core supports polarity disorder. | Minimal Excel agent mapping plus manually accepted typed modifier/source refs for Yanagi polarity-disorder behavior. |
+| G22 | Yixuan + Nicole defense reduction | Excel has Nicole rows/descriptions; lo-user accepted the defense-reduction mapping. | Passed with explicit inactive/active snapshot replay. |
+| G23 | Yixuan + Nicole + Yanagi polarity disorder | Excel has Yanagi rows/descriptions; lo-user accepted the disorder boost and EX Special polarity-disorder template. | Passed with explicit inactive/active replay and skill-level parameterized polarity-disorder template. |
 
 ## Agent Source Evidence For G21-G23
 
@@ -69,14 +69,15 @@ Calculation-relevant source text candidates:
 
 | Anchor | Source anchor | Candidate normalized effect | Acceptance status |
 |---|---|---|---|
-| G22 Nicole defense reduction | `代理人核心技描述!D4:J4` | Target defense reduction by core passive level; level 7 text says target defense is reduced by 40% for 3.5s. Bucket should map to the defense-zone reduction path, not penetration. | Needs deterministic parser/template or manual acceptance before cleaned typed modifier output. |
+| G22 Nicole defense reduction | `代理人核心技描述!D4:J4` | Target defense reduction by core passive level; level 7 text says target defense is reduced by 40% for 3.5s. Bucket maps to the defense-zone reduction path, not penetration. | Accepted by @lo-user on 2026-05-05 as `requiresActivation`; replay verifies inactive/no-effect and active/effect snapshots. |
 | G22 Nicole ether damage bonus | `代理人核心技描述!K4:L4` | Additional ability grants team damage against the debuffed target for ether damage. Not required for a pure defense-reduction G22 replay unless the fixture explicitly activates it. | Keep as source-text candidate; do not auto-activate. |
-| G23 Yanagi disorder boost | `代理人核心技描述!D23:J23` | Core passive increases disorder damage multiplier after EX Special; level 7 text reaches +250% and also grants electric damage. | Needs manual acceptance because the duration/trigger state is snapshot-active, not timeline-simulated. |
-| G23 Yanagi polarity disorder | `代理人技能描述!C298`, `代理人技能描述!C303` | EX Special / Ultimate can trigger Polarity Disorder using a formula based on original Disorder damage plus Yanagi Anomaly Proficiency. | Needs a dedicated handler/template because the text carries a formula placeholder (`{CAL:...}`) and must preserve source refs. |
+| G23 Yanagi disorder boost | `代理人核心技描述!D23:J23` | Core passive increases disorder damage multiplier after EX Special; level 7 text reaches +250% and also grants electric damage. | Accepted by @lo-user on 2026-05-05 as `requiresActivation`; replay verifies inactive/no-effect and active/effect snapshots. |
+| G23 Yanagi polarity disorder | `代理人技能描述!C298`, `代理人技能描述!C303` | EX Special / Ultimate can trigger Polarity Disorder using a formula based on original Disorder damage plus Yanagi Anomaly Proficiency. | EX Special accepted by @lo-user on 2026-05-05 as a skill-level parameterized template; replay verifies skill levels 1-16. Ultimate remains a non-blocking candidate. |
 
-These rows are enough for a minimal #40 agent/source-text reader. They are not
-enough to publish trusted typed modifiers until the acceptance gate records which
-template/handler was accepted for each effect.
+These rows are enough for a minimal #40 agent/source-text reader. Trusted G22
+and G23 replay now uses the acceptance records described below; any future
+source-text effect still needs the same deterministic-template or manual
+acceptance treatment before it can become a typed modifier.
 
 ## Manual Acceptance Gate
 
@@ -84,9 +85,10 @@ G22/G23 stay in the V1 replay gate, but calculation-relevant natural-language
 effects must not be guessed. Before a typed modifier derived from Nicole/Yanagi
 source text can enter replay, it needs an acceptance record.
 
-Suggested storage path:
+Storage path:
 
-- `data/cleaned/audit/<agent>.acceptance.json`
+- `data/cleaned/audit/nicole.acceptance.json`
+- `data/cleaned/audit/yanagi.acceptance.json`
 
 Minimum acceptance record fields:
 
@@ -95,7 +97,7 @@ Minimum acceptance record fields:
 | `agentId` | Stable cleaned agent id, e.g. `nicole` / `yanagi`. |
 | `effectId` | Stable modifier/effect id used by replay. |
 | `sourceId` | `lo-user-excel`. |
-| `sourceAnchor` | Exact workbook anchor, e.g. `代理人核心技描述!D4:J4`. |
+| `sourceRefs[]` | Exact workbook anchors, e.g. `代理人核心技描述!D4:J4`. |
 | `sourceTextHash` | SHA-256 of the accepted source text after parser normalization. |
 | `effectTemplateId` / `handlerId` | The deterministic template or runtime handler being accepted. |
 | `acceptedBy` | For V1 dogfooding, this must be `@lo-user`. |
@@ -104,6 +106,14 @@ Minimum acceptance record fields:
 Replay rule: if an effect required by G22/G23 has no matching acceptance record,
 the replay harness must emit blocking `ERR-DAT-005` and must not silently apply a
 modifier inferred from text.
+
+Current accepted records:
+
+| Effect | Acceptance semantics |
+|---|---|
+| `nicole-defense-reduction` | `requiresActivation=true`; inactive snapshot must have no defense-reduction effect, active snapshot applies 40% defense reduction from core passive level 7. |
+| `yanagi-disorder-boost` | `requiresActivation=true`; inactive snapshot must have no disorder-damage boost, active snapshot applies +250% anomaly/disorder damage bonus from core passive level 7. |
+| `yanagi-polarity-disorder-ex-special` | EX Special polarity disorder template; supports skill levels 1-16 using `(5 + specialLevel * 2.25) / 100` times Yanagi anomaly proficiency, plus 15% of original disorder damage. Snapshot validation fails loud if the Yanagi provider is missing, `skillLevels.special` is missing, the skill level is outside 1-16, or provider `panel.anomalyProficiency` is missing. |
 
 ## Immediate #40 Minimum Range
 
@@ -131,38 +141,40 @@ cleaned artifacts:
 - `data/cleaned/audit/v1-agent-source-candidates.json` — minimal #40 reader
   output for Yixuan / Nicole / Yanagi identity rows plus calculation-relevant
   source text candidates and `sourceTextHash` values.
+- `data/cleaned/audit/nicole.acceptance.json` and
+  `data/cleaned/audit/yanagi.acceptance.json` — lo-user manual acceptance
+  records for G22/G23 source-text mappings.
 - `data/cleaned/golden/v1-replay-report.json` — #43 replay baseline for the
   DD-002 19-anchor scope.
 
-The current baseline intentionally reports:
+The current replay report intentionally reports:
 
 | Status | Anchors | Meaning |
 |---|---|---|
-| `passed` | 17 anchors | Core calculation replay ran with sourced Excel/DA refs. G04/G09/G10 now have executable assertions. |
-| `pendingHarness` | none | No V1 anchors are pending harness after the G04/G09/G10 replay patch. |
-| `blocked` | G22, G23 | Excel source text is extracted and hashed, but trusted modifier replay needs manual acceptance or deterministic template support. |
+| `passed` | 19 anchors | All V1 anchors pass executable replay with sourced Excel/DA refs and lo-user accepted G22/G23 mappings. |
+| `pendingHarness` | none | No V1 anchors are pending harness. |
+| `blocked` | none | G22/G23 `ERR-DAT-005` diagnostics are cleared by acceptance records. |
 | `deferred` | G13, G18-G20 | Explicit V1.x scope. |
 
 `pnpm --filter @fairy/data verify:golden-v1` is an offline freshness and shape
 gate. It verifies the artifacts are regenerated from the retained sources and
-that the blocking/pending statuses stay explicit. It does not mark V1
-`releaseReady` until G22/G23 blocking `ERR-DAT-005` diagnostics are cleared.
+that V1 replay has `passed=19`, `pendingHarness=0`, `blocked=0`,
+`blockingDiagnostics=0`, and `releaseReady=true`.
 
-## Product / Human Decisions Needed
-
-| Decision | Why |
-|---|---|
-| Nicole/Yanagi modifier acceptance | Natural-language conversion cannot be fully automatic. Any V1 typed modifier used in G22/G23 needs deterministic parser support or explicit manual acceptance tied to the source anchors above. |
+## Product / Human Decisions
 
 TL recommendation:
 
 - **G13**: deferred by @lo-user on 2026-05-05. Track with G18/G19/G20 as V1.x
   golden expansion work. Do not use `thresholdOverride` to claim the anchor in
   V1, because that would bypass sourced rule composition and source trace.
-- **Nicole/Yanagi**: Product accepted the manual gate above. Keep G22/G23 in V1,
-  but require acceptance records for the specific source anchors. If no
-  acceptance record exists, the replay harness should emit `ERR-DAT-005` instead
-  of silently applying a guessed modifier.
+- **Nicole/Yanagi**: @lo-user accepted the G22/G23 mapping semantics on
+  2026-05-05. A/B effects are explicit inactive/active snapshot states; C is a
+  skill-level-parameterized EX Special polarity-disorder template. C must fail
+  loud when provider, explicit skill level, or provider anomaly proficiency input
+  is missing. If a required acceptance record is removed or its source hash
+  changes, the replay harness must fail instead of silently applying a guessed
+  modifier.
 
-#43 can build the replay harness for the 19 V1 anchors. G13 must remain listed
-as an explicit V1.x gap rather than disappearing from QA visibility.
+#43 now has a release-ready replay baseline for the 19 V1 anchors. G13 remains
+listed as an explicit V1.x gap rather than disappearing from QA visibility.

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -629,6 +629,7 @@ describe("calculate", () => {
           level: 60,
           agentSpecialty: "anomaly",
           attribute: "electric",
+          skillLevels: { special: 12 },
           panel: {
             attack: 1600,
             maxHp: 10000,
@@ -647,6 +648,14 @@ describe("calculate", () => {
             status: "polarityDisorder",
             buildup: 100,
             remainingDurationSeconds: 5,
+            polarityDisorder: {
+              providerActorId: "yanagi",
+              skillLevelKey: "special",
+              originalDisorderDamageRatio: 0.15,
+              anomalyProficiencyBasePercent: 5,
+              anomalyProficiencyPerSkillLevelPercent: 2.25,
+              source: { sourceId: "provider:Yanagi", sourceVersion: "rules-v0.1" },
+            },
             contributors: [
               { actorId: "yixuan", buildup: 40, included: true },
               { actorId: "yanagi", buildup: 60, included: true },
@@ -672,6 +681,9 @@ describe("calculate", () => {
       ],
     })
     const disorderTrace = result.trace.find(event => event.path === "attackSegments[0].disorderFormulaId")
+    const polarityExtraTrace = result.trace.find(event =>
+      event.path === "attackSegments[0].polarityDisorderBaseDamageExtra",
+    )
     const virtualTrace = result.trace.find(event =>
       event.path === "attackSegments[0].anomalyContribution.virtualAgent",
     )
@@ -684,10 +696,139 @@ describe("calculate", () => {
       remainingDurationT: 5,
     })
     expect(disorderTrace?.rawValue).toBeCloseTo(1.6125, 4)
+    expect(polarityExtraTrace?.rawValue).toBeCloseTo(70.4, 4)
+    expect(polarityExtraTrace?.inputs).toMatchObject({
+      providerActorId: "yanagi",
+      skillLevelKey: "special",
+      skillLevel: 12,
+      anomalyProficiencyMultiplier: 0.32,
+    })
     expect(rows).toEqual(expect.arrayContaining([
       expect.objectContaining({ actorId: "yixuan", buildupContributionRatio: 0.4 }),
       expect.objectContaining({ actorId: "yanagi", buildupContributionRatio: 0.6 }),
     ]))
     expect(sourceIds).toEqual(expect.arrayContaining(["provider:Nicole", "provider:Yanagi"]))
+  })
+
+  it("supports polarity disorder proficiency formula across skill levels", () => {
+    for (let skillLevel = 1; skillLevel <= 16; skillLevel += 1) {
+      const result = calculate({
+        ...baseSnapshot,
+        team: [
+          baseSnapshot.team[0]!,
+          {
+            agentId: "yanagi",
+            level: 60,
+            agentSpecialty: "anomaly",
+            attribute: "electric",
+            skillLevels: { special: skillLevel },
+            panel: {
+              attack: 1600,
+              maxHp: 10000,
+              anomalyProficiency: 220,
+            },
+          },
+        ],
+        attackSegments: [
+          {
+            ...baseSnapshot.attackSegments[0]!,
+            id: `seg-polarity-skill-${skillLevel}`,
+            attribute: "electric",
+            damageType: "disorder",
+            multiplier: undefined,
+            anomalyContribution: {
+              status: "polarityDisorder",
+              buildup: 100,
+              remainingDurationSeconds: 5,
+              polarityDisorder: {
+                providerActorId: "yanagi",
+                skillLevelKey: "special",
+                originalDisorderDamageRatio: 0.15,
+                anomalyProficiencyBasePercent: 5,
+                anomalyProficiencyPerSkillLevelPercent: 2.25,
+              },
+            },
+          },
+        ],
+      })
+      const polarityExtraTrace = result.trace.find(event =>
+        event.path === "attackSegments[0].polarityDisorderBaseDamageExtra",
+      )
+
+      expect(polarityExtraTrace?.rawValue).toBeCloseTo(220 * ((5 + skillLevel * 2.25) / 100), 5)
+    }
+  })
+
+  it.each([
+    ["missing provider", [baseSnapshot.team[0]!], /providerActorId/],
+    [
+      "missing skill level",
+      [
+        baseSnapshot.team[0]!,
+        {
+          agentId: "yanagi",
+          level: 60,
+          agentSpecialty: "anomaly",
+          attribute: "electric",
+          panel: { attack: 1600, maxHp: 10000, anomalyProficiency: 220 },
+        },
+      ],
+      /skillLevelKey/,
+    ],
+    [
+      "out-of-range skill level",
+      [
+        baseSnapshot.team[0]!,
+        {
+          agentId: "yanagi",
+          level: 60,
+          agentSpecialty: "anomaly",
+          attribute: "electric",
+          skillLevels: { special: 17 },
+          panel: { attack: 1600, maxHp: 10000, anomalyProficiency: 220 },
+        },
+      ],
+      /between 1 and 16/,
+    ],
+    [
+      "missing anomaly proficiency",
+      [
+        baseSnapshot.team[0]!,
+        {
+          agentId: "yanagi",
+          level: 60,
+          agentSpecialty: "anomaly",
+          attribute: "electric",
+          skillLevels: { special: 12 },
+          panel: { attack: 1600, maxHp: 10000 },
+        },
+      ],
+      /anomalyProficiency/,
+    ],
+  ] as const)("fails loud for polarity disorder %s", (_, team, expectedError) => {
+    expect(() => calculate({
+      ...baseSnapshot,
+      team,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-polarity-invalid-input",
+          attribute: "electric",
+          damageType: "disorder",
+          anomalyContribution: {
+            status: "polarityDisorder",
+            buildup: 100,
+            remainingDurationSeconds: 5,
+            polarityDisorder: {
+              providerActorId: "yanagi",
+              skillLevelKey: "special",
+              originalDisorderDamageRatio: 0.15,
+              anomalyProficiencyBasePercent: 5,
+              anomalyProficiencyPerSkillLevelPercent: 2.25,
+            },
+          },
+        },
+      ],
+    })).toThrow(expectedError)
   })
 })

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -153,7 +153,12 @@ function calculateSegment(
   errors.push(...modifierEvaluation.errors)
   const formulaActor = getFormulaActor(snapshot, activeActor, segment, index)
 
-  const baseDamage = getBaseDamage(formulaActor.actor, segment, formulaActor.disorderMultiplier)
+  const baseDamage = getBaseDamage(
+    formulaActor.actor,
+    segment,
+    formulaActor.disorderMultiplier,
+    formulaActor.polarityBaseDamageExtra,
+  )
   const damageBonusValue = getDamageBonus(formulaActor.actor, segment)
     + sumBucketContributors(modifierEvaluation.contributorsByBucket.get("damageBonusZone"))
   const damageBonusMultiplier = clamp(1 + damageBonusValue, 0, 6)
@@ -572,6 +577,7 @@ interface FormulaActorContext {
   trace: TraceEvent[]
   disorderMultiplier?: number
   disorderDazeMultiplier?: number
+  polarityBaseDamageExtra?: number
 }
 
 function getFormulaActor(
@@ -623,7 +629,11 @@ function getFormulaActor(
   ]
 
   if (segment.damageType === "disorder") {
-    const disorder = getDisorderFormula(segment)
+    const disorder = getDisorderFormula(
+      segment,
+      segment.anomalyContribution?.polarityDisorder?.originalDisorderDamageRatio,
+    )
+    const polarityExtra = getPolarityDisorderExtra(snapshot, segment)
     trace.push(makeTraceEvent({
       kind: "formula",
       path: `attackSegments[${index}].disorderFormulaId`,
@@ -639,6 +649,23 @@ function getFormulaActor(
       displayValue: disorder.formulaId,
       sourceAnchor: "guide-3.4.1",
     }))
+    if (polarityExtra !== undefined) {
+      trace.push(makeTraceEvent({
+        kind: "formula",
+        path: `attackSegments[${index}].polarityDisorderBaseDamageExtra`,
+        inputs: {
+          providerActorId: polarityExtra.providerActorId,
+          skillLevelKey: polarityExtra.skillLevelKey,
+          skillLevel: polarityExtra.skillLevel,
+          anomalyProficiency: polarityExtra.anomalyProficiency,
+          anomalyProficiencyMultiplier: polarityExtra.anomalyProficiencyMultiplier,
+        },
+        formula: "polarityDisorderBaseDamageExtra = provider.anomalyProficiency * (basePercent + skillLevel * perSkillLevelPercent) / 100",
+        rawValue: polarityExtra.value,
+        displayValue: "polarityDisorderBaseDamageExtra",
+        ...(polarityExtra.source === undefined ? {} : { source: polarityExtra.source }),
+      }))
+    }
     trace.push(makeTraceEvent({
       kind: "formula",
       path: `attackSegments[${index}].disorderDazeLevelZone`,
@@ -657,6 +684,7 @@ function getFormulaActor(
       trace,
       disorderMultiplier: disorder.multiplier,
       disorderDazeMultiplier: getDisorderDazeLevelMultiplier(formulaActor.actor.level),
+      ...(polarityExtra === undefined ? {} : { polarityBaseDamageExtra: polarityExtra.value }),
     }
   }
 
@@ -827,7 +855,12 @@ function calculateManualEvent(
   }
 }
 
-function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment, disorderMultiplier?: number): number {
+function getBaseDamage(
+  activeActor: AgentSnapshot,
+  segment: AttackSegment,
+  disorderMultiplier?: number,
+  polarityBaseDamageExtra = 0,
+): number {
   const multiplier = segment.multiplier ?? 1
   if (segment.damageType === "sheer")
     return (activeActor.panel.sheerForce ?? 0) * multiplier
@@ -836,7 +869,7 @@ function getBaseDamage(activeActor: AgentSnapshot, segment: AttackSegment, disor
     return 0
 
   if (segment.damageType === "disorder")
-    return activeActor.panel.attack * (disorderMultiplier ?? multiplier)
+    return activeActor.panel.attack * (disorderMultiplier ?? multiplier) + polarityBaseDamageExtra
 
   return activeActor.panel.attack * multiplier
 }
@@ -1058,7 +1091,7 @@ function isPhysicalAnomaly(segment: AttackSegment): boolean {
     || segment.anomalyContribution?.status === "flinch"
 }
 
-function getDisorderFormula(segment: AttackSegment): {
+function getDisorderFormula(segment: AttackSegment, originalDisorderDamageRatio = 0.15): {
   formulaId: string
   formula: string
   multiplier: number
@@ -1072,8 +1105,8 @@ function getDisorderFormula(segment: AttackSegment): {
       return {
         formulaId,
         remainingDurationSeconds,
-        formula: "polarity disorder multiplier = electric disorder multiplier * 0.15 unless segment.multiplier overrides it",
-        multiplier: segment.multiplier ?? (4.5 + Math.floor(remainingDurationSeconds) * 1.25) * 0.15,
+        formula: "polarity disorder multiplier = electric disorder multiplier * originalDisorderDamageRatio unless segment.multiplier overrides it",
+        multiplier: segment.multiplier ?? (4.5 + Math.floor(remainingDurationSeconds) * 1.25) * originalDisorderDamageRatio,
       }
     case "disorder-burn":
       return {
@@ -1111,6 +1144,48 @@ function getDisorderFormula(segment: AttackSegment): {
         formula: "physical/ice disorder multiplier = 4.5 + floor(T) * 0.075",
         multiplier: 4.5 + Math.floor(remainingDurationSeconds) * 0.075,
       }
+  }
+}
+
+function getPolarityDisorderExtra(snapshot: BattleSnapshot, segment: AttackSegment): {
+  providerActorId: string
+  skillLevelKey: string
+  skillLevel: number
+  anomalyProficiency: number
+  anomalyProficiencyMultiplier: number
+  value: number
+  source?: SourceRef
+} | undefined {
+  const polarity = segment.anomalyContribution?.polarityDisorder
+  if (segment.anomalyContribution?.status !== "polarityDisorder" || polarity === undefined)
+    return undefined
+
+  const provider = snapshot.team.find(candidate => candidate.agentId === polarity.providerActorId)
+  if (provider === undefined)
+    throw new Error("polarityDisorder.providerActorId must reference a team agent")
+
+  const skillLevel = provider.skillLevels?.[polarity.skillLevelKey]
+  if (skillLevel === undefined)
+    throw new Error("polarityDisorder.skillLevelKey must reference an explicit provider skill level")
+  if (skillLevel < 1 || skillLevel > 16)
+    throw new Error("polarityDisorder provider skill level must be between 1 and 16")
+
+  const anomalyProficiency = provider.panel.anomalyProficiency
+  if (anomalyProficiency === undefined)
+    throw new Error("polarityDisorder provider panel.anomalyProficiency is required")
+  const anomalyProficiencyMultiplier = (
+    polarity.anomalyProficiencyBasePercent
+    + skillLevel * polarity.anomalyProficiencyPerSkillLevelPercent
+  ) / 100
+
+  return {
+    providerActorId: polarity.providerActorId,
+    skillLevelKey: polarity.skillLevelKey,
+    skillLevel,
+    anomalyProficiency,
+    anomalyProficiencyMultiplier,
+    value: anomalyProficiency * anomalyProficiencyMultiplier,
+    ...(polarity.source === undefined ? {} : { source: polarity.source }),
   }
 }
 

--- a/packages/core/src/schema/battle-snapshot.ts
+++ b/packages/core/src/schema/battle-snapshot.ts
@@ -124,6 +124,17 @@ export const anomalyContributionInputSchema = z
     overflowBuildup: z.number().finite().optional(),
     remainingDurationSeconds: z.number().finite().nonnegative().optional(),
     contributors: z.array(anomalyContributionActorInputSchema).optional(),
+    polarityDisorder: z
+      .object({
+        providerActorId: z.string().min(1),
+        skillLevelKey: z.string().min(1),
+        originalDisorderDamageRatio: z.number().finite(),
+        anomalyProficiencyBasePercent: z.number().finite(),
+        anomalyProficiencyPerSkillLevelPercent: z.number().finite(),
+        source: sourceRefSchema.optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
 
@@ -273,6 +284,7 @@ export const battleSnapshotSchema = z
   .strict()
   .superRefine((snapshot, ctx) => {
     const teamAgentIds = new Set(snapshot.team.map(agent => agent.agentId))
+    const teamByAgentId = new Map(snapshot.team.map(agent => [agent.agentId, agent]))
 
     if (!teamAgentIds.has(snapshot.activeActor.agentId)) {
       ctx.addIssue({
@@ -288,6 +300,46 @@ export const battleSnapshotSchema = z
           code: "custom",
           path: ["attackSegments", index, "actorId"],
           message: "attackSegments[].actorId must reference a team agent when provided",
+        })
+      }
+
+      const polarityDisorder = segment.anomalyContribution?.polarityDisorder
+      if (polarityDisorder === undefined)
+        return
+
+      const provider = teamByAgentId.get(polarityDisorder.providerActorId)
+      if (provider === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attackSegments", index, "anomalyContribution", "polarityDisorder", "providerActorId"],
+          message: "polarityDisorder.providerActorId must reference a team agent",
+        })
+        return
+      }
+
+      const skillLevel = provider.skillLevels?.[polarityDisorder.skillLevelKey]
+      if (skillLevel === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attackSegments", index, "anomalyContribution", "polarityDisorder", "skillLevelKey"],
+          message: "polarityDisorder.skillLevelKey must reference an explicit provider skill level",
+        })
+        return
+      }
+
+      if (skillLevel < 1 || skillLevel > 16) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["attackSegments", index, "anomalyContribution", "polarityDisorder", "skillLevelKey"],
+          message: "polarityDisorder provider skill level must be between 1 and 16",
+        })
+      }
+
+      if (provider.panel.anomalyProficiency === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["team", snapshot.team.indexOf(provider), "panel", "anomalyProficiency"],
+          message: "polarityDisorder provider panel.anomalyProficiency is required",
         })
       }
     })

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -241,6 +241,112 @@ describe("BattleSnapshot schema", () => {
       issue.path.join(".") === "attackSegments.0.anomalyContribution.status",
     )).toBe(true)
   })
+
+  it("rejects polarity disorder without an explicit provider and supported skill level", () => {
+    const yanagi = {
+      agentId: "yanagi",
+      level: 60,
+      agentSpecialty: "anomaly",
+      attribute: "electric",
+      skillLevels: { special: 12 },
+      panel: {
+        attack: 1600,
+        maxHp: 10000,
+        anomalyProficiency: 300,
+      },
+    }
+    const base = {
+      schemaVersion: "1.0.0",
+      gameVersion: "ZZZ-2.2",
+      ruleSetVersion: "rules-v0.1",
+      dataVersion: "data-v0.1.0",
+      sourceVersion: "source-v0.1.0",
+      team: [minimalAgent, yanagi],
+      activeActor: { agentId: "yixuan" },
+      attackSegments: [
+        {
+          id: "seg-polarity",
+          attribute: "electric",
+          tags: ["exSpecial"],
+          damageType: "disorder",
+          anomalyContribution: {
+            status: "polarityDisorder",
+            remainingDurationSeconds: 5,
+            polarityDisorder: {
+              providerActorId: "yanagi",
+              skillLevelKey: "special",
+              originalDisorderDamageRatio: 0.15,
+              anomalyProficiencyBasePercent: 5,
+              anomalyProficiencyPerSkillLevelPercent: 2.25,
+            },
+          },
+        },
+      ],
+      enemy: {
+        level: 60,
+        rank: "boss",
+      },
+    }
+
+    expect(battleSnapshotSchema.safeParse(base).success).toBe(true)
+
+    const missingProvider = battleSnapshotSchema.safeParse({
+      ...base,
+      team: [minimalAgent],
+    })
+    expect(missingProvider.success).toBe(false)
+    expect(missingProvider.error?.issues.some(issue =>
+      issue.path.join(".") === "attackSegments.0.anomalyContribution.polarityDisorder.providerActorId",
+    )).toBe(true)
+
+    const missingSkillLevel = battleSnapshotSchema.safeParse({
+      ...base,
+      team: [
+        minimalAgent,
+        {
+          ...yanagi,
+          skillLevels: {},
+        },
+      ],
+    })
+    expect(missingSkillLevel.success).toBe(false)
+    expect(missingSkillLevel.error?.issues.some(issue =>
+      issue.path.join(".") === "attackSegments.0.anomalyContribution.polarityDisorder.skillLevelKey",
+    )).toBe(true)
+
+    const outOfRangeSkillLevel = battleSnapshotSchema.safeParse({
+      ...base,
+      team: [
+        minimalAgent,
+        {
+          ...yanagi,
+          skillLevels: { special: 17 },
+        },
+      ],
+    })
+    expect(outOfRangeSkillLevel.success).toBe(false)
+    expect(outOfRangeSkillLevel.error?.issues.some(issue =>
+      issue.message === "polarityDisorder provider skill level must be between 1 and 16",
+    )).toBe(true)
+
+    const missingAnomalyProficiency = battleSnapshotSchema.safeParse({
+      ...base,
+      team: [
+        minimalAgent,
+        {
+          ...yanagi,
+          panel: {
+            attack: 1600,
+            maxHp: 10000,
+          },
+        },
+      ],
+    })
+    expect(missingAnomalyProficiency.success).toBe(false)
+    expect(missingAnomalyProficiency.error?.issues.some(issue =>
+      issue.path.join(".") === "team.1.panel.anomalyProficiency",
+    )).toBe(true)
+  })
 })
 
 describe("CalcResult schema", () => {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -8,8 +8,8 @@ Current state:
 - raw source archives are retained under the repo-level `data/source/`;
 - buhflipexplode and Mihoyo Deadly Assault source snapshots have offline
   verification scripts;
-- V1 golden source candidates and the replay baseline are generated under
-  repo-level `data/cleaned/`;
+- V1 golden source candidates, manual acceptance records, and the replay report
+  are generated under repo-level `data/cleaned/`;
 - `pnpm --filter @fairy/data sync-cleaned` mirrors repo-level cleaned JSON into
   package-local `packages/data/cleaned/` for npm packaging;
 - package exports include TypeScript source/types plus package-local cleaned

--- a/packages/data/cleaned/audit/nicole.acceptance.json
+++ b/packages/data/cleaned/audit/nicole.acceptance.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "fairy-manual-acceptance-v1",
+  "parserVersion": "golden-v1-replay-v0.1.0",
+  "generatedAt": "2026-05-05T18:20:00+08:00",
+  "agentId": "nicole",
+  "records": [
+    {
+      "agentId": "nicole",
+      "effectId": "nicole-defense-reduction",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D4:J4"
+        }
+      ],
+      "sourceTextHash": "07f9d239f43d3deafd4a001cdae349a6f10325cb3bbae090181a00f48e293549",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-core-passive-defense-reduction-v1",
+        "handlerId": "defense-reduction",
+        "bucket": "defenseZone",
+        "appliesTo": {
+          "kind": "enemy"
+        },
+        "params": {
+          "value": 0.4,
+          "corePassiveLevel": 7,
+          "durationSeconds": 3.5
+        },
+        "requiresActivation": true,
+        "activationModel": "snapshotActiveFlag",
+        "inactiveStateMustHaveNoEffect": true
+      }
+    }
+  ]
+}

--- a/packages/data/cleaned/audit/yanagi.acceptance.json
+++ b/packages/data/cleaned/audit/yanagi.acceptance.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": "fairy-manual-acceptance-v1",
+  "parserVersion": "golden-v1-replay-v0.1.0",
+  "generatedAt": "2026-05-05T18:20:00+08:00",
+  "agentId": "yanagi",
+  "records": [
+    {
+      "agentId": "yanagi",
+      "effectId": "yanagi-disorder-boost",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D23:J23"
+        }
+      ],
+      "sourceTextHash": "1d5b17072f8389b59b4f0083ac99c84d2c0e9dd68467a32909c8a5e0938b1462",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-core-passive-disorder-boost-v1",
+        "handlerId": "anomaly-damage-bonus",
+        "bucket": "anomalyDamageBonusZone",
+        "appliesTo": {
+          "kind": "segment"
+        },
+        "params": {
+          "value": 2.5,
+          "corePassiveLevel": 7,
+          "durationSeconds": 15
+        },
+        "requiresActivation": true,
+        "activationModel": "snapshotActiveFlag",
+        "inactiveStateMustHaveNoEffect": true
+      }
+    },
+    {
+      "agentId": "yanagi",
+      "effectId": "yanagi-polarity-disorder-ex-special",
+      "sourceId": "lo-user-excel",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人技能描述!C298"
+        }
+      ],
+      "sourceTextHash": "4ac89b99d4fead4a8cb78d2dfdf84f32a93864cb11c4307e0474d5087bb25f5b",
+      "parserVersion": "golden-v1-replay-v0.1.0",
+      "acceptedBy": "@lo-user",
+      "acceptedAt": "2026-05-05T18:45:21+08:00",
+      "decisionRef": {
+        "target": "#fairy:e2e57d52",
+        "messageId": "6af6f017"
+      },
+      "reason": "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+      "acceptedMapping": {
+        "effectTemplateId": "excel-yanagi-polarity-disorder-v1",
+        "templateKind": "attackSegment.anomalyContribution.polarityDisorder",
+        "handlerId": "polarity-disorder-template",
+        "appliesTo": {
+          "kind": "segment"
+        },
+        "params": {
+          "providerActorId": "yanagi",
+          "skillLevelKey": "special",
+          "originalDisorderDamageRatio": 0.15,
+          "anomalyProficiencyBasePercent": 5,
+          "anomalyProficiencyPerSkillLevelPercent": 2.25,
+          "clearsOriginalAnomaly": false
+        },
+        "supportedSkillLevels": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "requiresActivation": true,
+        "activationModel": "snapshotAttackSegmentTemplate"
+      }
+    }
+  ]
+}

--- a/packages/data/cleaned/golden/v1-replay-report.json
+++ b/packages/data/cleaned/golden/v1-replay-report.json
@@ -5,7 +5,7 @@
   "policy": {
     "scope": "V1 true-data replay harness baseline after DD-002: 19 anchors in V1, G13/G18/G19/G20 deferred.",
     "releaseGate": "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
-    "manualAcceptance": "G22/G23 must emit ERR-DAT-005 until lo-user manual acceptance records exist for the sourceTextHash values in v1-agent-source-candidates.json."
+    "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
   "v1AnchorIds": [
     "G01",
@@ -36,12 +36,12 @@
   ],
   "summary": {
     "v1AnchorCount": 19,
-    "passed": 17,
+    "passed": 19,
     "pendingHarness": 0,
-    "blocked": 2,
+    "blocked": 0,
     "deferred": 4,
-    "blockingDiagnostics": 3,
-    "releaseReady": false
+    "blockingDiagnostics": 0,
+    "releaseReady": true
   },
   "anchors": [
     {
@@ -324,7 +324,7 @@
     },
     {
       "id": "G22",
-      "status": "blocked",
+      "status": "passed",
       "sourceRefs": [
         {
           "sourceId": "lo-user-excel",
@@ -332,30 +332,20 @@
           "sourceAnchor": "代理人核心技描述!D4:J4"
         }
       ],
-      "diagnostics": [
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "ambiguousCondition",
-          "effectId": "nicole-defense-reduction",
-          "sourceTextHash": "07f9d239f43d3deafd4a001cdae349a6f10325cb3bbae090181a00f48e293549",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人核心技描述!D4:J4"
-            }
-          ]
-        }
-      ],
       "notes": [
-        "Source text is extracted and hashed, but replay must not apply inferred Nicole/Yanagi modifiers before manual acceptance."
+        "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+        "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
       ]
     },
     {
       "id": "G23",
-      "status": "blocked",
+      "status": "passed",
       "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "代理人核心技描述!D4:J4"
+        },
         {
           "sourceId": "lo-user-excel",
           "sourceVersion": "2.6.0_R14028417",
@@ -367,38 +357,10 @@
           "sourceAnchor": "代理人技能描述!C298"
         }
       ],
-      "diagnostics": [
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "ambiguousCondition",
-          "effectId": "yanagi-disorder-boost",
-          "sourceTextHash": "1d5b17072f8389b59b4f0083ac99c84d2c0e9dd68467a32909c8a5e0938b1462",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人核心技描述!D23:J23"
-            }
-          ]
-        },
-        {
-          "key": "ERR-DAT-005",
-          "severity": "blocking",
-          "reason": "unknownHandler",
-          "effectId": "yanagi-polarity-disorder-ex-special",
-          "sourceTextHash": "4ac89b99d4fead4a8cb78d2dfdf84f32a93864cb11c4307e0474d5087bb25f5b",
-          "sourceRefs": [
-            {
-              "sourceId": "lo-user-excel",
-              "sourceVersion": "2.6.0_R14028417",
-              "sourceAnchor": "代理人技能描述!C298"
-            }
-          ]
-        }
-      ],
       "notes": [
-        "Source text is extracted and hashed, but replay must not apply inferred Nicole/Yanagi modifiers before manual acceptance."
+        "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+        "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+        "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
       ]
     },
     {

--- a/packages/data/scripts/golden-v1-replay.ts
+++ b/packages/data/scripts/golden-v1-replay.ts
@@ -11,6 +11,8 @@ const repoRoot = join(packageDir, "../..")
 const workbookPath = join(repoRoot, "data/source/excel/data.xlsx")
 const sourceManifestPath = join(repoRoot, "data/source/source-manifest.json")
 const candidatePath = join(repoRoot, "data/cleaned/audit/v1-agent-source-candidates.json")
+const nicoleAcceptancePath = join(repoRoot, "data/cleaned/audit/nicole.acceptance.json")
+const yanagiAcceptancePath = join(repoRoot, "data/cleaned/audit/yanagi.acceptance.json")
 const replayReportPath = join(repoRoot, "data/cleaned/golden/v1-replay-report.json")
 const buhflipexplodeVersionsPath = join(
   repoRoot,
@@ -25,6 +27,16 @@ const sourceId = "lo-user-excel"
 const parserVersion = "golden-v1-replay-v0.1.0"
 const excelSourceVersion = "2.6.0_R14028417"
 const replaySourceVersion = "excel-2.6.0_R14028417+buhflipexplode-2026-05-05T0445Z"
+const manualAcceptance = {
+  acceptedBy: "@lo-user",
+  acceptedAt: "2026-05-05T18:45:21+08:00",
+  decisionRef: {
+    target: "#fairy:e2e57d52",
+    messageId: "6af6f017",
+  },
+  reason:
+    "lo-user confirmed A/B as explicit active/inactive states and C as a skill-level-parameterized formula based on source formula, guide, and context.",
+} as const
 
 const v1AnchorIds = [
   "G01",
@@ -510,6 +522,98 @@ function makeEffectCandidate(input: {
   }
 }
 
+function candidateById(candidates: ReturnType<typeof buildCandidates>, effectId: string) {
+  const candidate = candidates.effectCandidates.find(effect => effect.effectId === effectId)
+  if (candidate === undefined)
+    throw new Error(`Missing effect candidate ${effectId}`)
+  return candidate
+}
+
+function acceptedRecord(
+  candidates: ReturnType<typeof buildCandidates>,
+  effectId: string,
+  acceptedMapping: Record<string, unknown>,
+) {
+  const candidate = candidateById(candidates, effectId)
+  return {
+    agentId: candidate.agentId,
+    effectId,
+    sourceId,
+    sourceRefs: candidate.sourceRefs,
+    sourceTextHash: candidate.sourceTextHash,
+    parserVersion,
+    ...manualAcceptance,
+    acceptedMapping,
+  }
+}
+
+function buildAcceptanceArtifacts(generatedAt: string, candidates: ReturnType<typeof buildCandidates>) {
+  const nicoleDefenseReduction = acceptedRecord(candidates, "nicole-defense-reduction", {
+    effectTemplateId: "excel-core-passive-defense-reduction-v1",
+    handlerId: "defense-reduction",
+    bucket: "defenseZone",
+    appliesTo: { kind: "enemy" },
+    params: {
+      value: 0.4,
+      corePassiveLevel: 7,
+      durationSeconds: 3.5,
+    },
+    requiresActivation: true,
+    activationModel: "snapshotActiveFlag",
+    inactiveStateMustHaveNoEffect: true,
+  })
+
+  const yanagiDisorderBoost = acceptedRecord(candidates, "yanagi-disorder-boost", {
+    effectTemplateId: "excel-core-passive-disorder-boost-v1",
+    handlerId: "anomaly-damage-bonus",
+    bucket: "anomalyDamageBonusZone",
+    appliesTo: { kind: "segment" },
+    params: {
+      value: 2.5,
+      corePassiveLevel: 7,
+      durationSeconds: 15,
+    },
+    requiresActivation: true,
+    activationModel: "snapshotActiveFlag",
+    inactiveStateMustHaveNoEffect: true,
+  })
+
+  const yanagiPolarityDisorder = acceptedRecord(candidates, "yanagi-polarity-disorder-ex-special", {
+    effectTemplateId: "excel-yanagi-polarity-disorder-v1",
+    templateKind: "attackSegment.anomalyContribution.polarityDisorder",
+    handlerId: "polarity-disorder-template",
+    appliesTo: { kind: "segment" },
+    params: {
+      providerActorId: "yanagi",
+      skillLevelKey: "special",
+      originalDisorderDamageRatio: 0.15,
+      anomalyProficiencyBasePercent: 5,
+      anomalyProficiencyPerSkillLevelPercent: 2.25,
+      clearsOriginalAnomaly: false,
+    },
+    supportedSkillLevels: Array.from({ length: 16 }, (_, index) => index + 1),
+    requiresActivation: true,
+    activationModel: "snapshotAttackSegmentTemplate",
+  })
+
+  return {
+    nicole: {
+      schemaVersion: "fairy-manual-acceptance-v1",
+      parserVersion,
+      generatedAt,
+      agentId: "nicole",
+      records: [nicoleDefenseReduction],
+    },
+    yanagi: {
+      schemaVersion: "fairy-manual-acceptance-v1",
+      parserVersion,
+      generatedAt,
+      agentId: "yanagi",
+      records: [yanagiDisorderBoost, yanagiPolarityDisorder],
+    },
+  }
+}
+
 function buildCandidates(generatedAt: string) {
   const { workbook, workbookSha256, workbookVersion } = loadWorkbook()
   return {
@@ -716,7 +820,71 @@ function passedAnchor(id: string, sourceRefs: Array<Record<string, string>>, not
   return { id, status: "passed", sourceRefs, notes }
 }
 
+function acceptanceRecordFor(
+  artifacts: ReturnType<typeof buildAcceptanceArtifacts>,
+  agentId: "nicole" | "yanagi",
+  effectId: string,
+) {
+  const record = artifacts[agentId].records.find(item => item.effectId === effectId)
+  if (record === undefined)
+    throw new Error(`Missing ${agentId} acceptance record for ${effectId}`)
+  return record
+}
+
+function firstSourceRef(record: ReturnType<typeof acceptanceRecordFor>): Record<string, string> {
+  const source = record.sourceRefs[0]
+  if (source === undefined)
+    throw new Error(`Missing accepted source ref for ${record.effectId}`)
+  return source
+}
+
+function nicoleDefenseReductionModifier(
+  artifacts: ReturnType<typeof buildAcceptanceArtifacts>,
+  active: boolean,
+) {
+  const record = acceptanceRecordFor(artifacts, "nicole", "nicole-defense-reduction")
+  return {
+    id: "nicole-defense-reduction",
+    handlerId: "defense-reduction",
+    bucket: "defenseZone",
+    params: { value: 0.4 },
+    appliesTo: { kind: "enemy" },
+    active,
+    source: firstSourceRef(record),
+  }
+}
+
+function yanagiDisorderBoostModifier(
+  artifacts: ReturnType<typeof buildAcceptanceArtifacts>,
+  active: boolean,
+) {
+  const record = acceptanceRecordFor(artifacts, "yanagi", "yanagi-disorder-boost")
+  return {
+    id: "yanagi-disorder-boost",
+    handlerId: "anomaly-damage-bonus",
+    bucket: "anomalyDamageBonusZone",
+    params: { value: 2.5 },
+    appliesTo: { kind: "segment" },
+    when: { field: "segment.damageType", op: "eq", value: "disorder" },
+    active,
+    source: firstSourceRef(record),
+  }
+}
+
+function yanagiPolarityDisorderInput(artifacts: ReturnType<typeof buildAcceptanceArtifacts>) {
+  const record = acceptanceRecordFor(artifacts, "yanagi", "yanagi-polarity-disorder-ex-special")
+  return {
+    providerActorId: "yanagi",
+    skillLevelKey: "special",
+    originalDisorderDamageRatio: 0.15,
+    anomalyProficiencyBasePercent: 5,
+    anomalyProficiencyPerSkillLevelPercent: 2.25,
+    source: firstSourceRef(record),
+  }
+}
+
 function buildReplayReport(generatedAt: string, candidates = buildCandidates(generatedAt)) {
+  const acceptanceArtifacts = buildAcceptanceArtifacts(generatedAt, candidates)
   const enemy = loadBuhflipexplodeBoss()
   const snapshot = baseSnapshot(candidates, enemy)
   const anchors: AnchorReport[] = []
@@ -1165,36 +1333,154 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     anchors.push(passedAnchor("G21", [sourceRef("代理人属性!A37:AF37")], ["One-agent Yixuan path has no teammate modifiers and keeps sheer defense skip."]))
   }
 
-  const effectCandidates = candidates.effectCandidates as Array<{
-    effectId: string
-    goldenAnchors: string[]
-    releaseGateRequired: boolean
-    unparsedEffect: Record<string, unknown>
-    sourceRefs: Array<Record<string, string>>
-  }>
-  for (const anchorId of ["G22", "G23"]) {
-    const diagnostics = effectCandidates
-      .filter(candidate =>
-        candidate.releaseGateRequired === true
-        && candidate.goldenAnchors.includes(anchorId),
-      )
-      .map(candidate => ({
-        key: "ERR-DAT-005",
-        severity: "blocking",
-        reason: candidate.unparsedEffect.reason,
-        effectId: candidate.effectId,
-        sourceTextHash: candidate.unparsedEffect.sourceTextHash,
-        sourceRefs: candidate.sourceRefs,
-      }))
-    anchors.push({
-      id: anchorId,
-      status: "blocked",
-      sourceRefs: diagnostics.flatMap(diagnostic => diagnostic.sourceRefs as Array<Record<string, string>>),
-      diagnostics,
-      notes: [
-        "Source text is extracted and hashed, but replay must not apply inferred Nicole/Yanagi modifiers before manual acceptance.",
+  {
+    const nicoleRecord = acceptanceRecordFor(acceptanceArtifacts, "nicole", "nicole-defense-reduction")
+    const team = [
+      snapshot.team[0]!,
+      agentSnapshot(candidates, "nicole", {
+        attack: 2000,
+        maxHp: 10000,
+        impact: 80,
+        anomalyProficiency: 300,
+        anomalyMastery: 100,
+      }),
+    ]
+    const inactive = calculate({
+      ...snapshot,
+      team,
+      modifiers: [nicoleDefenseReductionModifier(acceptanceArtifacts, false)],
+    })
+    const active = calculate({
+      ...snapshot,
+      team,
+      modifiers: [nicoleDefenseReductionModifier(acceptanceArtifacts, true)],
+    })
+    const inactiveModifier = inactive.modifiers.find(modifier => modifier.id === "nicole-defense-reduction")
+    const activeModifier = active.modifiers.find(modifier => modifier.id === "nicole-defense-reduction")
+    if (inactiveModifier?.active !== false || inactiveModifier.inactiveReason !== "inactive-flag")
+      throw new Error("G22 inactive snapshot must keep Nicole defense reduction disabled")
+    if (activeModifier?.active !== true)
+      throw new Error("G22 active snapshot must apply Nicole defense reduction")
+    assertClose(
+      bucket(inactive, "defenseZone").effectiveMultiplier,
+      bucket(calculate(snapshot), "defenseZone").effectiveMultiplier,
+      0.00001,
+      "G22 inactive defenseZone",
+    )
+    if (active.summary.rawTotalDamage <= inactive.summary.rawTotalDamage)
+      throw new Error("G22 active Nicole defense reduction should increase damage over inactive snapshot")
+    anchors.push(passedAnchor("G22", nicoleRecord.sourceRefs, [
+      "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+      "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7.",
+    ]))
+  }
+
+  {
+    const nicoleRecord = acceptanceRecordFor(acceptanceArtifacts, "nicole", "nicole-defense-reduction")
+    const yanagiDisorderRecord = acceptanceRecordFor(acceptanceArtifacts, "yanagi", "yanagi-disorder-boost")
+    const yanagiPolarityRecord = acceptanceRecordFor(acceptanceArtifacts, "yanagi", "yanagi-polarity-disorder-ex-special")
+    const yanagi = agentSnapshot(candidates, "yanagi", {
+      attack: 1600,
+      maxHp: 10000,
+      impact: 86,
+      anomalyProficiency: 300,
+      anomalyMastery: 112,
+    })
+    const team = [
+      snapshot.team[0]!,
+      agentSnapshot(candidates, "nicole", {
+        attack: 2000,
+        maxHp: 10000,
+        impact: 80,
+        anomalyProficiency: 300,
+        anomalyMastery: 100,
+      }),
+      {
+        ...yanagi,
+        skillLevels: { special: 12 },
+      },
+    ]
+    const polaritySegment = {
+      ...snapshot.attackSegments[0]!,
+      id: "seg-g23-polarity-disorder",
+      attribute: "electric",
+      damageType: "disorder",
+      multiplier: undefined,
+      anomalyContribution: {
+        status: "polarityDisorder",
+        buildup: 100,
+        remainingDurationSeconds: 5,
+        polarityDisorder: yanagiPolarityDisorderInput(acceptanceArtifacts),
+        contributors: [
+          { actorId: "yixuan", buildup: 40, included: true },
+          { actorId: "nicole", buildup: 20, included: true },
+          { actorId: "yanagi", buildup: 40, included: true },
+        ],
+      },
+    } as const
+    const inactive = calculate({
+      ...snapshot,
+      team,
+      attackSegments: [polaritySegment],
+      modifiers: [
+        nicoleDefenseReductionModifier(acceptanceArtifacts, true),
+        yanagiDisorderBoostModifier(acceptanceArtifacts, false),
       ],
     })
+    const active = calculate({
+      ...snapshot,
+      team,
+      attackSegments: [polaritySegment],
+      modifiers: [
+        nicoleDefenseReductionModifier(acceptanceArtifacts, true),
+        yanagiDisorderBoostModifier(acceptanceArtifacts, true),
+      ],
+    })
+    const inactiveModifier = inactive.modifiers.find(modifier => modifier.id === "yanagi-disorder-boost")
+    const activeModifier = active.modifiers.find(modifier => modifier.id === "yanagi-disorder-boost")
+    if (inactiveModifier?.active !== false || inactiveModifier.inactiveReason !== "inactive-flag")
+      throw new Error("G23 inactive snapshot must keep Yanagi disorder boost disabled")
+    if (activeModifier?.active !== true)
+      throw new Error("G23 active snapshot must apply Yanagi disorder boost")
+    if (active.summary.rawTotalDamage <= inactive.summary.rawTotalDamage)
+      throw new Error("G23 active Yanagi disorder boost should increase damage over inactive snapshot")
+    assertClose(
+      trace(active, "attackSegments[0].polarityDisorderBaseDamageExtra").rawValue as number,
+      96,
+      0.00001,
+      "G23 skill level 12 polarity extra",
+    )
+
+    for (let skillLevel = 1; skillLevel <= 16; skillLevel += 1) {
+      const leveled = calculate({
+        ...snapshot,
+        team: [
+          snapshot.team[0]!,
+          team[1]!,
+          {
+            ...yanagi,
+            skillLevels: { special: skillLevel },
+          },
+        ],
+        attackSegments: [polaritySegment],
+      })
+      assertClose(
+        trace(leveled, "attackSegments[0].polarityDisorderBaseDamageExtra").rawValue as number,
+        300 * ((5 + skillLevel * 2.25) / 100),
+        0.00001,
+        `G23 polarity extra skill level ${skillLevel}`,
+      )
+    }
+
+    anchors.push(passedAnchor("G23", [
+      ...nicoleRecord.sourceRefs,
+      ...yanagiDisorderRecord.sourceRefs,
+      ...yanagiPolarityRecord.sourceRefs,
+    ], [
+      "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+      "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+      "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi.",
+    ]))
   }
 
   for (const anchorId of deferredAnchorIds) {
@@ -1211,14 +1497,15 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
   }
 
   const v1Anchors = anchors.filter(anchor => v1AnchorIds.includes(anchor.id as (typeof v1AnchorIds)[number]))
+  const blockingDiagnostics = v1Anchors.flatMap(anchor => anchor.diagnostics ?? []).length
   const summary = {
     v1AnchorCount: v1AnchorIds.length,
     passed: v1Anchors.filter(anchor => anchor.status === "passed").length,
     pendingHarness: v1Anchors.filter(anchor => anchor.status === "pendingHarness").length,
     blocked: v1Anchors.filter(anchor => anchor.status === "blocked").length,
     deferred: anchors.filter(anchor => anchor.status === "deferred").length,
-    blockingDiagnostics: v1Anchors.flatMap(anchor => anchor.diagnostics ?? []).length,
-    releaseReady: false,
+    blockingDiagnostics,
+    releaseReady: v1Anchors.every(anchor => anchor.status === "passed") && blockingDiagnostics === 0,
   }
 
   return {
@@ -1231,7 +1518,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
       releaseGate:
         "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
       manualAcceptance:
-        "G22/G23 must emit ERR-DAT-005 until lo-user manual acceptance records exist for the sourceTextHash values in v1-agent-source-candidates.json.",
+        "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized.",
     },
     v1AnchorIds,
     deferredAnchorIds,
@@ -1242,12 +1529,19 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
 
 function assertArtifactsFresh(generatedAt: string): void {
   const expectedCandidates = buildCandidates(generatedAt)
+  const expectedAcceptance = buildAcceptanceArtifacts(generatedAt, expectedCandidates)
   const expectedReport = buildReplayReport(generatedAt, expectedCandidates)
   const actualCandidates = readJson<unknown>(candidatePath)
+  const actualNicoleAcceptance = readJson<unknown>(nicoleAcceptancePath)
+  const actualYanagiAcceptance = readJson<unknown>(yanagiAcceptancePath)
   const actualReport = readJson<unknown>(replayReportPath)
 
   if (JSON.stringify(actualCandidates) !== JSON.stringify(expectedCandidates))
     throw new Error("V1 source candidates are stale; rerun pnpm --filter @fairy/data audit:golden-v1")
+  if (JSON.stringify(actualNicoleAcceptance) !== JSON.stringify(expectedAcceptance.nicole))
+    throw new Error("Nicole acceptance artifact is stale; rerun pnpm --filter @fairy/data audit:golden-v1")
+  if (JSON.stringify(actualYanagiAcceptance) !== JSON.stringify(expectedAcceptance.yanagi))
+    throw new Error("Yanagi acceptance artifact is stale; rerun pnpm --filter @fairy/data audit:golden-v1")
   if (JSON.stringify(actualReport) !== JSON.stringify(expectedReport))
     throw new Error("V1 replay report is stale; rerun pnpm --filter @fairy/data audit:golden-v1")
 }
@@ -1255,25 +1549,36 @@ function assertArtifactsFresh(generatedAt: string): void {
 function auditCommand(flags: Record<string, string | true>): void {
   const generatedAt = String(flags["generated-at"] ?? new Date().toISOString())
   const candidates = buildCandidates(generatedAt)
+  const acceptanceArtifacts = buildAcceptanceArtifacts(generatedAt, candidates)
   const report = buildReplayReport(generatedAt, candidates)
   writeJson(candidatePath, candidates)
+  writeJson(nicoleAcceptancePath, acceptanceArtifacts.nicole)
+  writeJson(yanagiAcceptancePath, acceptanceArtifacts.yanagi)
   writeJson(replayReportPath, report)
 }
 
 function verifyCommand(): void {
   if (!existsSync(candidatePath))
     throw new Error("Missing data/cleaned/audit/v1-agent-source-candidates.json; run audit:golden-v1 first")
+  if (!existsSync(nicoleAcceptancePath))
+    throw new Error("Missing data/cleaned/audit/nicole.acceptance.json; run audit:golden-v1 first")
+  if (!existsSync(yanagiAcceptancePath))
+    throw new Error("Missing data/cleaned/audit/yanagi.acceptance.json; run audit:golden-v1 first")
   if (!existsSync(replayReportPath))
     throw new Error("Missing data/cleaned/golden/v1-replay-report.json; run audit:golden-v1 first")
 
-  const report = readJson<{ generatedAt: string; summary: { v1AnchorCount: number; blocked: number; pendingHarness: number } }>(replayReportPath)
+  const report = readJson<{ generatedAt: string; summary: { v1AnchorCount: number; blocked: number; pendingHarness: number; blockingDiagnostics: number; releaseReady: boolean } }>(replayReportPath)
   assertArtifactsFresh(report.generatedAt)
   if (report.summary.v1AnchorCount !== 19)
     throw new Error(`Expected 19 V1 anchors, got ${report.summary.v1AnchorCount}`)
-  if (report.summary.blocked !== 2)
-    throw new Error(`Expected G22/G23 to be blocked by manual acceptance, got ${report.summary.blocked} blocked anchors`)
+  if (report.summary.blocked !== 0)
+    throw new Error(`Expected no blocked anchors after G22/G23 manual acceptance, got ${report.summary.blocked}`)
   if (report.summary.pendingHarness !== 0)
     throw new Error(`Expected no pending harness entries after G04/G09/G10 executable assertions, got ${report.summary.pendingHarness}`)
+  if (report.summary.blockingDiagnostics !== 0)
+    throw new Error(`Expected no blocking diagnostics after G22/G23 manual acceptance, got ${report.summary.blockingDiagnostics}`)
+  if (report.summary.releaseReady !== true)
+    throw new Error("Expected V1 golden replay releaseReady=true after all 19 anchors pass")
 }
 
 async function main(): Promise<void> {

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it } from "vitest"
 const repoRoot = join(import.meta.dirname, "../../..")
 const candidatePath = join(repoRoot, "data/cleaned/audit/v1-agent-source-candidates.json")
 const packageCandidatePath = join(repoRoot, "packages/data/cleaned/audit/v1-agent-source-candidates.json")
+const nicoleAcceptancePath = join(repoRoot, "data/cleaned/audit/nicole.acceptance.json")
+const packageNicoleAcceptancePath = join(repoRoot, "packages/data/cleaned/audit/nicole.acceptance.json")
+const yanagiAcceptancePath = join(repoRoot, "data/cleaned/audit/yanagi.acceptance.json")
+const packageYanagiAcceptancePath = join(repoRoot, "packages/data/cleaned/audit/yanagi.acceptance.json")
 const replayReportPath = join(repoRoot, "data/cleaned/golden/v1-replay-report.json")
 const packageReplayReportPath = join(repoRoot, "packages/data/cleaned/golden/v1-replay-report.json")
 
@@ -70,11 +74,11 @@ describe("V1 golden true-data replay baseline", () => {
     expect(report.deferredAnchorIds).toEqual(["G13", "G18", "G19", "G20"])
     expect(report.summary).toMatchObject({
       v1AnchorCount: 19,
-      passed: 17,
+      passed: 19,
       pendingHarness: 0,
-      blocked: 2,
-      blockingDiagnostics: 3,
-      releaseReady: false,
+      blocked: 0,
+      blockingDiagnostics: 0,
+      releaseReady: true,
     })
 
     const g13 = report.anchors.find(anchor => anchor.id === "G13")
@@ -91,29 +95,11 @@ describe("V1 golden true-data replay baseline", () => {
     const g11 = report.anchors.find(anchor => anchor.id === "G11")
     expect(g11?.status).toBe("passed")
     const g22 = report.anchors.find(anchor => anchor.id === "G22")
-    expect(g22?.status).toBe("blocked")
-    expect(g22?.diagnostics).toEqual([
-      expect.objectContaining({
-        key: "ERR-DAT-005",
-        effectId: "nicole-defense-reduction",
-        reason: "ambiguousCondition",
-      }),
-    ])
+    expect(g22?.status).toBe("passed")
+    expect(g22?.notes.join("\n")).toContain("inactive/active snapshot states")
     const g23 = report.anchors.find(anchor => anchor.id === "G23")
-    expect(g23?.diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          key: "ERR-DAT-005",
-          effectId: "yanagi-disorder-boost",
-          reason: "ambiguousCondition",
-        }),
-        expect.objectContaining({
-          key: "ERR-DAT-005",
-          effectId: "yanagi-polarity-disorder-ex-special",
-          reason: "unknownHandler",
-        }),
-      ]),
-    )
+    expect(g23?.status).toBe("passed")
+    expect(g23?.notes.join("\n")).toContain("skill levels 1-16")
   })
 
   it("extracts only the minimal V1 agent rows and source text candidates", () => {
@@ -163,8 +149,57 @@ describe("V1 golden true-data replay baseline", () => {
     ).toBe(true)
   })
 
+  it("records lo-user manual acceptance for G22/G23 source mappings", () => {
+    const nicole = readJson<{
+      records: Array<{
+        effectId: string
+        acceptedBy: string
+        decisionRef: { target: string; messageId: string }
+        acceptedMapping: Record<string, unknown>
+      }>
+    }>(nicoleAcceptancePath)
+    const yanagi = readJson<{
+      records: Array<{
+        effectId: string
+        acceptedBy: string
+        decisionRef: { target: string; messageId: string }
+        acceptedMapping: { supportedSkillLevels?: number[]; inactiveStateMustHaveNoEffect?: boolean }
+      }>
+    }>(yanagiAcceptancePath)
+
+    expect(nicole.records).toHaveLength(1)
+    expect(nicole.records[0]).toMatchObject({
+      effectId: "nicole-defense-reduction",
+      acceptedBy: "@lo-user",
+      decisionRef: { target: "#fairy:e2e57d52", messageId: "6af6f017" },
+      acceptedMapping: {
+        handlerId: "defense-reduction",
+        requiresActivation: true,
+        inactiveStateMustHaveNoEffect: true,
+      },
+    })
+    expect(yanagi.records.map(record => record.effectId)).toEqual([
+      "yanagi-disorder-boost",
+      "yanagi-polarity-disorder-ex-special",
+    ])
+    expect(yanagi.records.every(record =>
+      record.acceptedBy === "@lo-user"
+      && record.decisionRef.messageId === "6af6f017",
+    )).toBe(true)
+    expect(
+      yanagi.records.find(record => record.effectId === "yanagi-disorder-boost")
+        ?.acceptedMapping.inactiveStateMustHaveNoEffect,
+    ).toBe(true)
+    expect(
+      yanagi.records.find(record => record.effectId === "yanagi-polarity-disorder-ex-special")
+        ?.acceptedMapping.supportedSkillLevels,
+    ).toEqual(Array.from({ length: 16 }, (_, index) => index + 1))
+  })
+
   it("keeps the synced package copy byte-identical to cleaned staging", () => {
     expect(readFileSync(packageCandidatePath, "utf8")).toBe(readFileSync(candidatePath, "utf8"))
+    expect(readFileSync(packageNicoleAcceptancePath, "utf8")).toBe(readFileSync(nicoleAcceptancePath, "utf8"))
+    expect(readFileSync(packageYanagiAcceptancePath, "utf8")).toBe(readFileSync(yanagiAcceptancePath, "utf8"))
     expect(readFileSync(packageReplayReportPath, "utf8")).toBe(readFileSync(replayReportPath, "utf8"))
   })
 })


### PR DESCRIPTION
## Summary

- add lo-user manual acceptance artifacts for G22/G23 Nicole/Yanagi source-text mappings
- replay Nicole/Yanagi active effects as explicit inactive/active snapshot states instead of permanent modifiers
- add Yanagi polarity-disorder EX Special template support with skill-level parameterization across levels 1-16
- update V1 golden replay report to `passed=19`, `blocked=0`, `releaseReady=true`
- sync cleaned package payload and docs for the accepted G22/G23 baseline

## Verification

- `pnpm --filter @fairy/core test`
- `pnpm --filter @fairy/data test`
- `pnpm --filter @fairy/data verify:golden-v1`
- `pnpm --filter @fairy/data verify:excel`
- `pnpm --filter @fairy/data verify:buhflipexplode-da`
- `pnpm --filter @fairy/data verify:mihoyo-da`
- `pnpm check`
- `pnpm test`
- `jq empty data/cleaned/audit/v1-agent-source-candidates.json data/cleaned/audit/nicole.acceptance.json data/cleaned/audit/yanagi.acceptance.json data/cleaned/golden/v1-replay-report.json packages/data/cleaned/audit/v1-agent-source-candidates.json packages/data/cleaned/audit/nicole.acceptance.json packages/data/cleaned/audit/yanagi.acceptance.json packages/data/cleaned/golden/v1-replay-report.json`
- `git diff --check`
- `pnpm --filter @fairy/data pack --pack-destination /tmp --json`

## Notes

- Acceptance source: lo-user message in `#fairy:e2e57d52`, `messageId=6af6f017`, 2026-05-05 18:45:21 +08:00.
- G13/G18/G19/G20 remain V1.x deferred per DD-002; this PR only clears G22/G23.
