### PR TITLE
docs: add V1 dogfooding quick start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,10 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 ## Read First
 
 1. Project map: [docs/index.md](docs/index.md)
-2. Product scope: [docs/product/v2.0.md](docs/product/v2.0.md)
-3. Terminology: [docs/glossary/glossary.md](docs/glossary/glossary.md)
-4. Data contracts: [docs/data-contract/](docs/data-contract/)
+2. V1 dogfooding quick start: [docs/getting-started.md](docs/getting-started.md)
+3. Product scope: [docs/product/v2.0.md](docs/product/v2.0.md)
+4. Terminology: [docs/glossary/glossary.md](docs/glossary/glossary.md)
+5. Data contracts: [docs/data-contract/](docs/data-contract/)
 
 ## Current Rules
 
@@ -34,3 +35,4 @@ S5 data ingestion. Current engineering entry points:
 - `packages/core/src/engine/`
 - `packages/cli/`
 - `packages/data/`
+- `examples/snapshots/`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ V1 focuses on a TypeScript monorepo with three packages:
 
 Start with [docs/index.md](docs/index.md).
 
+## V1 Dogfooding Status
+
+V1 is currently validated through lo-user single-person dogfooding plus QA
+regression. It has not gone through broad community dogfooding yet.
+
+Use [docs/getting-started.md](docs/getting-started.md) for the repo-local
+dogfooding flow and executable examples.
+
 ## Development
 
 Fairy uses pnpm workspaces. See [docs/architecture/monorepo-development.md](docs/architecture/monorepo-development.md) for package boundaries, dependency rules, verification commands, and PR workflow.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,130 @@
+# Fairy V1 Dogfooding Quick Start
+
+Status: V1 dogfood candidate
+
+Fairy V1 is currently a repo-local CLI baseline. It is not published as a
+global npm package yet. Use this guide for dogfooding and pre-release review.
+
+V1 dogfooding is currently scoped to lo-user single-person deep validation plus
+QA regression. It has not gone through broad community dogfooding yet.
+
+## 1. Prepare a Clean Checkout
+
+```bash
+git clone https://github.com/LoTwT/fairy.git
+cd fairy
+
+# Optional: if Product provides a dogfood tag or commit, check it out here.
+# git checkout <dogfood-tag-or-commit>
+
+pnpm install --frozen-lockfile
+pnpm check
+pnpm test
+pnpm --filter @fairy/data verify:golden-v1
+```
+
+## 2. Run the First Example
+
+Use the root alias scripts for the first pass. Keep `--silent` so stdout is
+pure JSON and can be piped to `jq`.
+
+```bash
+pnpm --silent fairy:s1 | jq '.summary'
+pnpm --silent fairy:s2 | jq '.summary'
+pnpm --silent fairy:s3 | jq '.summary'
+```
+
+The examples are strict JSON files under `examples/snapshots/`:
+
+| Script | Snapshot | Scenario |
+|---|---|---|
+| `pnpm --silent fairy:s1` | `examples/snapshots/s1-yixuan-sheer.json` | S1 Yixuan sheer damage against Corruption Priest |
+| `pnpm --silent fairy:s2` | `examples/snapshots/s2-yanagi-disorder.json` | S2 Yanagi shock disorder against Pompey |
+| `pnpm --silent fairy:s3` | `examples/snapshots/s3-team-g22-g23-acceptance.json` | S3 V1 G22/G23 manual-acceptance demo with Nicole and Yanagi accepted effects |
+
+The narrative source for S1 and S2 is
+[`docs/ux/starter-scenarios.md`](ux/starter-scenarios.md). That document uses
+JSONC for explanation and AI-plugin context; the files in `examples/snapshots/`
+are executable strict JSON for CLI dogfooding.
+
+S3 is a V1 executable variant for the accepted G22/G23 Nicole/Yanagi effects.
+It intentionally differs from the starter-scenarios S3 narrative, which still
+uses Lycaon as a broader target-state modifier propagation example. Lycaon typed
+modifier acceptance is outside the current V1 dogfooding gate.
+
+S2 does not simulate the full EX Special -> anomaly buildup -> trigger timeline.
+V1 treats `anomalyContribution.buildup=100` as a user-provided snapshot state:
+the anomaly is already ready to settle for this calculation.
+
+## 3. Use the Full CLI
+
+The root alias forwards arguments to `@fairy/cli`:
+
+```bash
+pnpm --silent fairy -- help --pretty
+pnpm --silent fairy -- calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty
+pnpm --silent fairy -- explain examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty
+pnpm --silent fairy -- scan examples/snapshots/s1-yixuan-sheer.json --path 'team[0].panel.attack' --from 1000 --to 2000 --step 100 --pretty
+```
+
+Use the package-level command when you want the exact underlying invocation:
+
+```bash
+pnpm --silent --filter @fairy/cli run cli -- calc ../../examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty
+```
+
+The package-level command runs with `packages/cli` as its working directory;
+that is why the example path uses `../../examples/...`. Prefer the root
+`pnpm --silent fairy -- ...` alias for dogfooding.
+
+The CLI accepts `-` for stdin:
+
+```bash
+cat examples/snapshots/s1-yixuan-sheer.json \
+  | pnpm --silent fairy -- calc - --lang zh --pretty
+```
+
+## 4. What to Inspect
+
+Every CLI command writes JSON to stdout. For `calc`, start with:
+
+- `summary.displayTotalDamage`
+- `summary.rawTotalDamage`
+- `attackSegments[]`
+- `buckets[]`
+- `modifiers[]`
+- `trace[]`
+- `warnings[]`
+- `errors[]`
+
+Warnings and errors are also rendered to stderr in the selected `--lang zh|en`
+language. JSON diagnostic keys remain language-independent.
+
+## 5. Dogfooding Feedback
+
+When reporting feedback, include:
+
+1. The command you ran.
+2. The snapshot file or edited JSON.
+3. The relevant stdout/stderr.
+4. Whether `jq empty` can parse stdout.
+5. What was confusing or numerically wrong.
+
+Feedback routing:
+
+| Feedback | Owner |
+|---|---|
+| Calculation mismatch, crash, schema failure | TechLead + QA |
+| `ERR-*` copy is unclear | UX |
+| Starter scenario or example is hard to use | UX |
+| Missing scenario or unsupported feature | Product backlog for V1.x |
+
+## 6. Current V1 Boundaries
+
+- V1 is a static `BattleSnapshot` calculator, not a battle timeline simulator.
+- V1 does not yet provide a Web UI or automatic character/equipment resolver.
+- Users provide or edit explicit JSON snapshots.
+- The V1 golden gate is 19 anchors passed with zero blocking diagnostics.
+- The V1 dogfooding gate is lo-user single-person deep validation plus QA
+  regression; broad community validation is deferred.
+- G13, G18, G19, and G20 are intentionally deferred to V1.x.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 
 ## 快速入口
 
+- V1 dogfooding 上手：[getting-started.md](getting-started.md)
 - 项目范围与里程碑：[product/v2.0.md](product/v2.0.md)
 - 术语权威：[glossary/glossary.md](glossary/glossary.md)
 - 数据契约：[data-contract/](data-contract/)
@@ -32,3 +33,4 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - 米游社危局强袭战 source snapshot：[data-source/mihoyo/](data-source/mihoyo/)
 - buhflipexplode 危局强袭战 source snapshot：[data-source/buhflipexplode/](data-source/buhflipexplode/)
 - V1 golden source coverage：[qa/golden-source-coverage.md](qa/golden-source-coverage.md)
+- Starter scenarios narrative：[ux/starter-scenarios.md](ux/starter-scenarios.md)

--- a/examples/snapshots/s1-yixuan-sheer.json
+++ b/examples/snapshots/s1-yixuan-sheer.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.7.3",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "data-v0.1.0",
+  "sourceVersion": "dogfood-examples-v0.1.0",
+  "team": [
+    {
+      "agentId": "yixuan",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "skillLevels": {
+        "basic": 9,
+        "dodge": 9,
+        "chain": 9,
+        "core": 6,
+        "special": 12
+      },
+      "panel": {
+        "attack": 3000,
+        "maxHp": 18305,
+        "defense": 718,
+        "impact": 93,
+        "critRate": 0.554,
+        "critDamage": 2.004,
+        "penetrationRate": 0,
+        "flatPenetration": 0,
+        "anomalyProficiency": 117,
+        "anomalyMastery": 92,
+        "sheerForce": 2423
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "yixuan"
+  },
+  "attackSegments": [
+    {
+      "id": "s1-yixuan-ex-special-sheer",
+      "actorId": "yixuan",
+      "skillId": "yixuan.exSpecial.sigilShroudBreak",
+      "levelKey": "special",
+      "multiplier": 12,
+      "baseDazeMultiplier": 3.741,
+      "attribute": "auricInk",
+      "tags": [
+        "exSpecial",
+        "heavyHit"
+      ],
+      "damageType": "sheer",
+      "distanceDecay": 1,
+      "source": {
+        "sourceId": "fairy-starter-scenario",
+        "sourceVersion": "v0.4.1",
+        "sourceAnchor": "docs/ux/starter-scenarios.md#scenario-s1"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "corruptionPriest",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "ether": 0.4
+    },
+    "corruptedShield": {
+      "active": true,
+      "defenseMultiplier": 1.8
+    },
+    "states": [
+      "corruptedDomain"
+    ],
+    "anomalyTriggerCounts": {
+      "corruption": 0
+    }
+  },
+  "modifiers": [],
+  "manualEvents": []
+}

--- a/examples/snapshots/s2-yanagi-disorder.json
+++ b/examples/snapshots/s2-yanagi-disorder.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.7.3",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "data-v0.1.0",
+  "sourceVersion": "dogfood-examples-v0.1.0",
+  "team": [
+    {
+      "agentId": "yanagi",
+      "level": 60,
+      "agentSpecialty": "anomaly",
+      "attribute": "electric",
+      "skillLevels": {
+        "special": 12
+      },
+      "panel": {
+        "attack": 2400,
+        "maxHp": 10000,
+        "defense": 600,
+        "impact": 86,
+        "critRate": 0.3,
+        "critDamage": 1.5,
+        "anomalyProficiency": 600,
+        "anomalyMastery": 450
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "yanagi"
+  },
+  "attackSegments": [
+    {
+      "id": "s2-yanagi-shock-disorder",
+      "actorId": "yanagi",
+      "skillId": "yanagi.disorder.shock",
+      "multiplier": 1,
+      "attribute": "electric",
+      "tags": [
+        "exSpecial"
+      ],
+      "damageType": "disorder",
+      "anomalyContribution": {
+        "status": "shock",
+        "buildup": 100,
+        "remainingDurationSeconds": 5,
+        "contributors": [
+          {
+            "actorId": "yanagi",
+            "buildup": 100,
+            "included": true,
+            "source": {
+              "sourceId": "fairy-starter-scenario",
+              "sourceVersion": "v0.4.1",
+              "sourceAnchor": "docs/ux/starter-scenarios.md#scenario-s2"
+            }
+          }
+        ]
+      },
+      "source": {
+        "sourceId": "fairy-starter-scenario",
+        "sourceVersion": "v0.4.1",
+        "sourceAnchor": "docs/ux/starter-scenarios.md#scenario-s2"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "pompey",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "electric": 0.4
+    },
+    "anomalyTriggerCounts": {
+      "shock": 0
+    },
+    "states": []
+  },
+  "modifiers": [],
+  "manualEvents": []
+}

--- a/examples/snapshots/s3-team-g22-g23-acceptance.json
+++ b/examples/snapshots/s3-team-g22-g23-acceptance.json
@@ -1,0 +1,169 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.7.3",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "data-v0.1.0",
+  "sourceVersion": "dogfood-examples-v0.1.0",
+  "team": [
+    {
+      "agentId": "yixuan",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "panel": {
+        "attack": 1000,
+        "maxHp": 12000,
+        "defense": 600,
+        "impact": 120,
+        "critRate": 0,
+        "critDamage": 0,
+        "anomalyProficiency": 300,
+        "anomalyMastery": 100,
+        "sheerForce": 1000
+      }
+    },
+    {
+      "agentId": "nicole",
+      "level": 60,
+      "agentSpecialty": "support",
+      "attribute": "ether",
+      "panel": {
+        "attack": 2000,
+        "maxHp": 10000,
+        "defense": 600,
+        "impact": 80,
+        "critRate": 0.1,
+        "critDamage": 0.5,
+        "anomalyProficiency": 300,
+        "anomalyMastery": 100
+      }
+    },
+    {
+      "agentId": "yanagi",
+      "level": 60,
+      "agentSpecialty": "anomaly",
+      "attribute": "electric",
+      "skillLevels": {
+        "special": 12
+      },
+      "panel": {
+        "attack": 1600,
+        "maxHp": 10000,
+        "defense": 600,
+        "impact": 86,
+        "critRate": 0.3,
+        "critDamage": 1.5,
+        "anomalyProficiency": 300,
+        "anomalyMastery": 112
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "yixuan"
+  },
+  "attackSegments": [
+    {
+      "id": "s3-yanagi-polarity-disorder",
+      "actorId": "yixuan",
+      "skillId": "yanagi.exSpecial.polarityDisorder",
+      "attribute": "electric",
+      "tags": [
+        "exSpecial"
+      ],
+      "damageType": "disorder",
+      "anomalyContribution": {
+        "status": "polarityDisorder",
+        "buildup": 100,
+        "remainingDurationSeconds": 5,
+        "contributors": [
+          {
+            "actorId": "yixuan",
+            "buildup": 40,
+            "included": true
+          },
+          {
+            "actorId": "nicole",
+            "buildup": 20,
+            "included": true
+          },
+          {
+            "actorId": "yanagi",
+            "buildup": 40,
+            "included": true
+          }
+        ],
+        "polarityDisorder": {
+          "providerActorId": "yanagi",
+          "skillLevelKey": "special",
+          "originalDisorderDamageRatio": 0.15,
+          "anomalyProficiencyBasePercent": 5,
+          "anomalyProficiencyPerSkillLevelPercent": 2.25,
+          "source": {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人技能描述!C298"
+          }
+        }
+      },
+      "source": {
+        "sourceId": "fairy-starter-scenario",
+        "sourceVersion": "v0.4.1",
+        "sourceAnchor": "docs/ux/starter-scenarios.md#scenario-s3"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "corruptionPriest",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "states": [
+      "dazed"
+    ],
+    "corruptedShield": {
+      "active": false
+    }
+  },
+  "modifiers": [
+    {
+      "id": "support-defense-reduction",
+      "handlerId": "defense-reduction",
+      "bucket": "defenseZone",
+      "params": {
+        "value": 0.4
+      },
+      "appliesTo": {
+        "kind": "enemy"
+      },
+      "active": true,
+      "source": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4"
+      }
+    },
+    {
+      "id": "yanagi-disorder-boost",
+      "handlerId": "anomaly-damage-bonus",
+      "bucket": "anomalyDamageBonusZone",
+      "params": {
+        "value": 2.5
+      },
+      "appliesTo": {
+        "kind": "segment"
+      },
+      "when": {
+        "field": "segment.damageType",
+        "op": "eq",
+        "value": "disorder"
+      },
+      "active": true,
+      "source": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D23:J23"
+      }
+    }
+  ],
+  "manualEvents": []
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "scripts": {
     "check": "pnpm -r --if-present check",
+    "fairy": "node packages/cli/bin/fairy.js",
+    "fairy:s1": "node packages/cli/bin/fairy.js calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty",
+    "fairy:s2": "node packages/cli/bin/fairy.js calc examples/snapshots/s2-yanagi-disorder.json --lang zh --pretty",
+    "fairy:s3": "node packages/cli/bin/fairy.js calc examples/snapshots/s3-team-g22-g23-acceptance.json --lang zh --pretty",
     "test": "pnpm -r --if-present test"
   },
   "devDependencies": {

--- a/packages/cli/src/examples.test.ts
+++ b/packages/cli/src/examples.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { readdirSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+const examplesDir = resolve(repoRoot, "examples/snapshots")
+
+describe("dogfooding examples", () => {
+  const exampleFiles = readdirSync(examplesDir)
+    .filter(file => file.endsWith(".json"))
+    .sort()
+
+  it("keeps all example snapshots as strict JSON", () => {
+    expect(exampleFiles.length).toBeGreaterThan(0)
+
+    for (const file of exampleFiles) {
+      const text = readFileSync(resolve(examplesDir, file), "utf8")
+      expect(() => JSON.parse(text), file).not.toThrow()
+    }
+  })
+
+  it("runs every example snapshot through calc with JSON-only stdout", () => {
+    for (const file of exampleFiles) {
+      const run = spawnSync("pnpm", [
+        "--silent",
+        "--filter",
+        "@fairy/cli",
+        "run",
+        "cli",
+        "--",
+        "calc",
+        resolve(examplesDir, file),
+        "--lang",
+        "zh",
+      ], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      })
+      const parsed = JSON.parse(run.stdout) as { errors: unknown[] }
+
+      expect(run.status, `${file} exit status\nstderr:\n${run.stderr}`).toBe(0)
+      expect(run.stderr, `${file} stderr`).toBe("")
+      expect(parsed.errors, `${file} result errors`).toEqual([])
+    }
+  })
+
+  it("keeps root example aliases JSON-only when called with pnpm --silent", () => {
+    for (const script of ["fairy:s1", "fairy:s2", "fairy:s3"]) {
+      const run = spawnSync("pnpm", ["--silent", script], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      })
+      const parsed = JSON.parse(run.stdout) as { errors: unknown[] }
+
+      expect(run.status, `${script} exit status\nstderr:\n${run.stderr}`).toBe(0)
+      expect(run.stderr, `${script} stderr`).toBe("")
+      expect(parsed.errors, `${script} result errors`).toEqual([])
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add repo-local V1 dogfooding quick start and README/CLAUDE/docs index entry points
- add executable strict JSON S1/S2/S3 snapshots under examples/snapshots
- add root pnpm aliases and CLI tests that verify examples are strict JSON and JSON-only stdout

## Verification
- pnpm install --frozen-lockfile
- pnpm check
- pnpm test
- pnpm --filter @fairy/data verify:golden-v1
- pnpm --filter @fairy/data verify:excel
- pnpm --filter @fairy/data verify:buhflipexplode-da
- pnpm --filter @fairy/data verify:mihoyo-da
- pnpm --silent fairy:s1 | jq empty
- pnpm --silent fairy:s2 | jq empty
- pnpm --silent fairy:s3 | jq empty
- pnpm --silent fairy -- scan examples/snapshots/s1-yixuan-sheer.json --path 'team[0].panel.attack' --from 1000 --to 2000 --step 500 --pretty | jq '.rows | length'
- pnpm --filter @fairy/data pack --pack-destination /tmp --json
- git diff --check

## Review notes
- @UX please verify the executable snapshots preserve starter-scenario semantics.
- @QA please review the clean-checkout copy/paste path, strict JSON examples, JSON-only stdout, and package payload exclusion.
