### PR TITLE
feat(cli): add D-19 summary-first calc output

### DIFF
--- a/docs/data-contract/calc-result.md
+++ b/docs/data-contract/calc-result.md
@@ -50,6 +50,19 @@ interface CalcSummary {
   activeActorId: string
   enemyId?: string
   damageType: DamageType
+  lanes: {
+    nonCrit?: DamageLane
+    crit?: DamageLane
+    fixed?: DamageLane
+  }
+  daze?: {
+    value: number
+    ratioRaw?: number
+    ratioDisplay?: number
+  }
+
+  // Deprecated transition fields. Kept in verbose/full results for V1
+  // compatibility; default CLI brief output does not expose them.
   rawTotalDamage: number
   displayTotalDamage: number
   expectedDamage?: number
@@ -60,11 +73,28 @@ interface CalcSummary {
   disorderDamage?: number
   trueDamage?: number
 }
+
+interface DamageLane {
+  rawDamage: number
+  displayDamage: number
+}
 ```
 
-`rawTotalDamage` is the theoretical sum before display rounding.
-`displayTotalDamage` is the game-style displayed total after each segment has
-been rounded according to the segment rounding rule.
+`lanes.nonCrit` and `lanes.crit` are the default user-facing damage outcomes
+for standard crittable damage (`regular` / `sheer`). They are deterministic
+branches, not a crit-rate expectation. `lanes.fixed` is used for deterministic
+damage paths such as anomaly/disorder/daze/manual events; when a calculation
+mixes crittable and fixed damage, the fixed amount is also included in the
+non-crit and crit lane totals.
+
+`daze.value` is the accumulated daze value. When `enemy.dazeCap` is available,
+`daze.ratioRaw` is `daze.value / enemy.dazeCap * 100`, and
+`daze.ratioDisplay` is the floored in-game percentage display.
+
+`rawTotalDamage`, `displayTotalDamage`, and `expectedDamage` are retained for
+V1 transition compatibility and full trace/audit views. New CLI/user-facing
+renderers should prefer `lanes` and only request expectation explicitly through
+`--result-mode expected`.
 
 ## 3. Segment Results
 

--- a/docs/data-contract/snapshot-schema.md
+++ b/docs/data-contract/snapshot-schema.md
@@ -136,9 +136,20 @@ interface CalcSummary {
   activeActorId: string         // 谁打出的 → AI prompt: "{{活动代理人}} 的"
   enemyId?: string              // 打了谁
   damageType: DamageType        // regular / sheer / anomaly / disorder / trueDamage / daze（与 TL-3/PR #7 锁定一致）
+  lanes: {
+    nonCrit?: { rawDamage: number; displayDamage: number }
+    crit?: { rawDamage: number; displayDamage: number }
+    fixed?: { rawDamage: number; displayDamage: number }
+  }
+  daze?: {
+    value: number
+    ratioRaw?: number
+    ratioDisplay?: number
+  }
+  // Deprecated transition fields, kept for verbose/full compatibility.
   rawTotalDamage: number        // 理论值（不取整）
   displayTotalDamage: number    // 游戏显示值（每段向上取整后求和）
-  expectedDamage?: number       // 期望值（含 critRate * critDamage 加权）
+  expectedDamage?: number       // 可选期望值（仅显式 result-mode=expected 时作为理论分析）
   critDamage?: number           // 暴击数值
   nonCritDamage?: number        // 非暴击数值
   dazeValue?: number            // 该次累积的失衡值
@@ -149,14 +160,14 @@ interface CalcSummary {
 ```
 
 **UX 渲染优先级**：
-- `tiny`：`expectedDamage` / `critDamage` / `nonCritDamage` 三档
-- `brief`：tiny + `damageType` + warnings 摘要
-- `verbose`：brief + `rawTotalDamage` vs `displayTotalDamage`（多段取整差异）
+- `tiny`：`lanes.nonCrit.displayDamage` / `lanes.crit.displayDamage` 双栏
+- `brief`：tiny + `damageType` + `daze` + warnings 摘要
+- `verbose`：brief + legacy `rawTotalDamage` vs `displayTotalDamage`（多段取整差异）+ full trace evidence
 - `debug`：完整字段 + dazeValue / dazeRatioRaw / dazeRatioDisplay / anomalyBuildup / disorderDamage / trueDamage 副输出
 
 **易混淆**：
 - `rawTotalDamage` 是**理论**总伤（不取整）；`displayTotalDamage` 是**游戏内显示**总伤（每段向上取整后求和）。**两者通常不相等**（攻略 PART 01 开头硬规则）。
-- `expectedDamage` 是统计意义上的**期望**（含暴击概率加权）；不是"显示值"。
+- `expectedDamage` 是统计意义上的**期望**（含暴击概率加权）；不是默认显示结果，只在显式 expected 模式 / verbose 审计里出现。
 
 ### 2.3 attackSegments / SegmentResult：多段证据
 
@@ -277,10 +288,10 @@ UX 心智：用户在 UI 上点"添加一次秽盾净除事件 + 选规则版本
 
 | 字段 | tiny | brief | verbose | debug |
 |---|---|---|---|---|
-| `summary.expectedDamage` | ✓ | ✓ | ✓ | ✓ |
-| `summary.critDamage` / `nonCritDamage` | ✓ | ✓ | ✓ | ✓ |
+| `summary.lanes.nonCrit` / `lanes.crit` | ✓ | ✓ | ✓ | ✓ |
+| `summary.expectedDamage` | — | — | 可选 | ✓ |
 | `summary.damageType` | — | ✓ | ✓ | ✓ |
-| `summary.rawTotalDamage` vs `displayTotalDamage` | — | — | ✓ | ✓ |
+| `summary.rawTotalDamage` vs `displayTotalDamage` | — | — | legacy | ✓ |
 | `attackSegments[]` 逐段 | — | — | （多段时简表） | 完整 |
 | `buckets[]` top 3 contributors | — | ✓ | — | — |
 | `buckets[]` 完整 | — | — | ✓ | ✓ |
@@ -303,7 +314,7 @@ UX 心智：用户在 UI 上点"添加一次秽盾净除事件 + 选规则版本
 
 1. **glossary v0.4 errata**：`mindscape` 主名 → `mindscapeCinema`；`driveDisc` → `driveDiscs`（plural 字段）+ `DriveDisc`（singular 类型名）双名约定；`stagger` → `daze*` 全套确认
 2. **UX-2 starter scenarios JSON skeleton 同步**：S1 / S2 / S3 三个 BattleSnapshot 替换为 TL-3 真实字段（`mindscapeCinema` / `driveDiscs` / `panelSnapshot` 改 `panel` / 加 `attribute` / `agentSpecialty` / `attackSegments[]` / `enemy` 完整结构）
-3. **UX-3 prompt-templates 字段映射 v1.0**：把 `{{placeholder}}` 占位符全部填实成 TL-3 真实字段路径（如 `result.summary.expectedDamage` / `result.buckets[?bucketId=defenseZone]` 等）
+3. **UX-3 prompt-templates 字段映射 v1.0**：把 `{{placeholder}}` 占位符全部填实成 TL-3/D-19 真实字段路径（如 `result.summary.lanes.nonCrit.displayDamage` / `result.buckets[?bucketId=defenseZone]` 等）
 4. **错误文案库扩展**：随 ERR-VER-* 双路径具体化、ERR-EVENT-* 真实伤害事件错误（如缺 baseValue）等新增条目
 5. **本文档**最终路径 = `docs/data-contract/snapshot-schema.md`（与 Product UX-4 任务描述一致）；UX 维护内容 + TL 维护可执行 schema 引用边界
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,7 @@ The examples are strict JSON files under `examples/snapshots/`:
 | `pnpm --silent fairy:s1` | `examples/snapshots/s1-yixuan-sheer.json` | S1 Yixuan sheer damage against Corruption Priest |
 | `pnpm --silent fairy:s2` | `examples/snapshots/s2-yanagi-disorder.json` | S2 Yanagi shock disorder against Pompey |
 | `pnpm --silent fairy:s3` | `examples/snapshots/s3-team-g22-g23-acceptance.json` | S3 V1 G22/G23 manual-acceptance demo with Nicole and Yanagi accepted effects |
+| direct file | `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` | Dogfooding regression: Anby core F basic 16 vs Dullahan defense 952.8 |
 
 The narrative source for S1 and S2 is
 [`docs/ux/starter-scenarios.md`](ux/starter-scenarios.md). That document uses
@@ -63,6 +64,7 @@ The root alias forwards arguments to `@fairy/cli`:
 ```bash
 pnpm --silent fairy -- help --pretty
 pnpm --silent fairy -- calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty
+pnpm --silent fairy -- calc examples/snapshots/s1-yixuan-sheer.json --lang zh --view verbose --pretty
 pnpm --silent fairy -- explain examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty
 pnpm --silent fairy -- scan examples/snapshots/s1-yixuan-sheer.json --path 'team[0].panel.attack' --from 1000 --to 2000 --step 100 --pretty
 ```
@@ -88,14 +90,20 @@ cat examples/snapshots/s1-yixuan-sheer.json \
 
 Every CLI command writes JSON to stdout. For `calc`, start with:
 
-- `summary.displayTotalDamage`
-- `summary.rawTotalDamage`
-- `attackSegments[]`
-- `buckets[]`
-- `modifiers[]`
-- `trace[]`
+- `summary.lanes.nonCrit.displayDamage`
+- `summary.lanes.crit.displayDamage`
+- `summary.daze.value`
 - `warnings[]`
 - `errors[]`
+
+`fairy calc` defaults to `--view brief`, so it only prints the summary-first
+shape plus diagnostics. Use `--view verbose` when you need legacy full fields
+such as `summary.rawTotalDamage`, `attackSegments[]`, `buckets[]`,
+`modifiers[]`, and `trace[]`.
+
+Use `--result-mode expected` only for statistical/theory checks. The default
+brief view shows deterministic non-crit and crit lanes instead of crit-rate
+expectation.
 
 Warnings and errors are also rendered to stderr in the selected `--lang zh|en`
 language. JSON diagnostic keys remain language-independent.

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -29,6 +29,7 @@
 | **D-14** | cleaned data typed modifier 双层结构 | ✅ 锁定（2026-05-05） | Layer 1 原文层 `sourceText` / `localizedText` + Layer 2 计算层 `modifiers[]` / `calculationEffects[]` + 风险层 `unparsedEffects[]`；bucket 受控 enum 严格匹配 glossary v0.4 D-11；效果 4 级（L1 静态 / L2 静态条件 / L3 动态参数 / L4 时序需 `requiresActivation`）；确定性 pipeline + sourceTextHash + parserVersion + effectTemplateId + 人工 audit gate；AI 候选不能直接入 cleaned | 中 |
 | **D-15** | V1 package exports 4 入口 | ✅ 锁定（2026-05-05） | V1 全做：`@fairy/data/cleaned`（总入口）/ `@fairy/data/cleaned/<domain>` / `@fairy/data/types` / `@fairy/data/cleaned/i18n/<domain>`；data 包 game labels 源码 `packages/data/src/i18n/` → 发布 `packages/data/cleaned/i18n/`；UX ERR-* `docs/ux/i18n/` 完全独立 | 中 |
 | **D-16** | Source priority + multi-source + unknown policy | ✅ 锁定（2026-05-05） | Excel base / buhflipexplode DA overlay / 米游社 i18n；冲突 fail loud + manual review；entity-level `sources[]` + 关键数值字段级 `sourceRefs`；unknown 分级 blocking（影响计算）/ non-blocking（纯展示）；新增 ERR-DAT-005（multi-source conflict / 未解析 modifier blocking）+ ERR-DAT-006（locale mapping unresolved / 展示缺失 non-blocking，与 PR #21 cleaned schema spec 锁定一致） | 中 |
+| **D-19** | V1 CLI 输出改革 | ✅ 锁定（2026-05-06） | `fairy calc` 默认 `--view brief` summary-first；完整 trace 通过 `--view verbose`；默认输出 `summary.lanes.nonCrit` / `summary.lanes.crit`，不使用期望伤害；`--result-mode expected` 保留为可选理论分析；其他二元输入差异通过 `fairy compare` | 中 |
 | **D-1=D**（S2 节奏） | V1 推进顺序 | ✅ 锁定 | S2 双门槛：schema discovery + 并行 scraper 准备；S6 全量化最后；不允许 data 全量化阻塞 core 启动 | 中 |
 
 ---
@@ -214,6 +215,26 @@
 - `ERR-DAT-006` non-blocking：locale mapping unresolved / 展示缺失（与 PR #21 cleaned schema spec 锁定一致；不再使用 ERR-UI-004 占位）
 
 **来源**：会议纪要 §2.9 / §2.10 / §2.11
+
+### D-19 V1 CLI 输出改革
+
+**锁定状态**：@lo-user 2026-05-06 在 D-19 讨论 thread 中拍板。
+
+**输出视图**：
+- `fairy calc` 默认 `--view brief`，只输出 summary-first 结果与 diagnostics
+- `--view verbose` 输出完整 `CalcResult`，包含 `attackSegments[]` / `buckets[]` / `modifiers[]` / `trace[]`
+- `--view` 合法值固定为 `brief|verbose`，非法值必须 fail loud
+
+**结果语义**：
+- 默认 summary 使用 `lanes.nonCrit` / `lanes.crit` 双栏展示，不使用暴击率加权期望值
+- `--result-mode expected` 保留为可选理论分析；默认输出不把 expectation 当主结果
+- 旧 `rawTotalDamage` / `displayTotalDamage` / `expectedDamage` / `critDamage` / `nonCritDamage` 字段保留过渡，避免一次性破坏现有审计与脚本
+
+**二元场景边界**：
+- 只有同一输入下的 RNG 双面性（暴击 / 不暴击）进入 `calc` lanes
+- buff active/inactive、敌人状态前后、异常/紊乱触发与否等输入差异使用 `fairy compare`
+
+**来源**：Slock `#fairy:9f8fe6b6` D-19 输出结构讨论；lo-user 2026-05-06 拍板 Q1=`--view brief|verbose`、Q2=summary-first、Q3=保留 expected 可选。
 
 ### D-12 buhflipexplode 算法处理
 

--- a/docs/ux/prompt-templates.md
+++ b/docs/ux/prompt-templates.md
@@ -1,6 +1,6 @@
 # Prompt Templates — UX v0.3 重定向稿 B
 
-作者：@UX  日期：2026-05-05  状态：v0.4（基于 TL-3 PR #5 已 merge 的字段映射 v1.0 + UX-v0.4 errata）
+作者：@UX  日期：2026-05-05  状态：v0.4.1（D-19 patch — 默认 nonCrit/crit 双栏，expected 改为可选）
 
 > **用途**：AI plugin / CLI / Slock skill 把 `CalcResult` JSON 渲染为人类可读输出的模板库。
 > **结构**：4 档输出粒度（tiny / brief / verbose / debug）× 2 语言（zh / en）= 8 套模板。
@@ -13,12 +13,12 @@
 
 | 档 | 受众 | 内容 | 输出长度 |
 |---|---|---|---|
-| **tiny** | 普通玩家（移动端 AI 聊天 / 一行汇总） | 仅总伤害三档数字（暴击 / 期望 / 非暴击） | ≤ 2 行 |
+| **tiny** | 普通玩家（移动端 AI 聊天 / 一行汇总） | 仅总伤害双栏数字（暴击 / 非暴击） | ≤ 2 行 |
 | **brief** | 配装规划玩家（P2 配队党） | tiny + 关键乘区贡献 top 3 + warnings 摘要 | ≤ 8 行 |
 | **verbose** | 数据党 / 攻略作者（P3） | brief + 完整乘区拆解 + 公式溯源 + warnings 全文 | 完整段落 |
 | **debug** | 开发者 / QA 对账 | verbose + trace 中所有 modifier（生效 + 未生效 + 原因）+ 版本元数据 | 详尽 |
 
-CLI flag 切换：`--detail tiny|brief|verbose|debug`，默认 `brief`。
+CLI `calc` JSON 视图切换：`--view brief|verbose`，默认 `brief`。AI/plugin 渲染器仍可在 tiny / brief / verbose / debug 四档之间选择人类可读模板。
 AI plugin 默认按用户问题深度自动选档；显式可指定。
 
 ---
@@ -28,31 +28,31 @@ AI plugin 默认按用户问题深度自动选档；显式可指定。
 ### T1 · tiny / zh
 
 ```
-{{activeAgentName}} 的 {{attackName}} 期望伤害 {{expectedDamage}}（暴击 {{critDamage}} / 非暴击 {{nonCritDamage}}）。
+{{activeAgentName}} 的 {{attackName}}：非暴击 {{nonCritDamage}} / 暴击 {{critDamage}}。
 ```
 
 填充示例（仪玄 强化特殊技 vs 秽息司祭）：
 ```
-仪玄 的 符法千重-破 期望伤害 8,123,456（暴击 12,500,000 / 非暴击 4,200,000）。
+仪玄 的 符法千重-破：非暴击 4,200,000 / 暴击 12,500,000。
 ```
 
 ### T2 · tiny / en
 
 ```
-{{activeAgentName}}'s {{attackName}} deals {{expectedDamage}} expected damage (crit {{critDamage}} / non-crit {{nonCritDamage}}).
+{{activeAgentName}}'s {{attackName}} deals {{nonCritDamage}} non-crit / {{critDamage}} crit damage.
 ```
 
 Example fill:
 ```
-Yixuan's Sigil Shroud — Break deals 8,123,456 expected damage (crit 12,500,000 / non-crit 4,200,000).
+Yixuan's Sigil Shroud — Break deals 4,200,000 non-crit / 12,500,000 crit damage.
 ```
 
 ### T3 · brief / zh
 
 ```
 {{activeAgentName}} 的 {{attackName}}（{{damageType}}）
-- 期望伤害：{{expectedDamage}}
-- 暴击伤害：{{critDamage}} / 非暴击伤害：{{nonCritDamage}}
+- 非暴击伤害：{{nonCritDamage}}
+- 暴击伤害：{{critDamage}}
 
 主要乘区贡献（top 3）：
 {{#topZones}}
@@ -65,8 +65,8 @@ Yixuan's Sigil Shroud — Break deals 8,123,456 expected damage (crit 12,500,000
 填充示例：
 ```
 仪玄 的 符法千重-破（贯穿伤害）
-- 期望伤害：8,123,456
-- 暴击伤害：12,500,000 / 非暴击伤害：4,200,000
+- 非暴击伤害：4,200,000
+- 暴击伤害：12,500,000
 
 主要乘区贡献（top 3）：
 - 基础伤害区：29,076（贡献 35%）
@@ -80,8 +80,8 @@ Yixuan's Sigil Shroud — Break deals 8,123,456 expected damage (crit 12,500,000
 
 ```
 {{activeAgentName}}'s {{attackName}} ({{damageType}})
-- Expected damage: {{expectedDamage}}
-- Crit: {{critDamage}} / Non-crit: {{nonCritDamage}}
+- Non-crit damage: {{nonCritDamage}}
+- Crit damage: {{critDamage}}
 
 Top 3 zone contributions:
 {{#topZones}}
@@ -94,8 +94,8 @@ Top 3 zone contributions:
 Example fill:
 ```
 Yixuan's Sigil Shroud — Break (Sheer Damage)
-- Expected damage: 8,123,456
-- Crit: 12,500,000 / Non-crit: 4,200,000
+- Non-crit damage: 4,200,000
+- Crit damage: 12,500,000
 
 Top 3 zone contributions:
 - Base Damage Zone: 29,076 (35%)
@@ -111,10 +111,9 @@ Top 3 zone contributions:
 # {{activeAgentName}} · {{attackName}} · {{damageType}}
 
 **结果**
-- 期望伤害（理论值）：{{expectedDamageRaw}}
-- 期望伤害（游戏内显示，向上取整）：{{expectedDamageDisplay}}
-- 暴击伤害：{{critDamage}}
 - 非暴击伤害：{{nonCritDamage}}
+- 暴击伤害：{{critDamage}}
+{{#hasExpectedDamage}}- 期望伤害（可选 result-mode=expected）：{{expectedDamage}}{{/hasExpectedDamage}}
 {{#hasMultipleSegments}}- 多段总和（逐段向上取整后）：{{segmentDisplaySum}}{{/hasMultipleSegments}}
 
 **乘区拆解**
@@ -147,10 +146,9 @@ Top 3 zone contributions:
 # {{activeAgentName}} · {{attackName}} · {{damageType}}
 
 **Result**
-- Expected damage (raw): {{expectedDamageRaw}}
-- Expected damage (in-game display, ceil per segment): {{expectedDamageDisplay}}
-- Crit damage: {{critDamage}}
 - Non-crit damage: {{nonCritDamage}}
+- Crit damage: {{critDamage}}
+{{#hasExpectedDamage}}- Expected damage (optional result-mode=expected): {{expectedDamage}}{{/hasExpectedDamage}}
 {{#hasMultipleSegments}}- Multi-segment sum (ceil per segment): {{segmentDisplaySum}}{{/hasMultipleSegments}}
 
 **Zone breakdown**
@@ -284,11 +282,11 @@ Top 3 zone contributions:
 | `{{activeAgentName}}` | i18n: `glossary[agentId].label.<lang>` 派生；fallback `result.summary.activeActorId` | UX-1 glossary + UX-2 messages |
 | `{{attackName}}` | `result.attackSegments[i].id` 或 i18n 资源；多段时聚合段名 | TL-3 calc-result.md §3 |
 | `{{damageType}}` | `result.summary.damageType` (enum: `regular` / `sheer` / `anomaly` / `disorder` / `trueDamage` / `daze`，与 TL-3/PR #7 锁定一致) | TL-3 calc-result.md §2 |
-| `{{expectedDamage}}` | `result.summary.expectedDamage` | TL-3 calc-result.md §2 |
-| `{{expectedDamageRaw}}` | `result.summary.rawTotalDamage` | TL-3 calc-result.md §2 |
-| `{{expectedDamageDisplay}}` | `result.summary.displayTotalDamage` | TL-3 calc-result.md §2 |
-| `{{critDamage}}` | `result.summary.critDamage` | TL-3 calc-result.md §2 |
-| `{{nonCritDamage}}` | `result.summary.nonCritDamage` | TL-3 calc-result.md §2 |
+| `{{nonCritDamage}}` | `result.summary.lanes.nonCrit.displayDamage` | TL-3 calc-result.md §2 + D-19 |
+| `{{critDamage}}` | `result.summary.lanes.crit.displayDamage` | TL-3 calc-result.md §2 + D-19 |
+| `{{expectedDamage}}` | Optional: `result.summary.expectedDamage` when `--result-mode expected` is requested | TL-3 calc-result.md §2 + D-19 |
+| `{{expectedDamageRaw}}` | Deprecated transition: `result.summary.rawTotalDamage` in verbose/full results | TL-3 calc-result.md §2 + D-19 |
+| `{{expectedDamageDisplay}}` | Deprecated transition: `result.summary.displayTotalDamage` in verbose/full results | TL-3 calc-result.md §2 + D-19 |
 | `{{segmentDisplaySum}}` | `Σ result.attackSegments[].segmentDisplayDamage` (= `displayTotalDamage`) | TL-3 calc-result.md §3 |
 | `{{segments}}` 循环（各段 raw/display） | `result.attackSegments[]` (each: `id` / `rawDamage` / `segmentDisplayDamage` / `roundingMode`) | TL-3 calc-result.md §3 |
 | `{{topZones}}` (top 3 by contribution) | `result.buckets[]` 按 `effectiveMultiplier` 偏离 1 的程度排序 top 3；each bucket: `bucketId` / `effectiveMultiplier` / contributors[] top 1 | TL-3 calc-result.md §4 |
@@ -313,7 +311,7 @@ Top 3 zone contributions:
 - `defenseSkipped`（贯穿伤害）：检查 `result.summary.damageType === "sheer"` 且 trace 中有 `defenseSkipped` 标记 → verbose 档输出"防御区已跳过"
 
 **双语 i18n 边界（与 v0.3 一致）**：
-- 模板内嵌固定标签（"期望伤害" / "Expected damage" 等）硬编码
+- 模板内嵌固定标签（"非暴击伤害" / "Crit damage" 等）硬编码
 - `{{warnings.message}}` / `{{errors.message}}` 走 `messages.<lang>.json`（UX-2 v0.4）
 - 术语标签（`贯穿伤害` / `Sheer Damage`）走 glossary v0.4 `label.<lang>`
 
@@ -321,7 +319,7 @@ Top 3 zone contributions:
 
 ## 双语 i18n 复用 messages 资源
 
-模板内嵌的固定标签（如 `期望伤害` / `Expected damage` / `已生效 modifiers` / `Active modifiers`）是模板硬编码，**不**走 `messages.zh.json` / `messages.en.json`（那是错误文案库）。
+模板内嵌的固定标签（如 `非暴击伤害` / `Crit damage` / `已生效 modifiers` / `Active modifiers`）是模板硬编码，**不**走 `messages.zh.json` / `messages.en.json`（那是错误文案库）。
 
 但模板填充中的：
 - `{{warnings.message}}` — 走 `messages.<lang>.json` 的 ERR-* 文案（与 UX-2 一致）

--- a/docs/ux/starter-scenarios.md
+++ b/docs/ux/starter-scenarios.md
@@ -1,6 +1,6 @@
 # Starter Scenarios — UX v0.3 重定向稿 A
 
-作者：@UX  日期：2026-05-05  状态：v0.4.1（UX-S5-1-patch — 对齐 D-13 V1 = DA + cleaned-schema-spec.md externalBossId 体系）
+作者：@UX  日期：2026-05-05  状态：v0.4.2（D-19 patch — 默认 nonCrit/crit 双栏，expected 改为可选）
 
 > Starter scenarios = AI plugin / CLI 用户首次接入时的"开箱即用"参考用例。每个 scenario 包含：
 > - 自然语言描述（zh + en 双语）
@@ -98,13 +98,14 @@
 ```jsonc
 {
   "damageType": "sheer",
-  "expectedDamage": "≈ X (具体值由 core 计算)",
-  "critDamageMax": "≈ X * (1 + critDamage)",
-  "nonCritDamage": "≈ X / (1 + critRate * critDamage)",
+  "lanes": {
+    "nonCrit": { "displayDamage": "≈ X（由 core 计算）" },
+    "crit": { "displayDamage": "≈ X * (1 + critDamage)" }
+  },
   "trace": {
     "baseDamageZone": "= sheerForce 2423 * multiplier 12.0",
     "damageBonusZone": "1.0 (无外援)",
-    "critZone": "暴击时 1 + 200.4% = 3.004 / 期望 1 + 0.554*2.004 = 2.110",
+    "critZone": "暴击时 1 + 200.4% = 3.004；默认输出同时展示非暴击 / 暴击两栏，不使用期望模式",
     "defenseZone": "已跳过 (sheer 伤害)",
     "resistanceZone": "1 - (-0.2) = 1.2 (玄墨按以太结算; 司祭以太 0.4 抗性? — 待 data 验证)",
     "vulnerabilityZone": "1 + 25% 秽盾减伤 reverse = 0.75",

--- a/examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json
+++ b/examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.7.3",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "data-v0.1.0",
+  "sourceVersion": "dogfood-examples-v0.1.0",
+  "team": [
+    {
+      "agentId": "anby",
+      "level": 60,
+      "agentSpecialty": "stun",
+      "attribute": "electric",
+      "skillLevels": {
+        "basic": 16,
+        "core": 6
+      },
+      "panel": {
+        "attack": 658.957,
+        "maxHp": 7500.7134,
+        "defense": 612.6038,
+        "impact": 136,
+        "critRate": 0.05,
+        "critDamage": 0.5,
+        "anomalyProficiency": 93,
+        "anomalyMastery": 94
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "anby"
+  },
+  "attackSegments": [
+    {
+      "id": "dogfood-anby-basic-1",
+      "actorId": "anby",
+      "skillId": "anby.basic.voltSwift.segment1",
+      "levelKey": "basic",
+      "multiplier": 0.747,
+      "baseDazeMultiplier": 0.276,
+      "attribute": "electric",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "distanceDecay": 1,
+      "source": {
+        "sourceId": "manual-dogfood",
+        "sourceVersion": "2026-05-06",
+        "sourceAnchor": "slock:#fairy:6ddbcee4"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "dullahan-defense-9528-branch",
+    "level": 70,
+    "rank": "boss",
+    "maxHp": 4160105.1,
+    "defense": 952.8,
+    "dazeCap": 8229.7,
+    "resistance": {
+      "electric": 0
+    }
+  },
+  "modifiers": [],
+  "manualEvents": []
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,6 +6,7 @@ JSON-only command shell over `@fairy/core`.
 
 ```bash
 pnpm --silent --filter @fairy/cli run cli -- calc snapshot.json --lang zh --pretty
+pnpm --silent --filter @fairy/cli run cli -- calc snapshot.json --view verbose --lang zh --pretty
 pnpm --silent --filter @fairy/cli run cli -- compare left.json right.json --lang en
 pnpm --silent --filter @fairy/cli run cli -- scan snapshot.json --path team[0].panel.attack --from 1000 --to 2000 --step 100
 pnpm --silent --filter @fairy/cli run cli -- explain snapshot.json
@@ -18,17 +19,41 @@ workspace.
 
 ## Output Contract
 
-Stdout is always JSON. `calc` returns the authoritative `CalcResult` from
-`@fairy/core`, including `summary`, `attackSegments`, `buckets`, `modifiers`,
-`trace`, `warnings`, and `errors`.
+Stdout is always JSON.
+
+`calc` defaults to `--view brief`. The brief output is summary-first and contains
+only:
+
+- `schemaVersion: "fairy-cli-calc-brief-v1"`
+- `view: "brief"`
+- `resultMode` when explicitly requested
+- `calculationId`
+- `summary`
+- `warnings`
+- `errors`
+
+Brief `summary` exposes deterministic result lanes:
+
+- `summary.lanes.nonCrit`
+- `summary.lanes.crit`
+- `summary.lanes.fixed` for deterministic damage paths such as anomaly,
+  disorder, daze, or manual events
+- `summary.daze` when the input produces daze value
+- `summary.anomalyBuildup` when non-zero anomaly buildup is produced
+
+Use `--view verbose` to return the full authoritative `CalcResult` from
+`@fairy/core`, including `attackSegments`, `buckets`, `modifiers`, `events`,
+`trace`, and legacy transition fields such as `summary.rawTotalDamage`,
+`summary.displayTotalDamage`, and `summary.expectedDamage`.
 
 Warnings and errors from `CalcResult` are also rendered to stderr as localized
 diagnostic lines selected by `--lang zh|en`. The JSON diagnostic objects remain
 unchanged and language-independent.
 
 `--result-mode expected|crit|nonCrit` is passed into the snapshot options before
-calculation so the same snapshot can produce expected, forced-crit, and
-forced-non-crit output.
+calculation. The default brief view shows non-crit and crit lanes rather than a
+crit-rate expectation. `--result-mode expected` remains available for
+statistical/theory checks and adds `summary.expectedDamage` to brief output.
 
 Invalid arguments, invalid JSON, and schema validation failures are reported as
 JSON error objects on stderr. Their stable `error.code` stays language-independent,

--- a/packages/cli/src/examples.test.ts
+++ b/packages/cli/src/examples.test.ts
@@ -46,6 +46,47 @@ describe("dogfooding examples", () => {
     }
   })
 
+  it("covers the accepted Anby core F basic 16 dogfood fixture", () => {
+    const run = spawnSync("pnpm", [
+      "--silent",
+      "--filter",
+      "@fairy/cli",
+      "run",
+      "cli",
+      "--",
+      "calc",
+      resolve(examplesDir, "dogfood-anby-core-f-basic16-dullahan-9528.json"),
+      "--lang",
+      "zh",
+    ], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+    const parsed = JSON.parse(run.stdout) as {
+      summary: {
+        expectedDamage?: number
+        lanes: {
+          nonCrit: { rawDamage: number; displayDamage: number }
+          crit: { rawDamage: number; displayDamage: number }
+        }
+        daze: { value: number; ratioRaw: number; ratioDisplay: number }
+      }
+      errors: unknown[]
+    }
+
+    expect(run.status, `exit status\nstderr:\n${run.stderr}`).toBe(0)
+    expect(run.stderr).toBe("")
+    expect(parsed.errors).toEqual([])
+    expect(parsed.summary.expectedDamage).toBeUndefined()
+    expect(parsed.summary.lanes.nonCrit.rawDamage).toBeCloseTo(223.7458540909091, 10)
+    expect(parsed.summary.lanes.nonCrit.displayDamage).toBe(224)
+    expect(parsed.summary.lanes.crit.rawDamage).toBeCloseTo(335.6187811363636, 10)
+    expect(parsed.summary.lanes.crit.displayDamage).toBe(336)
+    expect(parsed.summary.daze.value).toBe(37.536)
+    expect(parsed.summary.daze.ratioRaw).toBeCloseTo(0.4561041107209254, 12)
+    expect(parsed.summary.daze.ratioDisplay).toBe(0)
+  })
+
   it("keeps root example aliases JSON-only when called with pnpm --silent", () => {
     for (const script of ["fairy:s1", "fairy:s2", "fairy:s3"]) {
       const run = spawnSync("pnpm", ["--silent", script], {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -62,15 +62,33 @@ const messages = {
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
 
 describe("fairy cli", () => {
-  it("calculates a snapshot from stdin and writes CalcResult JSON", async () => {
+  it("calculates a snapshot from stdin and writes brief JSON by default", async () => {
     const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
     const code = await runCli(["calc", "-", "--lang", "en"], io)
+    const result = JSON.parse(io.output.stdout) as {
+      schemaVersion: string
+      summary: { lanes: { nonCrit: { rawDamage: number; displayDamage: number }; crit: { rawDamage: number; displayDamage: number } }; expectedDamage?: number }
+      trace?: unknown[]
+    }
+
+    expect(code).toBe(0)
+    expect(result.schemaVersion).toBe("fairy-cli-calc-brief-v1")
+    expect(result.summary.lanes.nonCrit.rawDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.lanes.nonCrit.displayDamage).toBe(455)
+    expect(result.summary.lanes.crit.rawDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.expectedDamage).toBeUndefined()
+    expect(result.trace).toBeUndefined()
+    expect(io.output.stderr).toBe("")
+  })
+
+  it("writes the full CalcResult when --view verbose is selected", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const code = await runCli(["calc", "-", "--view", "verbose"], io)
     const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number }; trace: unknown[] }
 
     expect(code).toBe(0)
     expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
     expect(result.trace.length).toBeGreaterThan(0)
-    expect(io.output.stderr).toBe("")
   })
 
   it("renders localized warning diagnostics to stderr without changing stdout JSON", async () => {
@@ -180,11 +198,32 @@ describe("fairy cli", () => {
     snapshot.team[0]!.panel.critRate = 0.5
     snapshot.team[0]!.panel.critDamage = 1
     const io = fakeIo({ stdin: JSON.stringify(snapshot) })
-    const code = await runCli(["calc", "-", "--result-mode", "crit"], io)
+    const code = await runCli(["calc", "-", "--result-mode", "crit", "--view", "verbose"], io)
     const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
 
     expect(code).toBe(0)
     expect(result.summary.rawTotalDamage).toBeCloseTo(909.091, 3)
+  })
+
+  it("keeps expected mode optional in brief output", async () => {
+    const snapshot = structuredClone(baseSnapshot)
+    snapshot.team[0]!.panel.critRate = 0.5
+    snapshot.team[0]!.panel.critDamage = 1
+    const io = fakeIo({ stdin: JSON.stringify(snapshot) })
+    const code = await runCli(["calc", "-", "--result-mode", "expected"], io)
+    const result = JSON.parse(io.output.stdout) as {
+      resultMode: string
+      summary: {
+        expectedDamage: number
+        lanes: { nonCrit: { rawDamage: number }; crit: { rawDamage: number } }
+      }
+    }
+
+    expect(code).toBe(0)
+    expect(result.resultMode).toBe("expected")
+    expect(result.summary.expectedDamage).toBeCloseTo(681.818, 3)
+    expect(result.summary.lanes.nonCrit.rawDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.lanes.crit.rawDamage).toBeCloseTo(909.091, 3)
   })
 
   it("accepts boolean flags before the input path", async () => {
@@ -194,10 +233,10 @@ describe("fairy cli", () => {
       },
     })
     const code = await runCli(["calc", "--pretty", "snapshot.json"], io)
-    const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
+    const result = JSON.parse(io.output.stdout) as { summary: { lanes: { nonCrit: { rawDamage: number } } } }
 
     expect(code).toBe(0)
-    expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.lanes.nonCrit.rawDamage).toBeCloseTo(454.545, 3)
     expect(io.output.stdout.startsWith("{\n")).toBe(true)
   })
 
@@ -234,6 +273,17 @@ describe("fairy cli", () => {
     expect(code).toBe(1)
     expect(error.error.code).toBe("ERR-CLI-ARG")
     expect(error.error.message).toBe("Localized argument problem: --lang must be zh or en")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("returns a localized error for invalid view values", async () => {
+    const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const code = await runCli(["calc", "-", "--view", "full"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-ARG")
+    expect(error.error.message).toBe("Localized argument problem: --view must be brief or verbose")
     expect(io.output.stdout).toBe("")
   })
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { cliErrorFallbackMessages, isCliErrorCode, type CliErrorCode } from "./e
 
 type Lang = "zh" | "en"
 type ResultMode = "expected" | "crit" | "nonCrit"
+type View = "brief" | "verbose"
 
 interface CliIo {
   cwd: string
@@ -78,9 +79,11 @@ export async function runCli(argv: string[], io: CliIo = nodeIo()): Promise<numb
 
 async function runCalc(parsed: ParsedArgs, io: CliIo, lang: Lang): Promise<number> {
   const snapshot = await readSnapshotInput(parsed, io, 0)
-  const result = calculate(withResultMode(snapshot, parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))))
+  const view = parseView(parsed.flags.get("view"))
+  const resultMode = parseResultMode(parsed.flags.get("result-mode") ?? parsed.flags.get("resultMode"))
+  const result = calculate(withResultMode(snapshot, resultMode))
   await writeDiagnostics(io, result, lang)
-  writeJson(io, result, parsed.flags.has("pretty"))
+  writeJson(io, view === "verbose" ? result : toBriefCalcResult(result, resultMode), parsed.flags.has("pretty"))
   return result.errors.length > 0 ? 1 : 0
 }
 
@@ -267,6 +270,35 @@ function parseResultMode(value: string | boolean | undefined): ResultMode | unde
   throw cliError("ERR-CLI-ARG", { message: "--result-mode must be expected, crit, or nonCrit" })
 }
 
+function parseView(value: string | boolean | undefined): View {
+  if (value === undefined || value === false)
+    return "brief"
+  if (value === "brief" || value === "verbose")
+    return value
+  throw cliError("ERR-CLI-ARG", { message: "--view must be brief or verbose" })
+}
+
+function toBriefCalcResult(result: CalcResult, resultMode: ResultMode | undefined) {
+  const summary = result.summary
+  return {
+    schemaVersion: "fairy-cli-calc-brief-v1",
+    view: "brief",
+    ...(resultMode === undefined ? {} : { resultMode }),
+    calculationId: result.calculationId,
+    summary: {
+      activeActorId: summary.activeActorId,
+      ...(summary.enemyId === undefined ? {} : { enemyId: summary.enemyId }),
+      damageType: summary.damageType,
+      lanes: summary.lanes,
+      ...(summary.daze === undefined ? {} : { daze: summary.daze }),
+      ...(summary.anomalyBuildup === undefined || summary.anomalyBuildup === 0 ? {} : { anomalyBuildup: summary.anomalyBuildup }),
+      ...(resultMode === "expected" ? { expectedDamage: summary.expectedDamage ?? summary.rawTotalDamage } : {}),
+    },
+    warnings: result.warnings,
+    errors: result.errors,
+  }
+}
+
 function readStringFlag(parsed: ParsedArgs, name: string): string {
   const value = parsed.flags.get(name)
   if (typeof value !== "string" || value.length === 0)
@@ -346,6 +378,7 @@ function getHelp() {
     commands: supportedCommands,
     flags: {
       "--lang": ["zh", "en"],
+      "--view": ["brief", "verbose"],
       "--result-mode": ["expected", "crit", "nonCrit"],
       "--pretty": true,
       "--path": "scan target path",

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -55,6 +55,11 @@ describe("calculate", () => {
     expect(defense?.effectiveMultiplier).toBeCloseTo(0.454545, 5)
     expect(result.summary.rawTotalDamage).toBeCloseTo(454.545, 3)
     expect(result.summary.displayTotalDamage).toBe(455)
+    expect(result.summary.lanes.nonCrit?.rawDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.lanes.nonCrit?.displayDamage).toBe(455)
+    expect(result.summary.lanes.crit?.rawDamage).toBeCloseTo(454.545, 3)
+    expect(result.summary.lanes.crit?.displayDamage).toBe(455)
+    expect(result.summary.lanes.fixed).toBeUndefined()
   })
 
   it("shows the corrupted shield sheer damage defense skip ratio", () => {
@@ -244,6 +249,9 @@ describe("calculate", () => {
     expect(result.attackSegments[0]?.dazeValue).toBe(180)
     expect(result.attackSegments[0]?.dazeRatioRaw).toBe(18)
     expect(result.attackSegments[0]?.dazeRatioDisplay).toBe(18)
+    expect(result.summary.daze?.value).toBe(180)
+    expect(result.summary.daze?.ratioRaw).toBe(18)
+    expect(result.summary.daze?.ratioDisplay).toBe(18)
     expect(result.buckets.some(bucket => bucket.bucketId === "dazeInflictZone")).toBe(true)
   })
 

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -3,6 +3,7 @@ import type {
   AnomalyStatus,
   AttackSegment,
   BattleSnapshot,
+  CalcSummary,
   BucketContributor,
   BucketResult,
   CalcResult,
@@ -86,6 +87,10 @@ export function calculate(input: unknown, options: CalculateOptions = {}): CalcR
     ...attackSegments.map(segment => segment.expectedDamage ?? segment.rawDamage),
     ...eventResults.map(event => event.rawDamage),
   ])
+  const dazeValue = sum(attackSegments.map(segment => segment.dazeValue ?? 0))
+  const anomalyBuildup = sum(attackSegments.map(segment => segment.anomalyBuildup ?? 0))
+  const lanes = getSummaryLanes(attackSegments, eventResults)
+  const daze = getSummaryDaze(attackSegments, dazeValue, snapshot.enemy.dazeCap)
   const result: CalcResult = {
     schemaVersion: snapshot.schemaVersion,
     gameVersion: snapshot.gameVersion,
@@ -103,13 +108,15 @@ export function calculate(input: unknown, options: CalculateOptions = {}): CalcR
       activeActorId: activeActor.agentId,
       ...(snapshot.enemy.enemyId === undefined ? {} : { enemyId: snapshot.enemy.enemyId }),
       damageType: getSummaryDamageType(attackSegments, eventResults),
+      lanes,
+      ...(daze === undefined ? {} : { daze }),
       rawTotalDamage,
       displayTotalDamage,
       expectedDamage,
       critDamage: sum(attackSegments.map(segment => segment.critDamage ?? segment.rawDamage)),
       nonCritDamage: sum(attackSegments.map(segment => segment.nonCritDamage ?? segment.rawDamage)),
-      dazeValue: sum(attackSegments.map(segment => segment.dazeValue ?? 0)),
-      anomalyBuildup: sum(attackSegments.map(segment => segment.anomalyBuildup ?? 0)),
+      dazeValue,
+      anomalyBuildup,
       disorderDamage: sum(attackSegments.filter(segment => segment.damageType === "disorder").map(segment => segment.rawDamage)),
       trueDamage: sum(eventResults.map(event => event.rawDamage)),
     },
@@ -1374,6 +1381,65 @@ function getActiveActor(snapshot: BattleSnapshot): AgentSnapshot {
     throw new Error("activeActor.agentId must reference a team agent")
 
   return actor
+}
+
+function getSummaryLanes(
+  attackSegments: SegmentResult[],
+  manualEvents: ManualEventResult[],
+): CalcSummary["lanes"] {
+  const crittableSegments = attackSegments.filter(segment => usesStandardCrit(segment.damageType))
+  const fixedSegments = attackSegments.filter(segment => !usesStandardCrit(segment.damageType))
+  const fixedRawDamage = sum([
+    ...fixedSegments.map(segment => segment.rawDamage),
+    ...manualEvents.map(event => event.rawDamage),
+  ])
+  const fixedDisplayDamage = sum([
+    ...fixedSegments.map(segment => segment.segmentDisplayDamage),
+    ...manualEvents.map(event => event.displayDamage),
+  ])
+  const lanes: CalcSummary["lanes"] = {}
+
+  if (crittableSegments.length > 0) {
+    const nonCritRawDamage = sum(crittableSegments.map(segment => segment.nonCritDamage ?? segment.rawDamage)) + fixedRawDamage
+    const critRawDamage = sum(crittableSegments.map(segment => segment.critDamage ?? segment.rawDamage)) + fixedRawDamage
+    lanes.nonCrit = {
+      rawDamage: nonCritRawDamage,
+      displayDamage: sum(crittableSegments.map(segment => Math.ceil(segment.nonCritDamage ?? segment.rawDamage))) + fixedDisplayDamage,
+    }
+    lanes.crit = {
+      rawDamage: critRawDamage,
+      displayDamage: sum(crittableSegments.map(segment => Math.ceil(segment.critDamage ?? segment.rawDamage))) + fixedDisplayDamage,
+    }
+  }
+
+  if (fixedSegments.length > 0 || manualEvents.length > 0) {
+    lanes.fixed = {
+      rawDamage: fixedRawDamage,
+      displayDamage: fixedDisplayDamage,
+    }
+  }
+
+  return lanes
+}
+
+function getSummaryDaze(
+  attackSegments: SegmentResult[],
+  value: number,
+  enemyDazeCap: number | undefined,
+): CalcSummary["daze"] | undefined {
+  if (!attackSegments.some(segment => segment.dazeValue !== undefined))
+    return undefined
+
+  if (enemyDazeCap === undefined || enemyDazeCap <= 0) {
+    return { value }
+  }
+
+  const ratioRaw = (value / enemyDazeCap) * 100
+  return {
+    value,
+    ratioRaw,
+    ratioDisplay: Math.floor(ratioRaw),
+  }
 }
 
 function getSummaryDamageType(

--- a/packages/core/src/schema/calc-result.ts
+++ b/packages/core/src/schema/calc-result.ts
@@ -19,6 +19,39 @@ export const calcSummarySchema = z
     activeActorId: z.string().min(1),
     enemyId: z.string().min(1).optional(),
     damageType: damageTypeSchema,
+    lanes: z
+      .object({
+        nonCrit: z
+          .object({
+            rawDamage: z.number().finite(),
+            displayDamage: z.number().finite(),
+          })
+          .strict()
+          .optional(),
+        crit: z
+          .object({
+            rawDamage: z.number().finite(),
+            displayDamage: z.number().finite(),
+          })
+          .strict()
+          .optional(),
+        fixed: z
+          .object({
+            rawDamage: z.number().finite(),
+            displayDamage: z.number().finite(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict(),
+    daze: z
+      .object({
+        value: z.number().finite(),
+        ratioRaw: z.number().finite().optional(),
+        ratioDisplay: z.number().finite().optional(),
+      })
+      .strict()
+      .optional(),
     rawTotalDamage: z.number().finite(),
     displayTotalDamage: z.number().finite(),
     expectedDamage: z.number().finite().optional(),

--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -361,6 +361,10 @@ describe("CalcResult schema", () => {
       summary: {
         activeActorId: "yixuan",
         damageType: "sheer",
+        lanes: {
+          nonCrit: { rawDamage: 10.2, displayDamage: 11 },
+          crit: { rawDamage: 10.2, displayDamage: 11 },
+        },
         rawTotalDamage: 10.2,
         displayTotalDamage: 11,
       },
@@ -422,6 +426,10 @@ describe("CalcResult schema", () => {
       summary: {
         activeActorId: "yixuan",
         damageType: "sheer",
+        lanes: {
+          nonCrit: { rawDamage: 10.2, displayDamage: 11 },
+          crit: { rawDamage: 10.2, displayDamage: 11 },
+        },
         rawTotalDamage: 10.2,
         displayTotalDamage: 11,
       },


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #64
- Reviewers: @Product, @QA, @UX
- Related decisions: D-19
- i18n impact: docs/template wording updated; no new message catalog keys

## Summary

- Add `summary.lanes.nonCrit` / `summary.lanes.crit` / `summary.lanes.fixed` and aggregate `summary.daze` to core `CalcResult` while preserving legacy fields for verbose/full compatibility.
- Change `fairy calc` default output to `--view brief`; `--view verbose` returns the full `CalcResult`; invalid `--view` fails through localized `ERR-CLI-ARG`.
- Keep expected mode optional via `--result-mode expected`; default brief output hides expectation and shows deterministic crit/nonCrit lanes.
- Add the accepted Anby dogfooding fixture (`core F`, basic 16, Dullahan defense 952.8) with assertions for nonCrit 224 / crit 336 / daze 37.536.
- Update D-19/docs/getting-started/data contracts/UX templates/starter scenario wording to match summary-first nonCrit/crit output.

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm --filter @fairy/data verify:golden-v1`
- `pnpm --filter @fairy/data verify:excel`
- `pnpm --filter @fairy/data verify:buhflipexplode-da`
- `pnpm --filter @fairy/data verify:mihoyo-da`
- `jq empty examples/snapshots/*.json docs/ux/i18n/messages.zh.json docs/ux/i18n/messages.en.json`
- `git diff --check`
- Manual: `pnpm --silent fairy -- calc examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json --lang zh --pretty`

## Notes

- Legacy `summary.rawTotalDamage` / `displayTotalDamage` / `expectedDamage` remain available in `--view verbose` for existing audit paths and 19-anchor parity.
- The default brief output intentionally does not expose `expectedDamage` unless `--result-mode expected` is explicitly requested.
