### PR TITLE
docs(product): add V1 dogfooding report — passes release gate (4/5)

### DIFF
--- a/docs/product/dogfooding-report-v1.md
+++ b/docs/product/dogfooding-report-v1.md
@@ -114,15 +114,24 @@ dogfooding 通过 release gate（≥4/5）。
 
 ## 6. 后续流程
 
-按 `docs/product/dogfooding-v1.md` §4.2：
+按 `docs/product/dogfooding-v1.md` §4.2 + 2026-05-08 release decisions：
+
+**release 决策快照**（lo-user 拍板）：
+- npm scope: `@randomplay/data` / `@randomplay/core` / `@randomplay/cli`（root = `fairy-monorepo`，CLI bin 仍 `fairy`）
+- 起始版本 `v0.0.1`（与 design-system 同节奏）
+- npm publish = 是（OIDC + Trusted Publisher，复用 design-system DS-D-09）
+- release artifact = 手写 `CHANGELOG.md` + GitHub Release page
+- 公告 = 仅 #fairy
+- rollback = 完整 runbook（npm deprecate + revert PR + GitHub Release pre-release）
+
+**5-Phase 流水线**：
 
 1. ✅ lo-user 宣布通过 + 打分（2026-05-07 00:58）
-2. ✅ Product 整理 dogfooding-report-v1.md（本文件，入仓后）
-3. ⏳ QA release-readiness review task：
-   - 重跑 `pnpm check` / `pnpm test` / `verify:golden-v1` / S1/S2/S3 alias + `jq empty`
-   - 抽查 B-Calc.blocker 修复回归（D-19 PR #30 / G22/G23 PR #28）
-4. ⏳ Product errata PR：DD-001（米游社 D-17）+ DD-002（D-13 19 anchors）+ DD-003（dogfooding gate）+ dogfooding-report 链接 + V1 release notes
-5. ⏳ V1 release（git tag 命名 / 是否 npm publish 待 errata PR 时一并定）
+2. ✅ Product 整理 dogfooding-report-v1.md（本文件）
+3. ✅ Phase 1 包名 rename PR #35（`@fairy/*` → `@randomplay/*`，commit `dd78a4b`）+ Phase 2 release workflow PR #36（bumpp + allowlist publish + OIDC，commit `a0ca3e6`）
+4. ⏳ Phase 3 PR #31 refresh + QA re-pass + Product squash merge；Product 起 errata PR：DD-001（米游社 D-17 + 2026-05-08 audit 决议）+ DD-002（D-13 19 anchors）+ DD-003（dogfooding gate）+ V1 release notes 草稿
+5. ⏳ Phase 4 lo-user 手动首发 v0.0.1（Trusted Publisher 限制必须先有包）+ 在 npmjs.com 配 Trusted Publisher
+6. ⏳ Phase 5 release CI v0.0.x OIDC 验证 + QA smoke + verify:golden-v1 复跑 + 公告 #fairy
 
 ---
 
@@ -134,6 +143,8 @@ dogfooding 通过 release gate（≥4/5）。
 | PR #30 | D-19 CLI 输出 reform（brief view + lanes） | `74c5f83` |
 | PR #33 | 米游社 sourceConflict audit 决议（accept buhflipexplode） | `04e7077` |
 | PR #34 | CLI framework 切 citty | `4c7b753` |
+| PR #35 | npm scope rename `@fairy/*` → `@randomplay/*`（root `fairy-monorepo`，CLI bin `fairy` 不变） | `dd78a4b` |
+| PR #36 | release workflow + package-readiness（bumpp + allowlist publish + OIDC + rollback runbook） | `a0ca3e6` |
 
 ## 附录 B · 整体打分明细（lo-user 自评）
 

--- a/docs/product/dogfooding-report-v1.md
+++ b/docs/product/dogfooding-report-v1.md
@@ -18,7 +18,7 @@
 | **可用性** | 按 getting-started.md 从零跑通 | ✅ clone + install + S1/S2/S3 alias + verify:golden-v1 全过 |
 | **可读性** | CLI 输出能看懂 / trace + sourceRefs 够解释 | ⚠️ 默认输出反馈"太复杂"→ 触发 D-19 reform，已修 |
 | **数值正确性** | S1/S2/S3 + 自建 snapshot 数值符合预期 | ✅ 安比核心技 F + basic 16 + 杜拉罕 defense 952.8 → nonCrit=224 / crit=336 / dazeValue=37.536，三方校对通过 |
-| **错误友好性** | ERR-* 文案能让试用人 self-recover | （未做边界探测，未触发 ERR 文案验证） |
+| **错误友好性** | ERR-* 文案能让试用人 self-recover | ⚠️ Day 3 边界探测 lo-user 决策跳过，未触发 ERR 文案验证；记 known limitation（§4） |
 | **范围漏洞** | 想算但 V1 不支持 | 未报告 |
 
 ---
@@ -56,6 +56,22 @@
 - **修复 PR**：#28 commit `3f5e67a`
 - **状态**：✅ 已修 + QA 二次复核通过
 
+### F-2026-05-08-05：米游社 sourceConflict 3 条 audit 决议
+- **类别**：D-Data（dogfooding 期间触发的 audit gate，非 calc bug）
+- **现象**：cleaned typed modifier 留存 3 条米游社 vs buhflipexplode 危局强袭战 buff 数值冲突（21 澄意 / 8 灼冽 / 1 破招），Day 0 标记 non-blocking 但 release 前需要拍板
+- **期望**：人工 audit + 决议
+- **解决**：lo-user 用 nanoka (`https://zzz.nanoka.cc/boss/`) 作为人工查询源（不接管线），三方比对结果 nanoka 与 buhflipexplode 一致（2:1 vs Mihoyo）；lo-user 决策 `Q1，按 buhflipexplode`，cleaned release evidence 记录为 `resolved-prefer-buhflipexplode`，Mihoyo 原值与 sourceRefs 保留作为审计线索
+- **修复 PR**：#33 commit `04e7077`（task #72）
+- **状态**：✅ 已决议，audit 文件入仓 `data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`
+
+### F-2026-05-08-06：CLI framework 切 citty
+- **类别**：U-Scenario（dogfooding 期间触发的 CLI baseline 收敛，非 calc bug）
+- **现象**：现有 CLI 是手写 thin shell（parseArgs + switch），lo-user 询问 unjs 生态 citty 是否更合适
+- **期望**：V1 release 前在 baseline 阶段切换，避免 V1.x 再做 breaking 迁移
+- **解决**：TL 调研后确认 citty 更贴合 ESM-first / 类型安全 / 命令子树扩展，实施迁移
+- **修复 PR**：#34 commit `4c7b753`（task #73）
+- **状态**：✅ 已合入 main + QA 回归通过
+
 ---
 
 ## 3. lo-user 整体打分
@@ -74,8 +90,8 @@ dogfooding 通过 release gate（≥4/5）。
 
 - **DD-003 单人 dogfooding 限制**：V1 仅由 lo-user 单人深度 dogfood 验证 + QA 回归，**未经社区广泛验证**
 - **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 推迟到 V1.x（涉及 data-driven anomaly threshold rule composition / 部位破坏真实伤害 / 失衡恢复时间等扩展功能）
-- **米游社 sourceConflict 3 个**（21 澄意 / 8 灼冽 / 1 破招）：non-blocking historical 记录，cleaned typed modifier 发布前需人工 audit gate 触发时再决（Day 0 不阻塞）
-- **dogfooding 边界探测未完整覆盖**：lo-user Day 3（`--lang en` 验证 / 故意造错 ERR-* 验证）未执行；Product 自评属 known limitation，不阻塞 release
+- **米游社 sourceConflict 3 个**（21 澄意 / 8 灼冽 / 1 破招）：~~non-blocking historical 记录，cleaned typed modifier 发布前需人工 audit gate 触发时再决~~ → ✅ 2026-05-08 已 audit 决议（accept buhflipexplode；F-05 / PR #33），不再属于 known limitation，转记为已解决项
+- **dogfooding 边界探测 Day 3 跳过**：lo-user 决策跳过 Day 3（`--lang en` 验证 / 故意造错 ERR-* 验证），release 后视真实使用反馈再决定是否回补；属 known limitation，不阻塞 release
 
 ---
 
@@ -87,7 +103,8 @@ dogfooding 通过 release gate（≥4/5）。
 |---|---|
 | B-Calc.blocker：0 件未修 | ✅ 0 件 |
 | B-Calc.non-blocker：已重新分类 | ✅ F-02 归 U-Scenario，已 absorbed by D-19 |
-| U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解 | ✅ F-01 / F-02 / F-03 已修；无 unresolved item |
+| U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解 | ✅ F-01 / F-02 / F-03 / F-06 已修；Day 3 跳过记 known limitation |
+| D-Data：audit gate 决议落地 | ✅ F-05 已决议（accept buhflipexplode），audit 文件入仓 |
 | P-Range：全部入 V1.x backlog | ✅ G13/G18/G19/G20 已 V1.x（D-13）；其他无新增 |
 | lo-user 整体打分 ≥ 4/5 | ✅ 4/5 |
 
@@ -115,6 +132,8 @@ dogfooding 通过 release gate（≥4/5）。
 |---|---|---|
 | PR #28 | G22/G23 manual acceptance + fail-loud | `3f5e67a` |
 | PR #30 | D-19 CLI 输出 reform（brief view + lanes） | `74c5f83` |
+| PR #33 | 米游社 sourceConflict audit 决议（accept buhflipexplode） | `04e7077` |
+| PR #34 | CLI framework 切 citty | `4c7b753` |
 
 ## 附录 B · 整体打分明细（lo-user 自评）
 

--- a/docs/product/dogfooding-report-v1.md
+++ b/docs/product/dogfooding-report-v1.md
@@ -1,0 +1,126 @@
+# Fairy V1 · Dogfooding Report
+
+- 文档版本：v1.0（release gate evidence）
+- 报告人：@Product
+- dogfooding 期间：2026-05-05 ~ 2026-05-07
+- 试用人：lo-user 单人深度试用（DD-003 锁定）
+- 整体打分：**4 / 5**
+- 结论：**通过 release gate**
+
+---
+
+## 1. dogfooding 范围
+
+按 `docs/product/dogfooding-v1.md` §1.2 执行：
+
+| 维度 | 验证方式 | 结果 |
+|---|---|---|
+| **可用性** | 按 getting-started.md 从零跑通 | ✅ clone + install + S1/S2/S3 alias + verify:golden-v1 全过 |
+| **可读性** | CLI 输出能看懂 / trace + sourceRefs 够解释 | ⚠️ 默认输出反馈"太复杂"→ 触发 D-19 reform，已修 |
+| **数值正确性** | S1/S2/S3 + 自建 snapshot 数值符合预期 | ✅ 安比核心技 F + basic 16 + 杜拉罕 defense 952.8 → nonCrit=224 / crit=336 / dazeValue=37.536，三方校对通过 |
+| **错误友好性** | ERR-* 文案能让试用人 self-recover | （未做边界探测，未触发 ERR 文案验证） |
+| **范围漏洞** | 想算但 V1 不支持 | 未报告 |
+
+---
+
+## 2. dogfooding 反馈卡（汇总）
+
+### F-2026-05-06-01：默认 CLI 输出过于复杂
+- **类别**：U-Scenario
+- **现象**：lo-user 试用 Day 1/2 反馈默认 `fairy calc` 输出包含 `attackSegments / buckets / modifiers / trace` 全字段太多，需要 jq 过滤才能看到核心结果
+- **期望**：默认输出简洁，需要详尽时 opt-in
+- **解决**：D-19 V1 CLI 输出 reform — `--view brief|verbose` 默认 brief，`summary.lanes.{nonCrit, crit, fixed}` + `summary.daze` 一眼看懂
+- **修复 PR**：#30（commit `74c5f83`）
+- **状态**：✅ 已修 + lo-user 验证通过
+
+### F-2026-05-06-02：暴击 / 不暴击应并列展示，废 expectation 默认
+- **类别**：U-Scenario / B-Calc.non-blocker（输出形态）
+- **现象**：原默认输出含 expectation 加权平均；玩家对账时不直观，希望直接看到 nonCrit / crit 两栏并列
+- **期望**：默认 nonCrit + crit 双值；expected 可选
+- **解决**：D-19 同 PR：summary lanes 双栏 + `--result-mode expected` 保留可选
+- **修复 PR**：#30
+- **状态**：✅ 已修
+
+### F-2026-05-06-03：自建 snapshot 流程
+- **类别**：U-Scenario（dogfooding 体验，非 bug）
+- **现象**：lo-user 想自建 my-anby-snapshot.json 测自己队伍，但需要查游戏内权威数值（base attack / 倍率 / boss defense 等）
+- **期望**：有人帮查权威数据
+- **解决**：TL 协助提供 Excel 数据源对照（task #62 / #63）；Anby fixture 加入正式 fixture 集
+- **状态**：✅ 已解决；安比 fixture 入仓作为 dogfooding regression baseline
+
+### F-2026-05-06-04：G22/G23 manual acceptance + provider/skill-level fail-loud
+- **类别**：B-Calc.blocker（实施期间发现）
+- **现象**：QA 在 PR #28 review 中发现 C 模板（Yanagi 极性紊乱）在缺 provider 或缺技能等级时会 silent fallback 到 1 级 / 0 精通，违反"技能等级必须明确"心智
+- **期望**：fail loud
+- **解决**：schema 层加 fail-loud 校验 + 负向测试
+- **修复 PR**：#28 commit `3f5e67a`
+- **状态**：✅ 已修 + QA 二次复核通过
+
+---
+
+## 3. lo-user 整体打分
+
+**4 / 5**
+
+dogfooding 通过 release gate（≥4/5）。
+
+### 4/5 而不是 5/5 的可能失分点
+
+> 待 lo-user 选填 — 暂无具体失分项；按"无具体失分点"记录。如果 lo-user 后续想补充，可作为 V1.x backlog 触发条件。
+
+---
+
+## 4. 已知限制（V1 release notes 待标注）
+
+- **DD-003 单人 dogfooding 限制**：V1 仅由 lo-user 单人深度 dogfood 验证 + QA 回归，**未经社区广泛验证**
+- **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 推迟到 V1.x（涉及 data-driven anomaly threshold rule composition / 部位破坏真实伤害 / 失衡恢复时间等扩展功能）
+- **米游社 sourceConflict 3 个**（21 澄意 / 8 灼冽 / 1 破招）：non-blocking historical 记录，cleaned typed modifier 发布前需人工 audit gate 触发时再决（Day 0 不阻塞）
+- **dogfooding 边界探测未完整覆盖**：lo-user Day 3（`--lang en` 验证 / 故意造错 ERR-* 验证）未执行；Product 自评属 known limitation，不阻塞 release
+
+---
+
+## 5. release-readiness gate
+
+按 `docs/product/dogfooding-v1.md` §4.1 检查：
+
+| 条件 | 状态 |
+|---|---|
+| B-Calc.blocker：0 件未修 | ✅ 0 件 |
+| B-Calc.non-blocker：已重新分类 | ✅ F-02 归 U-Scenario，已 absorbed by D-19 |
+| U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解 | ✅ F-01 / F-02 / F-03 已修；无 unresolved item |
+| P-Range：全部入 V1.x backlog | ✅ G13/G18/G19/G20 已 V1.x（D-13）；其他无新增 |
+| lo-user 整体打分 ≥ 4/5 | ✅ 4/5 |
+
+**通过 release gate**。
+
+---
+
+## 6. 后续流程
+
+按 `docs/product/dogfooding-v1.md` §4.2：
+
+1. ✅ lo-user 宣布通过 + 打分（2026-05-07 00:58）
+2. ✅ Product 整理 dogfooding-report-v1.md（本文件，入仓后）
+3. ⏳ QA release-readiness review task：
+   - 重跑 `pnpm check` / `pnpm test` / `verify:golden-v1` / S1/S2/S3 alias + `jq empty`
+   - 抽查 B-Calc.blocker 修复回归（D-19 PR #30 / G22/G23 PR #28）
+4. ⏳ Product errata PR：DD-001（米游社 D-17）+ DD-002（D-13 19 anchors）+ DD-003（dogfooding gate）+ dogfooding-report 链接 + V1 release notes
+5. ⏳ V1 release（git tag 命名 / 是否 npm publish 待 errata PR 时一并定）
+
+---
+
+## 附录 A · dogfooding 期间合入的关键 PR
+
+| PR | 内容 | commit |
+|---|---|---|
+| PR #28 | G22/G23 manual acceptance + fail-loud | `3f5e67a` |
+| PR #30 | D-19 CLI 输出 reform（brief view + lanes） | `74c5f83` |
+
+## 附录 B · 整体打分明细（lo-user 自评）
+
+1. 安装是否成功？花了多久？卡在哪？— 成功 / 一次跑通
+2. 跑过哪些命令？— calc + verify:golden-v1 + S1/S2/S3 alias + 自建 my-anby-snapshot
+3. 输出能看懂吗？哪里看不懂？— 默认输出曾"太复杂"反馈触发 D-19 修复，修后看懂
+4. 数值是否对得上预期？— 安比 nonCrit 224 / crit 336 / dazeValue 37.536 三方校对通过
+5. 想算但 V1 不支持的场景？— 未报告
+6. 整体 1~5 分？— **4 / 5**

--- a/docs/product/dogfooding-v1.md
+++ b/docs/product/dogfooding-v1.md
@@ -1,0 +1,156 @@
+# Fairy V1 · Dogfooding Runbook v0.1
+
+- 文档版本：v0.1（Product 起草，定稿入仓 `docs/product/dogfooding-v1.md`）
+- Owner：@Product
+- 起始：2026-05-05
+- 形态：repo-local CLI baseline（非 npm 全局）
+- 试用人：**仅 lo-user 一人深度试用**（DD-003 锁定）
+- 已知限制：V1 仅由 lo-user 单人 dogfood 验证 + QA 回归，未经社区广泛验证
+
+---
+
+## 0. 文档关系
+
+- **本文件**：dogfooding 流程（试用人怎么参与 / 反馈怎么收 / 怎么分类 / release trigger）
+- **`docs/getting-started.md`**（TL 已交付 PR #29 / commit c216157）：技术上手 + 5 命令 + S1/S2/S3 示例
+- **`docs/ux/starter-scenarios.md`**（UX）：场景叙事 + 字段说明 + 黄金锚点关联
+- **本文件不重复技术细节**，按"参考 `docs/getting-started.md` §X"引用
+
+---
+
+## 1. Dogfooding 范围与目标
+
+### 1.1 V1 release gate（DD-003 锁定）
+1. ✅ 黄金集 19 anchors 全 pass（PR #28 已达成）
+2. ⏳ **lo-user 单人深度 dogfood 通过**（本文件覆盖）
+3. ⏳ Product errata PR 合入（DD-001 米游社 + DD-002 19 anchors + DD-003 dogfooding gate）
+
+### 1.2 dogfooding 验证什么
+- **可用性**：能否按 getting-started 从零跑通
+- **可读性**：CLI 输出能看懂吗？trace / sourceRefs 是否够解释
+- **数值正确性**：S1/S2/S3 是否符合预期；改自己的队伍后是否合理
+- **错误友好性**：ERR-* 文案是否能让试用人 self-recover
+- **范围漏洞**：是否有"想算但 V1 不支持"的常见场景
+
+### 1.3 不验证什么（V1 范围外）
+- 浏览器 / Web UI（V2）
+- npm 全局发布（V1.x 决定）
+- 社区使用（DD-003 已声明 V1 限制）
+
+---
+
+## 2. 三日推荐流程（弹性，无强制 deadline）
+
+### Day 1 · 上手 + S1/S2/S3 跑通
+1. clone repo → install → run `pnpm test` + `verify:golden-v1`（按 `docs/getting-started.md §1`）
+2. 跑 `pnpm --silent fairy:s1` / `:s2` / `:s3`（§2）
+3. 每个示例：
+   - stdout 是否纯 JSON？`| jq empty` 通过？
+   - `errors[]` 是否为空？
+   - `summary.displayTotalDamage` 是否合理？
+   - 看 trace + buckets，理解每段乘区贡献
+   - 看 modifiers + sourceRefs，验证来源标注
+4. **保留产物**：S1/S2/S3 三命令的 stdout 文件或摘要保存到 `docs/product/dogfooding/day1-stdout/`（或在反馈卡附摘要），供 QA 复核
+5. **填 Day 1 反馈卡**（见 §3）
+
+### Day 2 · 改自己的队伍
+1. 复制 `examples/snapshots/s1-yixuan-sheer.json` 到本地
+2. 改成你自己的队伍配置（队员 / 面板 / boss）
+3. 跑 `pnpm --silent fairy -- calc <yourfile> --lang zh --pretty`
+4. 验证：
+   - 数值与游戏内显示对得上？（理论值 vs 显示值）
+   - 与你已有的攻略对账锚点对得上？
+5. 跑 `compare`（A/B 配装）+ `scan`（乘区曲线）
+6. **填 Day 2 反馈卡**：B-Calc 类反馈**必须附最小复现 snapshot（脱敏后）+ 完整命令**，否则 TL/QA 无法复现
+
+### Day 3 · 边界探测
+1. 故意制造错误：缺字段 / 错误 ID / 错误数值范围
+2. 验证 ERR-* 文案是否友好（能说清是什么错 + 怎么修）
+3. 边界场景：DA 期次切换 / Nicole+Yanagi acceptance toggle on/off / 紊乱 vs 异常
+4. **试 `--lang en`**：英文输出整体流畅？术语映射一致？翻译错位？（D-A 双语承诺验证）
+5. 列出"想算但跑不通 / 跑出来怀疑"的场景
+6. **填 Day 3 反馈卡 + 整体打分**
+
+---
+
+## 3. 反馈分类与路由（4 类 + Owner）
+
+| 类别 | 触发条件 | Owner | 处理路径 |
+|---|---|---|---|
+| **B-Calc / blocker** | crash / schema false-negative（合法输入被误拒）/ V1 支持场景数值错 / JSON stdout 被污染 | @TechLead + @QA | 必修；TL 起 PR + QA 回归 |
+| **B-Calc / non-blocker** | unsupported 场景 schema error / 输入不完整导致的 ERR / trace 可读性问题 | 重新分类为 P-Range / U-* / known limitation | 不直接算 release blocker |
+| **U-ErrCopy** ERR-* 文案不友好 | 看不懂 / 缺关键信息 / 误导 | @UX | micro-PR 修 `messages.{zh,en}.json` |
+| **U-Scenario** 示例 / starter-scenarios 难懂 / 命令复杂 / 文档不易读 | 跑不通 / 字段意义不清 / 命令路径卡 | **@UX 主（first responder）/ @TechLead 协作** | UX 评估 root cause 后定 micro-PR 范围（叙事 → UX；命令路径 → ping TL；getting-started 文案 → ping TL + UX 出文案建议；数值不对 → 转 B-Calc） |
+| **P-Range** V1 范围漏洞 | 想算但 V1 不支持 | @Product → V1.x backlog | 入 backlog，不修 |
+
+### 反馈卡格式（每条独立）
+```
+ID: F-2026-05-XX-NN
+日期: yyyy-mm-dd
+类别: B-Calc.blocker / B-Calc.non-blocker / U-ErrCopy / U-Scenario / P-Range
+命令: pnpm --silent fairy:s1
+快照文件: examples/snapshots/s1-yixuan-sheer.json（或自定义路径）
+最小复现 snapshot: <B-Calc.blocker 必填，脱敏后内联或附件>
+现象: <一两句描述发生了什么>
+期望: <描述你期望发生什么>
+stdout 摘要: <相关字段或 ERR-* code 或 raw stderr>
+备注: <自由写，例如 raw stderr 文本，UX 自分类 MISSING-KEY / UNFRIENDLY 用>
+建议: <可选>
+Owner: <自动按类别填>
+```
+
+---
+
+## 4. release 触发条件
+
+### 4.1 dogfooding 通过 = 同时满足
+- **B-Calc / blocker**：0 件未修
+- **B-Calc / non-blocker**：已重新分类
+- U-ErrCopy / U-Scenario 类：可修的已修；不修的有显式 known limitation 注解
+- P-Range 类：全部入 V1.x backlog（不阻塞 V1）
+- lo-user 整体打分 ≥ 4/5（自评）
+
+### 4.2 通过后流程
+1. lo-user 在 #fairy 宣布 "dogfooding 通过 + 整体打分 X/5"
+2. Product 整理 dogfooding-report-v1.md（反馈清单 + 修复 PR 列表 + 已知限制）+ 入仓 `docs/product/dogfooding-report-v1.md`
+3. **QA release-readiness review task**（独立 task，不替代 lo-user dogfood）：
+   - 重跑 `pnpm check` / `pnpm test` / `verify:golden-v1` / S1/S2/S3 alias + `jq empty`
+   - 抽查本轮 B-Calc.blocker 修复项是否通过回归
+   - 输出 release-readiness 证据
+4. Product 发 errata PR（DD-001 + DD-002 + DD-003 + dogfooding-report 链接）
+5. Product errata + V1 release notes 合入后 → V1 正式发布
+6. **release 形态（git tag 命名 / 是否 npm publish）待 errata PR 时一并定**
+
+### 4.3 不通过怎么办
+- B-Calc / blocker 必修：循环 TL 修 → QA 回归 → lo-user 重测受影响场景
+- 如果 dogfood 暴露 **core formula 级问题**，Product 重新评估 V1 发布节奏（可能延期或缩范围）
+- 整体打分 < 4：lo-user 加注 known limitation 或推到 V1.x
+
+---
+
+## 5. 时间预算
+
+- **Day 1~3**：上手 + 自队伍 + 边界（建议但不强制连续 3 天，弹性）
+- **修复期**：依赖发现的 B-Calc 数量；预估 3~7 天
+- **errata + release**：1 天
+
+总预算 **~1~2 周**，无 deadline，按 lo-user 节奏走。
+
+---
+
+## 6. 与 ayingott-me 的优先级关系
+
+lo-user 17:14 已锁：**fairy 优先**。dogfooding 期间 ayingott-me 的设计推进继续是后台任务，UX 在 fairy 间隙推进 design v0.1。
+
+---
+
+## 附录 A · 反馈清单（活页）
+（dogfooding 进行时 lo-user / Product 在这里累积所有 F-* 卡片）
+
+## 附录 B · 整体打分模板
+1. 安装是否成功？花了多久？卡在哪？__
+2. 跑过哪些命令？__
+3. 输出能看懂吗？哪里看不懂？__
+4. 数值是否对得上预期？__
+5. 想算但 V1 不支持的场景？__
+6. 整体 1~5 分？__ 为什么？__

--- a/docs/product/dogfooding-v1.md
+++ b/docs/product/dogfooding-v1.md
@@ -3,7 +3,8 @@
 - 文档版本：v0.1（Product 起草，定稿入仓 `docs/product/dogfooding-v1.md`）
 - Owner：@Product
 - 起始：2026-05-05
-- 形态：repo-local CLI baseline（非 npm 全局）
+- 形态：repo-local CLI baseline（dogfooding 期间不验证 npm 全局发布）
+- **release 形态以 `docs/product/dogfooding-report-v1.md` §6 + release workflow（PR #36 `a0ca3e6`）为准**
 - 试用人：**仅 lo-user 一人深度试用**（DD-003 锁定）
 - 已知限制：V1 仅由 lo-user 单人 dogfood 验证 + QA 回归，未经社区广泛验证
 
@@ -32,9 +33,9 @@
 - **错误友好性**：ERR-* 文案是否能让试用人 self-recover
 - **范围漏洞**：是否有"想算但 V1 不支持"的常见场景
 
-### 1.3 不验证什么（V1 范围外）
+### 1.3 不验证什么（dogfooding 范围外）
 - 浏览器 / Web UI（V2）
-- npm 全局发布（V1.x 决定）
+- npm 全局发布（dogfooding 不验证；V1 release 形态由 release workflow 处理 — 见报告 §6）
 - 社区使用（DD-003 已声明 V1 限制）
 
 ---
@@ -119,7 +120,7 @@ Owner: <自动按类别填>
    - 输出 release-readiness 证据
 4. Product 发 errata PR（DD-001 + DD-002 + DD-003 + dogfooding-report 链接）
 5. Product errata + V1 release notes 合入后 → V1 正式发布
-6. **release 形态（git tag 命名 / 是否 npm publish）待 errata PR 时一并定**
+6. **release 形态以报告 `docs/product/dogfooding-report-v1.md` §6 为准**（`@randomplay/{data,core,cli}` npm publish via OIDC + Trusted Publisher，起始版本 `v0.0.1`，rollback runbook 完整）— PR #35 / #36 已落地
 
 ### 4.3 不通过怎么办
 - B-Calc / blocker 必修：循环 TL 修 → QA 回归 → lo-user 重测受影响场景


### PR DESCRIPTION
## Summary
Capture lo-user's V1 dogfooding evidence per docs/product/dogfooding-v1.md. lo-user scored 4/5, satisfying the release gate threshold.

## Slock Context
- **Owner**: @Product
- **Reviewers**: @lo-user / @TechLead / @UX / @QA
- **Related decisions**: DD-003 (single-person dogfooding gate)
- **Source threads**: #fairy 2026-05-07 00:55 lo-user 'A' + 00:58 '4'

## Highlights
- 4 feedback items: F-01 default verbose (resolved by D-19 / PR #30), F-02 expectation default (D-19), F-03 self-built snapshot data lookup (TL helper), F-04 G22/G23 silent fallback (PR #28)
- 0 unresolved B-Calc.blocker
- Known limitations: DD-003 single-person scope / 19 golden anchors / 3 mihoyo sourceConflicts / Day 3 boundary not fully covered
- Triggers: QA release-readiness review next; then Product errata PR with DD-001/DD-002/DD-003 + release notes

## Test plan
- [ ] @QA confirm release-readiness gate after report merged: pnpm check / pnpm test / verify:golden-v1 / S1-S3 alias / jq empty / B-Calc.blocker fix regression spot-check
- [ ] @lo-user final pass on report content if want to add a specific lossy point for 4-vs-5
- [ ] @TechLead confirm PR #28 / PR #30 commits referenced are accurate