### PR TITLE
docs: update V1 release-gate status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 
 ## Current Phase
 
-S5 data ingestion. Current engineering entry points:
+V1 release gate preparation. lo-user dogfooding has passed 4/5 with zero
+unresolved B-Calc blockers; Product errata, release notes, and QA
+release-readiness review remain before any V1 tag. Current engineering entry
+points:
 
 - `docs/architecture/naming-policy.md`
 - `docs/architecture/monorepo-development.md`
@@ -36,3 +39,10 @@ S5 data ingestion. Current engineering entry points:
 - `packages/cli/`
 - `packages/data/`
 - `examples/snapshots/`
+
+Release-gate notes:
+
+- `fairy calc` defaults to `--view brief`; use `--view verbose` for full trace.
+- The Anby dogfooding fixture
+  `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` is covered
+  by `packages/cli/src/examples.test.ts` and therefore by root `pnpm test`.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@ V1 focuses on a TypeScript monorepo with three packages:
 
 Start with [docs/index.md](docs/index.md).
 
-## V1 Dogfooding Status
+## V1 Release Gate Status
 
-V1 is currently validated through lo-user single-person dogfooding plus QA
-regression. It has not gone through broad community dogfooding yet.
+V1 has passed lo-user single-person dogfooding with an overall 4/5 score and
+zero unresolved B-Calc blockers. It has not gone through broad community
+dogfooding yet.
 
 Use [docs/getting-started.md](docs/getting-started.md) for the repo-local
 dogfooding flow and executable examples.
+
+`fairy calc` defaults to `--view brief`, which returns summary-first non-crit
+and crit lanes. The dogfooding Anby fixture is covered by the `@fairy/cli` test
+suite and remains part of the fixed `pnpm test` verification chain.
 
 ## Development
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,14 @@
 # Fairy V1 Dogfooding Quick Start
 
-Status: V1 dogfood candidate
+Status: V1 release-gate candidate
 
 Fairy V1 is currently a repo-local CLI baseline. It is not published as a
 global npm package yet. Use this guide for dogfooding and pre-release review.
 
-V1 dogfooding is currently scoped to lo-user single-person deep validation plus
-QA regression. It has not gone through broad community dogfooding yet.
+V1 dogfooding has passed lo-user single-person deep validation with an overall
+4/5 score and zero unresolved B-Calc blockers. QA regression and release notes
+still gate the V1 tag. Fairy has not gone through broad community dogfooding
+yet.
 
 ## 1. Prepare a Clean Checkout
 
@@ -42,6 +44,11 @@ The examples are strict JSON files under `examples/snapshots/`:
 | `pnpm --silent fairy:s2` | `examples/snapshots/s2-yanagi-disorder.json` | S2 Yanagi shock disorder against Pompey |
 | `pnpm --silent fairy:s3` | `examples/snapshots/s3-team-g22-g23-acceptance.json` | S3 V1 G22/G23 manual-acceptance demo with Nicole and Yanagi accepted effects |
 | direct file | `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` | Dogfooding regression: Anby core F basic 16 vs Dullahan defense 952.8 |
+
+The Anby dogfooding fixture is not only a manual example. It is asserted in
+`packages/cli/src/examples.test.ts` and therefore runs as part of the fixed
+`pnpm test` verification chain. Expected summary values are non-crit `224`,
+crit `336`, and daze value `37.536`.
 
 The narrative source for S1 and S2 is
 [`docs/ux/starter-scenarios.md`](ux/starter-scenarios.md). That document uses
@@ -134,5 +141,6 @@ Feedback routing:
 - Users provide or edit explicit JSON snapshots.
 - The V1 golden gate is 19 anchors passed with zero blocking diagnostics.
 - The V1 dogfooding gate is lo-user single-person deep validation plus QA
-  regression; broad community validation is deferred.
+  regression. It passed 4/5 with zero unresolved B-Calc blockers; broad
+  community validation is deferred.
 - G13, G18, G19, and G20 are intentionally deferred to V1.x.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,14 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@fai
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)
 
-## S5 当前重点
+## V1 release gate 当前重点
 
-1. 以危局强袭战（Deadly Assault）为 V1 cleaned-data 主场景，优先产出 `@fairy/data/cleaned/deadly-assault`。
-2. 保留 Excel 与 raw crawler source archive，但 V1 不要求全量清洗 Excel enemy；Excel enemy 作为后备 / V1.x 扩展源。
-3. 米游社用于危局强袭战中文详情正文、3 个可选 buff、3 个 boss 房间机制文本、zh/en source-text 对照；buhflipexplode 用于 DA period / boss slot / buff / multiplier overlay 和英文源文本。
-4. V1 golden fixture 真数据复算收窄到 19 个锚点；G13 异常阈值规则组合、部位破坏与非 DA enemy 失衡恢复锚点推迟到 V1.x。
-5. 当前 #43 replay 已生成 `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json`；19 个 V1 锚点全部跑通，`releaseReady=true`，G13/G18/G19/G20 仍作为 V1.x deferred 可见。
+1. lo-user 单人 dogfooding 已给出 4/5，B-Calc blocker 当前为 0；V1 仍未经过广泛社区 dogfooding。
+2. V1 golden fixture 真数据复算收窄到 19 个锚点；G13 异常阈值规则组合、G18 部位破坏真实伤害、G19/G20 失衡恢复时间推迟到 V1.x。
+3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；19 个 V1 锚点全部跑通，`releaseReady=true`，G13/G18/G19/G20 仍作为 V1.x deferred 可见。
+4. `fairy calc` 默认 `--view brief`，输出 summary-first 的 non-crit / crit lanes；完整 trace 通过 `--view verbose` 查看。
+5. 安比 dogfooding fixture `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` 已进入 `packages/cli/src/examples.test.ts`，因此由根命令 `pnpm test` 固定覆盖。
+6. V1 tag / release notes 前仍需 Product errata 与 QA release-readiness review；release 流程本身另行锁定。
 
 ## 关键文档
 


### PR DESCRIPTION
## Summary

- Update `CLAUDE.md` / `AGENTS.md`, `README.md`, `docs/index.md`, and `docs/getting-started.md` from stale S5 wording to the current V1 release-gate state.
- Record that lo-user dogfooding passed 4/5 with zero unresolved B-Calc blockers.
- Document that the Anby dogfooding fixture is part of the fixed `pnpm test` verification chain via `packages/cli/src/examples.test.ts`.
- Add the direct expected Anby summary values: nonCrit 224 / crit 336 / dazeValue 37.536.

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm --filter @fairy/data verify:golden-v1`
- `pnpm --silent fairy -- calc examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json --lang zh --pretty | jq '.summary | {nonCrit: .lanes.nonCrit.displayDamage, crit: .lanes.crit.displayDamage, dazeValue: .daze.value, expectedDamage}'`
- `git diff --check`

Note: root `pnpm lint` is not available in this repo (`Command "lint" not found`), so it is not part of the fairy verification contract.
