### PR TITLE
docs(data): resolve DA source conflict audit

### DIFF
--- a/data/cleaned/README.md
+++ b/data/cleaned/README.md
@@ -20,4 +20,8 @@ Current generated artifacts:
   candidates for V1 team-modifier replay.
 - `audit/nicole.acceptance.json` and `audit/yanagi.acceptance.json` —
   lo-user manual acceptance records for G22/G23 source-text mappings.
+- `audit/mihoyo-buhflipexplode.source-conflicts.json` — manual audit
+  resolution for the three historical Mihoyo/buhflipexplode Deadly Assault
+  buff source conflicts, preferring buhflipexplode after nanoka lookup while
+  retaining Mihoyo source trace.
 - `golden/v1-replay-report.json` — source-backed V1 golden replay report.

--- a/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json
+++ b/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json
@@ -1,0 +1,282 @@
+{
+  "schemaVersion": "fairy-da-source-conflict-audit-v1",
+  "parserVersion": "manual-da-source-conflict-audit-v0.1.0",
+  "generatedAt": "2026-05-08T15:55:00+08:00",
+  "policy": {
+    "scope": "Manual audit resolution for the three historical non-blocking Mihoyo/buhflipexplode Deadly Assault buff sourceConflict records from the 2026-05-05 Mihoyo alignment snapshot.",
+    "cleanedDataEffect": "These records resolve release evidence for the source conflicts only. They do not publish formal typed modifiers or overwrite retained raw source snapshots.",
+    "selectedSource": "buhflipexplode-zzz-da",
+    "resolutionStatus": "resolved",
+    "rawSnapshotPolicy": "Retained raw Mihoyo alignment still records the original sourceConflict issues for audit trace. Cleaned release evidence uses this manual audit artifact as the resolution layer.",
+    "thirdPartyLookupPolicy": "nanoka is used as manual tie-breaker evidence only. It is not a crawler source, not part of the cleaned-data pipeline, and not redistributed as source data.",
+    "starterScenarioImpact": {
+      "checkedPath": "docs/ux/starter-scenarios.md",
+      "checkedPattern": "澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt",
+      "matches": 0,
+      "action": "No UX starter-scenario update required."
+    }
+  },
+  "decision": {
+    "selectedBy": "@lo-user",
+    "selectedAt": "2026-05-08T10:54:29+08:00",
+    "decisionRef": {
+      "target": "#fairy",
+      "messageId": "0a08cfb6"
+    },
+    "decisionText": "Q1，按 buhflipexplode",
+    "rationale": "nanoka manual lookup matched buhflipexplode for all three conflicts, giving a 2:1 evidence split against the retained Mihoyo text."
+  },
+  "manualLookupSource": {
+    "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+    "url": "https://zzz.nanoka.cc/boss/",
+    "role": "manual-tie-breaker-only",
+    "observedDataVersion": "3.0.1+15390262",
+    "checkedBy": "@TechLead",
+    "checkedAt": "2026-05-07T19:49:33+08:00"
+  },
+  "summary": {
+    "totalRecords": 3,
+    "resolvedPreferBuhflipexplode": 3,
+    "remainingBlockingConflicts": 0,
+    "remainingNonBlockingReleaseConflicts": 0
+  },
+  "records": [
+    {
+      "auditId": "da-buff-69000030-period-21-clarity",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 21,
+        "title": "危局强袭战（第21期）",
+        "mihoyoContentId": 1605,
+        "buhflipexplodeVersionKey": "2.2.3"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "澄意",
+        "buhflipexplodeName": "Clarity",
+        "buhflipexplodeBuffId": "69000030"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1605.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "3c8f8638445db50ac70bc75f651f77dd546155ffcfb7c2fcdbd58dfe73ada742"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000030",
+          "sourceTextHash": "68b6720414f4edd87e27f1ef9481eda84e213d98910c19e4dad4350352cb13d1"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 21 / Clarity"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "代理人的暴击伤害提升30%，贯穿伤害提升15%。",
+          "[命破]特性的代理人造成的伤害提升15%，终结技造成的伤害额外提升15%。"
+        ],
+        "buhflipexplode": "Agent HP increases by 25%, and their Sheer DMG increases by 15%.\nAgents with Rupture specialty deal 15% more DMG, and their Ultimate DMG is additionally increased by 15%.",
+        "nanoka": "Matches buhflipexplode: HP +25%, Sheer DMG +15%, Rupture DMG +15%, Ultimate DMG +15%."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "critDamage": 0.3,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        },
+        "buhflipexplode": {
+          "maxHp": 0.25,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        },
+        "nanoka": {
+          "maxHp": 0.25,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"澄意\" in 危局强袭战（第21期）; mapped to 69000030 with score 0.75",
+        "mihoyoNumericSignature": "15|15|15|30",
+        "buhflipexplodeNumericSignature": "15|15|15|25"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    },
+    {
+      "auditId": "da-buff-69000015-period-8-blazing-chill",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 8,
+        "title": "危局强袭战（第8期）",
+        "mihoyoContentId": 1260,
+        "buhflipexplodeVersionKey": "1.6.2"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "灼冽",
+        "buhflipexplodeName": "Blazing Chill",
+        "buhflipexplodeBuffId": "69000015"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1260.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "ae3281d78854c0cfcd4f9f1cdbf536bf7fb1f330713559dfaff577e837416fa0"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000015",
+          "sourceTextHash": "8fdbd740ba8a8293aa76b75b610a995ad8500633948ad32c88d095c1504d0968"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 8 / Blazing Chill"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "代理人的火属性异常积蓄效率和冰属性异常积蓄效率将提升20%，攻击力提升25%。",
+          "对敌人施加属性异常效果时，代理人回复300点喧响值，提升80点异常精通，持续15秒。"
+        ],
+        "buhflipexplode": "Agent Fire Anomaly Buildup Rate and Ice Anomaly Buildup Rate increase by 20%, and ATK increases by 25%.\nWhen inflicting an Attribute Anomaly on enemies, the Agent restores 400 Decibels and Anomaly Proficiency is increased by 80, lasting 15s. Decibels recovery can be triggered once every 15s.",
+        "nanoka": "Matches buhflipexplode: Fire/Ice Anomaly Buildup Rate +20%, ATK +25%, restores 400 Decibels, Anomaly Proficiency +80 for 15s, Decibels recovery trigger interval 15s."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 300,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": null
+        },
+        "buhflipexplode": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 400,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": 15
+        },
+        "nanoka": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 400,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": 15
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"灼冽\" in 危局强袭战（第8期）; mapped to 69000015 with score 0.67",
+        "mihoyoNumericSignature": "15|20|25|80|300",
+        "buhflipexplodeNumericSignature": "15|15|20|25|80|400"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    },
+    {
+      "auditId": "da-buff-69000002-period-1-interrupt",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 1,
+        "title": "危局强袭战（第1期）",
+        "mihoyoContentId": 1035,
+        "buhflipexplodeVersionKey": "1.4.1"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "破招",
+        "buhflipexplodeName": "Interrupt",
+        "buhflipexplodeBuffId": "69000002"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1035.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "fd421cd01efbc75658d56b349487f4e5250a80051d9aaed7ab3c5d6b17a3c848"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000002",
+          "sourceTextHash": "97ad93b2094505dd03cce313ae3e469bbc36666a2f9db36e102f1a9575a1cc44"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 1 / Interrupt"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "[普通攻击]、[闪避反击]、[强化特殊技]、[冲刺攻击]造成的伤害提升30%。",
+          "触发[极限闪避]或[极限支援]后，全队攻击力提升10%，暴击伤害提升20%，持续15秒，最多叠加3层，每层效果单独结算持续时间。"
+        ],
+        "buhflipexplode": "Basic Attack, Dodge Counter, EX Special Attack, and Dash Attack DMG increases by 30%.\nAfter triggering a Perfect Dodge or Perfect Assist, increases all squad members' ATK by 10% and CRIT DMG by 10% for 15s. Stacks up to 3 times. The duration of each stack is calculated separately.",
+        "nanoka": "Matches buhflipexplode: listed attack DMG +30%; after Perfect Dodge/Assist, squad ATK +10% and CRIT DMG +10% for 15s, up to 3 stacks."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.2,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        },
+        "buhflipexplode": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.1,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        },
+        "nanoka": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.1,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"破招\" in 危局强袭战（第1期）; mapped to 69000002 with score 0.80",
+        "mihoyoNumericSignature": "3|10|15|20|30",
+        "buhflipexplodeNumericSignature": "3|10|10|15|30"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    }
+  ]
+}

--- a/docs/data-source/mihoyo/README.md
+++ b/docs/data-source/mihoyo/README.md
@@ -79,6 +79,25 @@ Current non-blocking source conflicts are recorded in
 `alignment/mihoyo-buhflipexplode.json`. They are source-text differences, not
 published cleaned modifiers.
 
+The three release-relevant buff conflicts from this snapshot were manually
+audited after lo-user provided nanoka (`https://zzz.nanoka.cc/boss/`) as a
+lookup-only third source. Nanoka matched buhflipexplode for all three records,
+so the cleaned release evidence resolves them as
+`resolved-prefer-buhflipexplode` in
+`data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`. The raw
+Mihoyo alignment artifact remains unchanged and continues to retain the original
+Mihoyo values, buhflipexplode values, hashes, and source anchors for audit
+trace. Nanoka is not part of the crawler or cleaned-data pipeline.
+
+UX impact was checked with:
+
+```bash
+rg -n "澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt" docs/ux/starter-scenarios.md
+```
+
+The command had no matches, so no starter-scenario update is required for this
+audit resolution.
+
 ## Verification
 
 `packages/data/scripts/mihoyo-da-source.mjs` has separate commands:

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -199,6 +199,13 @@
 - 米游社 = 中文 i18n / 描述源
 - 冲突时 fail loud + manual review，**不自动覆盖**
 
+**2026-05-08 sourceConflict audit 补充**：PR #24 留存的 3 条米游社 /
+buhflipexplode 危局强袭战 buff `sourceConflict` 已做人工 audit。lo-user 决策
+`Q1，按 buhflipexplode`；nanoka (`https://zzz.nanoka.cc/boss/`) 仅作为人工查询源，
+且 3 条均与 buhflipexplode 一致。因此 cleaned release evidence 记录为
+`resolved-prefer-buhflipexplode`，Mihoyo 原值和 source refs 继续保留为审计线索。
+详见 `data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`。
+
 **Multi-source metadata**：
 - entity-level `sources[]`
 - 关键数值字段级 `sourceRefs`（DA boss slot multiplier、buff 数值、effective HP / daze / anomaly 派生字段等必须有）

--- a/packages/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json
+++ b/packages/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json
@@ -1,0 +1,282 @@
+{
+  "schemaVersion": "fairy-da-source-conflict-audit-v1",
+  "parserVersion": "manual-da-source-conflict-audit-v0.1.0",
+  "generatedAt": "2026-05-08T15:55:00+08:00",
+  "policy": {
+    "scope": "Manual audit resolution for the three historical non-blocking Mihoyo/buhflipexplode Deadly Assault buff sourceConflict records from the 2026-05-05 Mihoyo alignment snapshot.",
+    "cleanedDataEffect": "These records resolve release evidence for the source conflicts only. They do not publish formal typed modifiers or overwrite retained raw source snapshots.",
+    "selectedSource": "buhflipexplode-zzz-da",
+    "resolutionStatus": "resolved",
+    "rawSnapshotPolicy": "Retained raw Mihoyo alignment still records the original sourceConflict issues for audit trace. Cleaned release evidence uses this manual audit artifact as the resolution layer.",
+    "thirdPartyLookupPolicy": "nanoka is used as manual tie-breaker evidence only. It is not a crawler source, not part of the cleaned-data pipeline, and not redistributed as source data.",
+    "starterScenarioImpact": {
+      "checkedPath": "docs/ux/starter-scenarios.md",
+      "checkedPattern": "澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt",
+      "matches": 0,
+      "action": "No UX starter-scenario update required."
+    }
+  },
+  "decision": {
+    "selectedBy": "@lo-user",
+    "selectedAt": "2026-05-08T10:54:29+08:00",
+    "decisionRef": {
+      "target": "#fairy",
+      "messageId": "0a08cfb6"
+    },
+    "decisionText": "Q1，按 buhflipexplode",
+    "rationale": "nanoka manual lookup matched buhflipexplode for all three conflicts, giving a 2:1 evidence split against the retained Mihoyo text."
+  },
+  "manualLookupSource": {
+    "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+    "url": "https://zzz.nanoka.cc/boss/",
+    "role": "manual-tie-breaker-only",
+    "observedDataVersion": "3.0.1+15390262",
+    "checkedBy": "@TechLead",
+    "checkedAt": "2026-05-07T19:49:33+08:00"
+  },
+  "summary": {
+    "totalRecords": 3,
+    "resolvedPreferBuhflipexplode": 3,
+    "remainingBlockingConflicts": 0,
+    "remainingNonBlockingReleaseConflicts": 0
+  },
+  "records": [
+    {
+      "auditId": "da-buff-69000030-period-21-clarity",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 21,
+        "title": "危局强袭战（第21期）",
+        "mihoyoContentId": 1605,
+        "buhflipexplodeVersionKey": "2.2.3"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "澄意",
+        "buhflipexplodeName": "Clarity",
+        "buhflipexplodeBuffId": "69000030"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1605.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "3c8f8638445db50ac70bc75f651f77dd546155ffcfb7c2fcdbd58dfe73ada742"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000030",
+          "sourceTextHash": "68b6720414f4edd87e27f1ef9481eda84e213d98910c19e4dad4350352cb13d1"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 21 / Clarity"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "代理人的暴击伤害提升30%，贯穿伤害提升15%。",
+          "[命破]特性的代理人造成的伤害提升15%，终结技造成的伤害额外提升15%。"
+        ],
+        "buhflipexplode": "Agent HP increases by 25%, and their Sheer DMG increases by 15%.\nAgents with Rupture specialty deal 15% more DMG, and their Ultimate DMG is additionally increased by 15%.",
+        "nanoka": "Matches buhflipexplode: HP +25%, Sheer DMG +15%, Rupture DMG +15%, Ultimate DMG +15%."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "critDamage": 0.3,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        },
+        "buhflipexplode": {
+          "maxHp": 0.25,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        },
+        "nanoka": {
+          "maxHp": 0.25,
+          "sheerDamage": 0.15,
+          "ruptureDamage": 0.15,
+          "ultimateDamage": 0.15
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"澄意\" in 危局强袭战（第21期）; mapped to 69000030 with score 0.75",
+        "mihoyoNumericSignature": "15|15|15|30",
+        "buhflipexplodeNumericSignature": "15|15|15|25"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    },
+    {
+      "auditId": "da-buff-69000015-period-8-blazing-chill",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 8,
+        "title": "危局强袭战（第8期）",
+        "mihoyoContentId": 1260,
+        "buhflipexplodeVersionKey": "1.6.2"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "灼冽",
+        "buhflipexplodeName": "Blazing Chill",
+        "buhflipexplodeBuffId": "69000015"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1260.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "ae3281d78854c0cfcd4f9f1cdbf536bf7fb1f330713559dfaff577e837416fa0"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000015",
+          "sourceTextHash": "8fdbd740ba8a8293aa76b75b610a995ad8500633948ad32c88d095c1504d0968"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 8 / Blazing Chill"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "代理人的火属性异常积蓄效率和冰属性异常积蓄效率将提升20%，攻击力提升25%。",
+          "对敌人施加属性异常效果时，代理人回复300点喧响值，提升80点异常精通，持续15秒。"
+        ],
+        "buhflipexplode": "Agent Fire Anomaly Buildup Rate and Ice Anomaly Buildup Rate increase by 20%, and ATK increases by 25%.\nWhen inflicting an Attribute Anomaly on enemies, the Agent restores 400 Decibels and Anomaly Proficiency is increased by 80, lasting 15s. Decibels recovery can be triggered once every 15s.",
+        "nanoka": "Matches buhflipexplode: Fire/Ice Anomaly Buildup Rate +20%, ATK +25%, restores 400 Decibels, Anomaly Proficiency +80 for 15s, Decibels recovery trigger interval 15s."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 300,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": null
+        },
+        "buhflipexplode": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 400,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": 15
+        },
+        "nanoka": {
+          "fireAnomalyBuildupRate": 0.2,
+          "iceAnomalyBuildupRate": 0.2,
+          "attack": 0.25,
+          "decibelsRestored": 400,
+          "anomalyProficiency": 80,
+          "durationSeconds": 15,
+          "decibelsRecoveryCooldownSeconds": 15
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"灼冽\" in 危局强袭战（第8期）; mapped to 69000015 with score 0.67",
+        "mihoyoNumericSignature": "15|20|25|80|300",
+        "buhflipexplodeNumericSignature": "15|15|20|25|80|400"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    },
+    {
+      "auditId": "da-buff-69000002-period-1-interrupt",
+      "status": "resolved-prefer-buhflipexplode",
+      "period": {
+        "periodNumber": 1,
+        "title": "危局强袭战（第1期）",
+        "mihoyoContentId": 1035,
+        "buhflipexplodeVersionKey": "1.4.1"
+      },
+      "buff": {
+        "slotIndex": 2,
+        "mihoyoName": "破招",
+        "buhflipexplodeName": "Interrupt",
+        "buhflipexplodeBuffId": "69000002"
+      },
+      "sourceRefs": {
+        "mihoyo": {
+          "sourceId": "mihoyo-zzz-critical-assault",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "details/1035.entry_page.json#data.page.modules[0].components[0].data.tables[0].row[2]",
+          "sourceTextHash": "fd421cd01efbc75658d56b349487f4e5250a80051d9aaed7ab3c5d6b17a3c848"
+        },
+        "buhflipexplode": {
+          "sourceId": "buhflipexplode-zzz-da",
+          "sourceVersion": "sha256:see-fetch-manifest",
+          "sourceAnchor": "assets/zzz/buffs.live.json#69000002",
+          "sourceTextHash": "97ad93b2094505dd03cce313ae3e469bbc36666a2f9db36e102f1a9575a1cc44"
+        },
+        "nanoka": {
+          "sourceId": "nanoka-zzz-boss-manual-2026-05-07",
+          "sourceVersion": "3.0.1+15390262",
+          "sourceAnchor": "https://zzz.nanoka.cc/boss/ manual lookup: period 1 / Interrupt"
+        }
+      },
+      "sourceText": {
+        "mihoyo": [
+          "[普通攻击]、[闪避反击]、[强化特殊技]、[冲刺攻击]造成的伤害提升30%。",
+          "触发[极限闪避]或[极限支援]后，全队攻击力提升10%，暴击伤害提升20%，持续15秒，最多叠加3层，每层效果单独结算持续时间。"
+        ],
+        "buhflipexplode": "Basic Attack, Dodge Counter, EX Special Attack, and Dash Attack DMG increases by 30%.\nAfter triggering a Perfect Dodge or Perfect Assist, increases all squad members' ATK by 10% and CRIT DMG by 10% for 15s. Stacks up to 3 times. The duration of each stack is calculated separately.",
+        "nanoka": "Matches buhflipexplode: listed attack DMG +30%; after Perfect Dodge/Assist, squad ATK +10% and CRIT DMG +10% for 15s, up to 3 stacks."
+      },
+      "normalizedComparison": {
+        "mihoyo": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.2,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        },
+        "buhflipexplode": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.1,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        },
+        "nanoka": {
+          "listedAttackDamage": 0.3,
+          "attack": 0.1,
+          "critDamage": 0.1,
+          "durationSeconds": 15,
+          "maxStacks": 3
+        }
+      },
+      "originalIssue": {
+        "severity": "nonBlocking",
+        "reason": "sourceConflict",
+        "message": "Mihoyo/buhflipexplode buff numeric text differs for \"破招\" in 危局强袭战（第1期）; mapped to 69000002 with score 0.80",
+        "mihoyoNumericSignature": "3|10|15|20|30",
+        "buhflipexplodeNumericSignature": "3|10|10|15|30"
+      },
+      "releaseDecision": {
+        "sourceForCleanedResolution": "buhflipexplode-zzz-da",
+        "mihoyoHandling": "retained-as-conflicting-source-trace",
+        "nanokaSupport": "supports-buhflipexplode"
+      }
+    }
+  ]
+}

--- a/packages/data/src/source-conflict-audit.test.ts
+++ b/packages/data/src/source-conflict-audit.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+const auditPath = join(repoRoot, "data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json")
+const packageAuditPath = join(repoRoot, "packages/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json")
+const rawAlignmentPath = join(
+  repoRoot,
+  "data/source/raw/mihoyo/zzz-da/2026-05-05T0850Z/alignment/mihoyo-buhflipexplode.json",
+)
+
+type AuditRecord = {
+  auditId: string
+  status: string
+  buff: {
+    mihoyoName: string
+    buhflipexplodeName: string
+    buhflipexplodeBuffId: string
+  }
+  normalizedComparison: {
+    mihoyo: Record<string, unknown>
+    buhflipexplode: Record<string, unknown>
+    nanoka: Record<string, unknown>
+  }
+  releaseDecision: {
+    sourceForCleanedResolution: string
+    mihoyoHandling: string
+    nanokaSupport: string
+  }
+}
+
+type SourceConflictAudit = {
+  policy: {
+    selectedSource: string
+    resolutionStatus: string
+    thirdPartyLookupPolicy: string
+    starterScenarioImpact: {
+      checkedPath: string
+      checkedPattern: string
+      matches: number
+    }
+  }
+  decision: {
+    selectedBy: string
+    decisionRef: { target: string; messageId: string }
+    decisionText: string
+  }
+  manualLookupSource: {
+    role: string
+    observedDataVersion: string
+  }
+  summary: {
+    totalRecords: number
+    resolvedPreferBuhflipexplode: number
+    remainingBlockingConflicts: number
+    remainingNonBlockingReleaseConflicts: number
+  }
+  records: AuditRecord[]
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T
+}
+
+function recordByBuffId(audit: SourceConflictAudit, buffId: string): AuditRecord {
+  const record = audit.records.find(item => item.buff.buhflipexplodeBuffId === buffId)
+  expect(record, `missing audit record for buff ${buffId}`).toBeDefined()
+  return record!
+}
+
+describe("Mihoyo/buhflipexplode source-conflict audit", () => {
+  it("resolves the three release-relevant buff conflicts to buhflipexplode", () => {
+    const audit = readJson<SourceConflictAudit>(auditPath)
+
+    expect(audit.policy).toMatchObject({
+      selectedSource: "buhflipexplode-zzz-da",
+      resolutionStatus: "resolved",
+      starterScenarioImpact: {
+        checkedPath: "docs/ux/starter-scenarios.md",
+        checkedPattern: "澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt",
+        matches: 0,
+      },
+    })
+    expect(audit.policy.thirdPartyLookupPolicy).toContain("manual tie-breaker evidence only")
+    expect(audit.decision).toMatchObject({
+      selectedBy: "@lo-user",
+      decisionRef: { target: "#fairy", messageId: "0a08cfb6" },
+      decisionText: "Q1，按 buhflipexplode",
+    })
+    expect(audit.manualLookupSource).toMatchObject({
+      role: "manual-tie-breaker-only",
+      observedDataVersion: "3.0.1+15390262",
+    })
+    expect(audit.summary).toMatchObject({
+      totalRecords: 3,
+      resolvedPreferBuhflipexplode: 3,
+      remainingBlockingConflicts: 0,
+      remainingNonBlockingReleaseConflicts: 0,
+    })
+    expect(audit.records.map(record => record.auditId)).toEqual([
+      "da-buff-69000030-period-21-clarity",
+      "da-buff-69000015-period-8-blazing-chill",
+      "da-buff-69000002-period-1-interrupt",
+    ])
+    expect(
+      audit.records.every(record =>
+        record.status === "resolved-prefer-buhflipexplode"
+        && record.releaseDecision.sourceForCleanedResolution === "buhflipexplode-zzz-da"
+        && record.releaseDecision.mihoyoHandling === "retained-as-conflicting-source-trace"
+        && record.releaseDecision.nanokaSupport === "supports-buhflipexplode",
+      ),
+    ).toBe(true)
+  })
+
+  it("records the buhflipexplode/nanoka values that won the audit", () => {
+    const audit = readJson<SourceConflictAudit>(auditPath)
+
+    const clarity = recordByBuffId(audit, "69000030")
+    expect(clarity.buff).toMatchObject({ mihoyoName: "澄意", buhflipexplodeName: "Clarity" })
+    expect(clarity.normalizedComparison.mihoyo).toMatchObject({
+      critDamage: 0.3,
+      sheerDamage: 0.15,
+    })
+    expect(clarity.normalizedComparison.buhflipexplode).toMatchObject({
+      maxHp: 0.25,
+      sheerDamage: 0.15,
+      ruptureDamage: 0.15,
+      ultimateDamage: 0.15,
+    })
+    expect(clarity.normalizedComparison.nanoka).toMatchObject(clarity.normalizedComparison.buhflipexplode)
+
+    const blazingChill = recordByBuffId(audit, "69000015")
+    expect(blazingChill.buff).toMatchObject({ mihoyoName: "灼冽", buhflipexplodeName: "Blazing Chill" })
+    expect(blazingChill.normalizedComparison.mihoyo).toMatchObject({
+      decibelsRestored: 300,
+      decibelsRecoveryCooldownSeconds: null,
+    })
+    expect(blazingChill.normalizedComparison.buhflipexplode).toMatchObject({
+      decibelsRestored: 400,
+      decibelsRecoveryCooldownSeconds: 15,
+      anomalyProficiency: 80,
+      durationSeconds: 15,
+    })
+    expect(blazingChill.normalizedComparison.nanoka).toMatchObject(blazingChill.normalizedComparison.buhflipexplode)
+
+    const interrupt = recordByBuffId(audit, "69000002")
+    expect(interrupt.buff).toMatchObject({ mihoyoName: "破招", buhflipexplodeName: "Interrupt" })
+    expect(interrupt.normalizedComparison.mihoyo).toMatchObject({ critDamage: 0.2 })
+    expect(interrupt.normalizedComparison.buhflipexplode).toMatchObject({
+      listedAttackDamage: 0.3,
+      attack: 0.1,
+      critDamage: 0.1,
+      durationSeconds: 15,
+      maxStacks: 3,
+    })
+    expect(interrupt.normalizedComparison.nanoka).toMatchObject(interrupt.normalizedComparison.buhflipexplode)
+  })
+
+  it("keeps the raw source-conflict trace while adding cleaned release resolution", () => {
+    const raw = readJson<{ unresolved: Array<{ reason: string }> }>(rawAlignmentPath)
+    const audit = readJson<SourceConflictAudit>(auditPath)
+
+    expect(raw.unresolved.filter(issue => issue.reason === "sourceConflict")).toHaveLength(3)
+    expect(audit.records.every(record => record.status === "resolved-prefer-buhflipexplode")).toBe(true)
+  })
+
+  it("keeps the synced package copy byte-identical to cleaned staging", () => {
+    expect(readFileSync(packageAuditPath, "utf8")).toBe(readFileSync(auditPath, "utf8"))
+  })
+})


### PR DESCRIPTION
## Slock Context
- Owner: @TechLead
- Task: task #72 `[TL-Fairy-Q1-mihoyo-audit-resolution]`
- Reviewers: @QA
- Related decisions: D-16 source priority/manual review; lo-user decision `#fairy` msg `0a08cfb6` (`Q1，按 buhflipexplode`)

## Summary
- Add `data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json` resolving the three historical DA buff `sourceConflict` records as `resolved-prefer-buhflipexplode`.
- Retain Mihoyo original values, buhflipexplode accepted values, source anchors/hashes, and nanoka manual lookup evidence as audit trace.
- Mirror the cleaned audit artifact into `packages/data/cleaned/` for `@fairy/data` package payload and document the resolution in cleaned/Mihoyo/decision docs.
- Add data tests covering the audit decision, nanoka tie-breaker evidence, raw trace retention, starter-scenario no-impact check, and package mirror freshness.

## Notes
- Raw Mihoyo alignment snapshots are intentionally unchanged; they remain the source archive trace.
- Nanoka is documented as manual lookup-only evidence, not a crawler source or cleaned-data input.
- UX starter scenario grep for `澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt` returned no matches, so no UX asset update is needed.

## Verification
- `pnpm install --frozen-lockfile`
- `jq empty data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json packages/data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`
- `! rg -n "澄意|灼冽|破招|Clarity|Blazing Chill|Interrupt" docs/ux/starter-scenarios.md`
- `pnpm --filter @fairy/data test`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @fairy/data verify:golden-v1`
- `pnpm --filter @fairy/data verify:mihoyo-da`
- `pnpm --filter @fairy/data verify:buhflipexplode-da`
- `pnpm --filter @fairy/data verify:excel`
- `pnpm --filter @fairy/data pack --dry-run --json`
- `git diff --check`
