### PR TITLE
feat(cli): migrate command parsing to citty

### DIFF
--- a/docs/architecture/monorepo-development.md
+++ b/docs/architecture/monorepo-development.md
@@ -33,7 +33,7 @@ This guide defines how to work in the Fairy pnpm workspace without breaking pack
 |---|---|---|
 | `@fairy/core` | Runtime schemas, validators, pure calculation functions, registered handler interfaces, traceable `CalcResult` output | Crawlers, file IO, network IO, CLI rendering, formal data source parsing |
 | `@fairy/data` | Source readers, raw-to-clean transforms, source metadata, alias migration, queryable game data | Formula decisions, CLI UX, hand-written formal game values |
-| `@fairy/cli` | JSON input/output shell, command parsing, diagnostics rendering when needed | Core math, source scraping, package-private data mutation |
+| `@fairy/cli` | JSON input/output shell, citty command/flag schemas, diagnostics rendering when needed | Core math, source scraping, package-private data mutation |
 
 The core package is the lowest-level runtime dependency. It must stay deterministic and side-effect-light so QA can validate formulas and trace output independently.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,10 @@
 
 JSON-only command shell over `@fairy/core`.
 
+Command and flag schemas are defined with `citty`, while stdout remains JSON-only
+for AI/plugin consumers. Help output is therefore JSON (`fairy help` or
+`fairy --help`) instead of citty's default human text renderer.
+
 ## Commands
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fairy/core": "workspace:*",
+    "citty": "0.2.2",
     "tsx": "^4.21.0"
   }
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -155,6 +155,26 @@ describe("fairy cli", () => {
     expect(run.stderr).toBe("")
   })
 
+  it("keeps citty help flags JSON-only", async () => {
+    const rootIo = fakeIo()
+    const rootCode = await runCli(["--help"], rootIo)
+    const rootHelp = JSON.parse(rootIo.output.stdout) as { schemaVersion: string; commands: string[] }
+
+    expect(rootCode).toBe(0)
+    expect(rootHelp.schemaVersion).toBe("fairy-cli-help-v1")
+    expect(rootHelp.commands).toEqual(["calc", "compare", "scan", "explain", "migrate"])
+    expect(rootIo.output.stderr).toBe("")
+
+    const calcIo = fakeIo()
+    const calcCode = await runCli(["calc", "--help"], calcIo)
+    const calcHelp = JSON.parse(calcIo.output.stdout) as { schemaVersion: string; commands: string[] }
+
+    expect(calcCode).toBe(0)
+    expect(calcHelp.schemaVersion).toBe("fairy-cli-help-v1")
+    expect(calcHelp.commands).toEqual(rootHelp.commands)
+    expect(calcIo.output.stderr).toBe("")
+  })
+
   it("shows pnpm lifecycle output without --silent, so docs must not recommend it", () => {
     const run = spawnSync("pnpm", [
       "--filter",
@@ -199,6 +219,18 @@ describe("fairy cli", () => {
     snapshot.team[0]!.panel.critDamage = 1
     const io = fakeIo({ stdin: JSON.stringify(snapshot) })
     const code = await runCli(["calc", "-", "--result-mode", "crit", "--view", "verbose"], io)
+    const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
+
+    expect(code).toBe(0)
+    expect(result.summary.rawTotalDamage).toBeCloseTo(909.091, 3)
+  })
+
+  it("keeps the legacy camelCase resultMode alias through citty parsing", async () => {
+    const snapshot = structuredClone(baseSnapshot)
+    snapshot.team[0]!.panel.critRate = 0.5
+    snapshot.team[0]!.panel.critDamage = 1
+    const io = fakeIo({ stdin: JSON.stringify(snapshot) })
+    const code = await runCli(["calc", "-", "--resultMode", "crit", "--view", "verbose"], io)
     const result = JSON.parse(io.output.stdout) as { summary: { rawTotalDamage: number } }
 
     expect(code).toBe(0)
@@ -265,6 +297,26 @@ describe("fairy cli", () => {
     expect(result.rows[1]!.summary.rawTotalDamage).toBeGreaterThan(result.rows[0]!.summary.rawTotalDamage)
   })
 
+  it("keeps explain and migrate command schemas executable", async () => {
+    const explainIo = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const explainCode = await runCli(["explain", "-"], explainIo)
+    const explain = JSON.parse(explainIo.output.stdout) as { schemaVersion: string; trace: unknown[] }
+
+    expect(explainCode).toBe(0)
+    expect(explain.schemaVersion).toBe("fairy-cli-explain-v1")
+    expect(explain.trace.length).toBeGreaterThan(0)
+    expect(explainIo.output.stderr).toBe("")
+
+    const migrateIo = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
+    const migrateCode = await runCli(["migrate", "-"], migrateIo)
+    const migrate = JSON.parse(migrateIo.output.stdout) as { schemaVersion: string; migrated: boolean }
+
+    expect(migrateCode).toBe(0)
+    expect(migrate.schemaVersion).toBe("fairy-cli-migrate-v1")
+    expect(migrate.migrated).toBe(false)
+    expect(migrateIo.output.stderr).toBe("")
+  })
+
   it("returns JSON errors for invalid arguments", async () => {
     const io = fakeIo({ stdin: JSON.stringify(baseSnapshot) })
     const code = await runCli(["calc", "-", "--lang", "fr"], io)
@@ -290,6 +342,17 @@ describe("fairy cli", () => {
   it("renders unknown command errors through the catalog", async () => {
     const io = fakeIo()
     const code = await runCli(["unknown"], io)
+    const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
+
+    expect(code).toBe(1)
+    expect(error.error.code).toBe("ERR-CLI-CMD")
+    expect(error.error.message).toBe("Localized command problem: unknown")
+    expect(io.output.stdout).toBe("")
+  })
+
+  it("keeps --lang available for unknown command errors", async () => {
+    const io = fakeIo()
+    const code = await runCli(["unknown", "--lang", "en"], io)
     const error = JSON.parse(io.output.stderr) as { ok: false; error: { code: string; message: string } }
 
     expect(code).toBe(1)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import type { CalcResult, Diagnostic } from "@fairy/core"
 import { calculate, parseBattleSnapshot } from "@fairy/core"
+import { defineCommand, parseArgs as parseCittyArgs, type ArgsDef } from "citty"
 import { readFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
@@ -37,16 +38,158 @@ interface CliErrorBody {
 }
 
 const supportedCommands = ["calc", "compare", "scan", "explain", "migrate"] as const
-const booleanFlags = new Set(["help", "pretty"])
 const defaultLang: Lang = "zh"
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
 
+const commonArgs = {
+  help: {
+    type: "boolean",
+    description: "Show JSON help output.",
+  },
+  lang: {
+    type: "string",
+    description: "Diagnostic language.",
+    valueHint: "zh|en",
+  },
+  pretty: {
+    type: "boolean",
+    description: "Pretty-print JSON output.",
+  },
+} satisfies ArgsDef
+
+const resultModeArg = {
+  "result-mode": {
+    type: "string",
+    description: "Select expected, crit, or nonCrit result mode.",
+    valueHint: "expected|crit|nonCrit",
+  },
+} satisfies ArgsDef
+
+const commandDefinitions = {
+  calc: defineCommand({
+    meta: {
+      name: "calc",
+      description: "Calculate one BattleSnapshot.",
+    },
+    args: {
+      input: {
+        type: "positional",
+        description: "Snapshot JSON path, or '-' for stdin.",
+        required: false,
+      },
+      view: {
+        type: "string",
+        description: "Output brief summary or verbose CalcResult.",
+        valueHint: "brief|verbose",
+      },
+      ...resultModeArg,
+      ...commonArgs,
+    },
+  }),
+  compare: defineCommand({
+    meta: {
+      name: "compare",
+      description: "Compare two BattleSnapshots.",
+    },
+    args: {
+      left: {
+        type: "positional",
+        description: "Left snapshot JSON path, or '-' for stdin.",
+        required: false,
+      },
+      right: {
+        type: "positional",
+        description: "Right snapshot JSON path.",
+        required: false,
+      },
+      ...resultModeArg,
+      ...commonArgs,
+    },
+  }),
+  scan: defineCommand({
+    meta: {
+      name: "scan",
+      description: "Scan a numeric snapshot path across a range.",
+    },
+    args: {
+      input: {
+        type: "positional",
+        description: "Snapshot JSON path, or '-' for stdin.",
+        required: false,
+      },
+      path: {
+        type: "string",
+        description: "Snapshot path to mutate.",
+      },
+      from: {
+        type: "string",
+        description: "Scan start value.",
+      },
+      to: {
+        type: "string",
+        description: "Scan end value.",
+      },
+      step: {
+        type: "string",
+        description: "Scan step value.",
+      },
+      ...resultModeArg,
+      ...commonArgs,
+    },
+  }),
+  explain: defineCommand({
+    meta: {
+      name: "explain",
+      description: "Return full explanation fields for one BattleSnapshot.",
+    },
+    args: {
+      input: {
+        type: "positional",
+        description: "Snapshot JSON path, or '-' for stdin.",
+        required: false,
+      },
+      ...resultModeArg,
+      ...commonArgs,
+    },
+  }),
+  migrate: defineCommand({
+    meta: {
+      name: "migrate",
+      description: "Normalize a BattleSnapshot with registered migrations.",
+    },
+    args: {
+      input: {
+        type: "positional",
+        description: "Snapshot JSON path, or '-' for stdin.",
+        required: false,
+      },
+      ...commonArgs,
+    },
+  }),
+  help: defineCommand({
+    meta: {
+      name: "help",
+      description: "Show JSON help output.",
+    },
+    args: {
+      command: {
+        type: "positional",
+        description: "Optional command name.",
+        required: false,
+      },
+      ...commonArgs,
+    },
+  }),
+}
+
 export async function runCli(argv: string[], io: CliIo = nodeIo()): Promise<number> {
-  const parsed = parseArgs(argv)
-  const langResult = parseLang(parsed.flags.get("lang"))
-  const lang = langResult.ok ? langResult.lang : defaultLang
+  let lang: Lang = defaultLang
 
   try {
+    const parsed = parseArgs(argv)
+    const langResult = parseLang(parsed.flags.get("lang"))
+    lang = langResult.ok ? langResult.lang : defaultLang
+
     if (!langResult.ok)
       throw cliError("ERR-CLI-ARG", { message: langResult.message })
 
@@ -188,44 +331,83 @@ function parseArgs(argv: string[]): ParsedArgs {
   const args = [...argv]
   if (args[0] === "--")
     args.shift()
-  const command = args.shift() ?? "help"
-  const inputs: string[] = []
+  const command = normalizeCommand(args.shift())
+  if (!isCliCommand(command))
+    return parseUnknownCommandArgs(command, args)
+
+  return parseCommandArgs(command, args)
+}
+
+function normalizeCommand(command: string | undefined): string {
+  if (command === undefined || command === "--help" || command === "-h")
+    return "help"
+  return command
+}
+
+function isCliCommand(command: string): command is keyof typeof commandDefinitions {
+  return command in commandDefinitions
+}
+
+function parseCommandArgs(command: keyof typeof commandDefinitions, rawArgs: string[]): ParsedArgs {
+  try {
+    const argsDef = (commandDefinitions[command].args ?? {}) as ArgsDef
+    const args = parseCittyArgs(rawArgs, argsDef)
+    return {
+      command,
+      inputs: readInputArgs(command, args),
+      flags: readFlagArgs(args),
+    }
+  }
+  catch (err) {
+    throw cliError("ERR-CLI-ARG", { message: describeCittyArgError(err) })
+  }
+}
+
+function parseUnknownCommandArgs(command: string, rawArgs: string[]): ParsedArgs {
+  try {
+    const args = parseCittyArgs(rawArgs, commonArgs)
+    return {
+      command,
+      inputs: [],
+      flags: readFlagArgs(args),
+    }
+  }
+  catch {
+    return {
+      command,
+      inputs: [],
+      flags: new Map(),
+    }
+  }
+}
+
+function readInputArgs(command: keyof typeof commandDefinitions, args: Record<string, unknown>): string[] {
+  switch (command) {
+    case "compare":
+      return [args.left, args.right].filter(isString)
+    case "help":
+      return [args.command].filter(isString)
+    default:
+      return [args.input].filter(isString)
+  }
+}
+
+function readFlagArgs(args: Record<string, unknown>): Map<string, string | boolean> {
   const flags = new Map<string, string | boolean>()
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index]!
-    if (!arg.startsWith("--")) {
-      inputs.push(arg)
-      continue
-    }
-
-    const [rawName, inlineValue] = arg.slice(2).split("=", 2)
-    const name = rawName ?? ""
-    if (booleanFlags.has(name)) {
-      flags.set(name, true)
-      continue
-    }
-
-    if (inlineValue !== undefined) {
-      flags.set(name, inlineValue)
-      continue
-    }
-
-    const next = args[index + 1]
-    if (next !== undefined && !next.startsWith("--")) {
-      flags.set(name, next)
-      index += 1
-    }
-    else {
-      flags.set(name, true)
-    }
+  for (const name of ["help", "lang", "pretty", "view", "result-mode", "resultMode", "path", "from", "to", "step"]) {
+    const value = args[name]
+    if (typeof value === "string" || typeof value === "boolean")
+      flags.set(name, value)
   }
+  return flags
+}
 
-  return {
-    command,
-    inputs,
-    flags,
-  }
+function isString(value: unknown): value is string {
+  return typeof value === "string"
+}
+
+function describeCittyArgError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 async function readSnapshotInput(parsed: ParsedArgs, io: CliIo, index: number): Promise<unknown> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fairy/core':
         specifier: workspace:*
         version: link:../core
+      citty:
+        specifier: 0.2.2
+        version: 0.2.2
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -398,6 +401,9 @@ packages:
   cheerio@1.2.0:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   codepage@1.15.0:
     resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
@@ -1035,6 +1041,8 @@ snapshots:
       parse5-parser-stream: 7.1.2
       undici: 7.25.0
       whatwg-mimetype: 4.0.0
+
+  citty@0.2.2: {}
 
   codepage@1.15.0: {}
 


### PR DESCRIPTION
## Slock Context
- Owner: @TechLead
- Task: task #73 `[TL-Fairy-Q2-citty-migration]`
- Reviewers: @QA
- Related decision: lo-user `#fairy` msg `0a08cfb6` (`Q2，切 citty`)

## Summary
- Add pinned `citty@0.2.2` to `@fairy/cli`.
- Replace the hand-written argument parser with citty command/flag schemas for `calc`, `compare`, `scan`, `explain`, `migrate`, and `help`.
- Preserve the existing JSON-only stdout contract, localized ERR-CLI stderr errors, `--result-mode` / `--resultMode`, `--view`, `--lang`, `--pretty`, and stdin `-` behavior.
- Keep help JSON-only and add `fairy --help` / `fairy calc --help` support without adopting citty's default text renderer.
- Update CLI docs and monorepo responsibilities to record citty as the CLI command/flag schema layer.

## Compatibility Notes
- Business command output shapes are unchanged (`fairy-cli-calc-brief-v1`, `compare`, `scan`, `explain`, `migrate`).
- `calc --help` still writes JSON to stdout, not human text.
- Unknown command errors still use ERR-CLI-CMD and can render through `--lang`.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @fairy/cli check`
- `pnpm --filter @fairy/cli test`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @fairy/data verify:golden-v1`
- `pnpm --filter @fairy/data verify:mihoyo-da`
- `pnpm --filter @fairy/data verify:buhflipexplode-da`
- `pnpm --filter @fairy/data verify:excel`
- `pnpm --filter @fairy/cli pack --dry-run --json`
- `git diff --check`
- Manual root/bin smoke:
  - `node packages/cli/bin/fairy.js --help`
  - `node packages/cli/bin/fairy.js calc examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json --lang zh`
  - `pnpm --silent fairy -- calc ...`
  - `pnpm --silent fairy -- compare ...`
  - `pnpm --silent fairy -- scan ...`
  - `pnpm --silent fairy -- explain ...`
  - `pnpm --silent fairy -- migrate ...`
  - invalid snapshot stderr JSON / ERR-CLI-SCHEMA
