### PR TITLE
chore(release): add randomplay publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,334 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish workspace packages
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    env:
+      PUBLISH_PACKAGES: '["packages/core","packages/data","packages/cli"]'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Derive release version
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
+            echo "Tag must be vX.Y.Z or vX.Y.Z-prerelease, got $TAG" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release metadata
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          ROOT_VERSION="$(node -p "require('./package.json').version")"
+          COMMIT_SUBJECT="$(git log -1 --pretty=%s)"
+
+          test "$ROOT_VERSION" = "$VERSION" || { echo "root package.json version $ROOT_VERSION != $VERSION" >&2; exit 1; }
+          test "$COMMIT_SUBJECT" = "chore: release v$VERSION" || { echo "unexpected release commit: $COMMIT_SUBJECT" >&2; exit 1; }
+          git fetch origin main:refs/remotes/origin/main --tags
+          git merge-base --is-ancestor HEAD origin/main || { echo "release tag commit is not contained in origin/main" >&2; exit 1; }
+
+      - name: Validate npm CLI version
+        shell: bash
+        run: |
+          set -euo pipefail
+          NPM_VERSION="$(npm --version)"
+          node - "$NPM_VERSION" <<'NODE'
+          const version = process.argv[2]
+          const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number)
+          const ok = major > 11 || (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)))
+          if (!ok) {
+            console.error(`npm ${version} does not satisfy >= 11.5.1`)
+            process.exit(1)
+          }
+          console.log(`npm ${version} satisfies >= 11.5.1`)
+          NODE
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test
+      - run: pnpm build
+      - run: pnpm --filter @randomplay/data verify:golden-v1
+      - run: pnpm --filter @randomplay/data verify:mihoyo-da
+      - run: pnpm --filter @randomplay/data verify:buhflipexplode-da
+      - run: pnpm --filter @randomplay/data verify:excel
+      - run: pnpm --silent fairy:s1 | jq empty
+      - run: pnpm --silent fairy:s2 | jq empty
+      - run: pnpm --silent fairy:s3 | jq empty
+
+      - name: Resolve publish package allowlist
+        id: packages
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+
+          const root = process.cwd()
+          const releaseVersion = process.env.VERSION
+          const allowlist = JSON.parse(process.env.PUBLISH_PACKAGES)
+
+          if (!Array.isArray(allowlist) || !allowlist.length) {
+            console.error('PUBLISH_PACKAGES must be a non-empty JSON array of package directories.')
+            process.exit(1)
+          }
+
+          const seen = new Set()
+          const packages = allowlist.map((directory) => {
+            if (seen.has(directory)) {
+              console.error(`Duplicate publish package directory: ${directory}`)
+              process.exit(1)
+            }
+            seen.add(directory)
+
+            const manifestPath = path.join(root, directory, 'package.json')
+            if (!fs.existsSync(manifestPath)) {
+              console.error(`Publish package manifest not found: ${directory}/package.json`)
+              process.exit(1)
+            }
+
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+            if (!manifest.name) {
+              console.error(`${directory}/package.json missing name`)
+              process.exit(1)
+            }
+            if (manifest.private === true) {
+              console.error(`${manifest.name} is private and cannot be published`)
+              process.exit(1)
+            }
+            if (manifest.version !== releaseVersion) {
+              console.error(`${directory}/package.json version ${manifest.version} != ${releaseVersion}`)
+              process.exit(1)
+            }
+            if (manifest.publishConfig?.access !== 'public') {
+              console.error(`${manifest.name} must set publishConfig.access = public`)
+              process.exit(1)
+            }
+            if (manifest.exports?.['.'] === './src/index.ts') {
+              console.error(`${manifest.name} exports TypeScript source instead of built dist output`)
+              process.exit(1)
+            }
+
+            return { name: manifest.name, version: manifest.version, directory }
+          })
+
+          fs.writeFileSync(process.env.GITHUB_OUTPUT, `packages=${JSON.stringify(packages)}\n`, { flag: 'a' })
+          console.log(JSON.stringify(packages, null, 2))
+          NODE
+
+      - name: Prepare npm publish manifests
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/prepare-npm-publish.mjs "$VERSION"
+
+      - name: Validate npm package tarballs
+        shell: bash
+        env:
+          PACKAGES: ${{ steps.packages.outputs.packages }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { execFileSync, spawnSync } = require('node:child_process')
+          const { mkdtempSync, rmSync } = require('node:fs')
+          const { tmpdir } = require('node:os')
+          const path = require('node:path')
+
+          const packages = JSON.parse(process.env.PACKAGES)
+          const version = process.env.VERSION
+          const tmp = mkdtempSync(path.join(tmpdir(), 'fairy-npm-pack-'))
+          const packageNames = new Set(packages.map(pkg => pkg.name))
+
+          try {
+            for (const pkg of packages) {
+              const result = spawnSync('npm', ['pack', '--json', '--pack-destination', tmp], {
+                cwd: pkg.directory,
+                encoding: 'utf8',
+                stdio: ['ignore', 'pipe', 'inherit'],
+              })
+              if (result.status !== 0) process.exit(result.status ?? 1)
+
+              const [packResult] = JSON.parse(result.stdout)
+              const tarball = path.join(tmp, packResult.filename)
+              const manifest = JSON.parse(execFileSync('tar', ['-xOf', tarball, 'package/package.json'], { encoding: 'utf8' }))
+
+              if (manifest.name !== pkg.name) {
+                console.error(`tarball name ${manifest.name} != ${pkg.name}`)
+                process.exit(1)
+              }
+              if (manifest.version !== version) {
+                console.error(`${manifest.name} tarball version ${manifest.version} != ${version}`)
+                process.exit(1)
+              }
+              const serialized = JSON.stringify(manifest)
+              if (serialized.includes('workspace:')) {
+                console.error(`${manifest.name} tarball package.json still contains workspace protocol`)
+                process.exit(1)
+              }
+              for (const key of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+                const deps = manifest[key] ?? {}
+                for (const [name, specifier] of Object.entries(deps)) {
+                  if (packageNames.has(name) && specifier !== version) {
+                    console.error(`${manifest.name} ${key}.${name} ${specifier} != ${version}`)
+                    process.exit(1)
+                  }
+                }
+              }
+              if (manifest.exports?.['.'] === './src/index.ts') {
+                console.error(`${manifest.name} tarball exports TypeScript source`)
+                process.exit(1)
+              }
+              console.log(`${manifest.name}@${manifest.version} npm tarball validated`)
+            }
+          }
+          finally {
+            rmSync(tmp, { recursive: true, force: true })
+          }
+          NODE
+
+      - name: Resolve npm publish state
+        id: npm-packages
+        shell: bash
+        env:
+          PACKAGES: ${{ steps.packages.outputs.packages }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { execFileSync } = require('node:child_process')
+          const fs = require('node:fs')
+
+          const packages = JSON.parse(process.env.PACKAGES)
+          const version = process.env.VERSION
+          const releaseSha = process.env.GITHUB_SHA
+          const publish = []
+          const existing = []
+
+          for (const pkg of packages) {
+            let exists = false
+            try {
+              execFileSync('npm', ['view', `${pkg.name}@${version}`, 'version', '--silent'], { stdio: 'pipe' })
+              exists = true
+            }
+            catch {
+              exists = false
+            }
+
+            if (!exists) {
+              publish.push(pkg)
+              continue
+            }
+
+            const gitHead = execFileSync('npm', ['view', `${pkg.name}@${version}`, 'gitHead', '--silent'], { encoding: 'utf8' }).trim()
+            if (!gitHead) {
+              console.error(`${pkg.name}@${version} exists on npm without gitHead`)
+              process.exit(1)
+            }
+            if (gitHead !== releaseSha) {
+              console.error(`${pkg.name}@${version} gitHead ${gitHead} != ${releaseSha}`)
+              process.exit(1)
+            }
+            existing.push(pkg)
+          }
+
+          fs.writeFileSync(process.env.GITHUB_OUTPUT, `publish=${JSON.stringify(publish)}\nexisting=${JSON.stringify(existing)}\n`, { flag: 'a' })
+          console.log('to publish:', JSON.stringify(publish, null, 2))
+          console.log('existing for this release:', JSON.stringify(existing, null, 2))
+          NODE
+
+      - name: Publish packages to npm with trusted publishing
+        shell: bash
+        env:
+          PACKAGES: ${{ steps.npm-packages.outputs.publish }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const { spawnSync } = require('node:child_process')
+          const packages = JSON.parse(process.env.PACKAGES)
+
+          for (const pkg of packages) {
+            console.log(`Publishing ${pkg.name} from ${pkg.directory}`)
+            const result = spawnSync('npm', ['publish', '--access', 'public', '--no-git-checks'], {
+              cwd: pkg.directory,
+              stdio: 'inherit',
+            })
+            if (result.status !== 0) process.exit(result.status ?? 1)
+          }
+          NODE
+
+      - name: Registry install smoke
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          TMP_DIR="$(mktemp -d)"
+          cd "$TMP_DIR"
+          npm init -y >/dev/null
+          npm install "@randomplay/core@$VERSION" "@randomplay/data@$VERSION" "@randomplay/cli@$VERSION" >/dev/null
+          node --input-type=module <<'NODE'
+          import { calculate, parseBattleSnapshot } from '@randomplay/core'
+          import * as data from '@randomplay/data'
+          import replay from '@randomplay/data/cleaned/golden/v1-replay-report.json' with { type: 'json' }
+
+          if (typeof calculate !== 'function') throw new Error('@randomplay/core calculate export missing')
+          if (typeof parseBattleSnapshot !== 'function') throw new Error('@randomplay/core parseBattleSnapshot export missing')
+          if (!Object.keys(data).length) throw new Error('@randomplay/data root export is empty')
+          if (replay.summary?.releaseReady !== true) throw new Error('golden replay report is not release ready')
+          NODE
+          ./node_modules/.bin/fairy --help | jq empty
+          ./node_modules/.bin/fairy calc "$GITHUB_WORKSPACE/examples/snapshots/s1-yixuan-sheer.json" --lang zh | jq empty
+          jq 'del(.attackSegments[0].source)' "$GITHUB_WORKSPACE/examples/snapshots/s1-yixuan-sheer.json" > warning-snapshot.json
+          ./node_modules/.bin/fairy calc warning-snapshot.json --lang en > warning-output.json 2> warning-stderr.txt
+          jq empty warning-output.json
+          grep -q "ERR-SRC-001" warning-stderr.txt
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            gh release edit "v$VERSION" \
+              --title "fairy v$VERSION" \
+              --notes-file CHANGELOG.md
+          else
+            gh release create "v$VERSION" \
+              --title "fairy v$VERSION" \
+              --notes-file CHANGELOG.md \
+              --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to Fairy will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Release workflow scaffold for `@randomplay/data`, `@randomplay/core`, and `@randomplay/cli`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 - 数据契约：[data-contract/](data-contract/)
 - 架构与工程：[architecture/](architecture/)
 - 数据来源：[data-source/](data-source/)
+- 发布流程：[release/release-workflow.md](release/release-workflow.md)
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)
 
@@ -34,4 +35,5 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 - 米游社危局强袭战 source snapshot：[data-source/mihoyo/](data-source/mihoyo/)
 - buhflipexplode 危局强袭战 source snapshot：[data-source/buhflipexplode/](data-source/buhflipexplode/)
 - V1 golden source coverage：[qa/golden-source-coverage.md](qa/golden-source-coverage.md)
+- Release workflow：[release/release-workflow.md](release/release-workflow.md)
 - Starter scenarios narrative：[ux/starter-scenarios.md](ux/starter-scenarios.md)

--- a/docs/release/release-workflow.md
+++ b/docs/release/release-workflow.md
@@ -1,0 +1,130 @@
+# Fairy Release Workflow
+
+## Scope
+
+This document defines the release flow for the `LoTwT/fairy` repository and the npm packages:
+
+- `@randomplay/core`
+- `@randomplay/data`
+- `@randomplay/cli`
+
+The repository uses one release version across the root package and all publishable workspace packages. The root package stays private and is not published.
+
+## Version Bump
+
+Use the root release script:
+
+```bash
+pnpm release:bump        # patch bump
+pnpm release:bump 0.0.1  # explicit first release
+```
+
+The script is a thin wrapper around `bumpp@11.1.0`:
+
+- no argument defaults to `patch`
+- one argument is passed as the release type or exact version
+- version files: root `package.json` plus `packages/core`, `packages/data`, and `packages/cli`
+- commit and tag use bumpp defaults: `chore: release vX.Y.Z` and `vX.Y.Z`
+- the script must run from `main` with an upstream branch
+- `noGitCheck: false` keeps bumpp's working-tree guard enabled
+- push is enabled so the tag triggers release CI
+
+## Release Gate
+
+The release workflow is triggered only by `vX.Y.Z` tag pushes. It validates:
+
+- semver tag with leading `v`
+- root and publishable package versions match the tag
+- release commit subject equals `chore: release vX.Y.Z`
+- tagged commit is contained in `origin/main`
+- npm CLI satisfies `>= 11.5.1`
+- publish allowlist packages exist, are public, and have `publishConfig.access = "public"`
+- publish manifests are prepared so internal dependencies use the release version, not `workspace:*`
+- npm tarballs produced by `npm pack` contain no `workspace:` protocol dependencies
+- already-published packages at the same version have npm `gitHead` equal to the release commit SHA
+
+The job then runs:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm check
+pnpm test
+pnpm build
+pnpm --filter @randomplay/data verify:golden-v1
+pnpm --filter @randomplay/data verify:mihoyo-da
+pnpm --filter @randomplay/data verify:buhflipexplode-da
+pnpm --filter @randomplay/data verify:excel
+pnpm --silent fairy:s1 | jq empty
+pnpm --silent fairy:s2 | jq empty
+pnpm --silent fairy:s3 | jq empty
+node scripts/prepare-npm-publish.mjs X.Y.Z
+npm pack --json --pack-destination <tmp> # per publish package, inspected by CI
+```
+
+## Publish Allowlist
+
+All packages share one version, but publish targets are explicit. The release workflow uses this allowlist:
+
+```json
+["packages/core", "packages/data", "packages/cli"]
+```
+
+Do not use `pnpm -r publish`. New publish targets must be added to the allowlist with package-specific pack and smoke gates.
+
+## npm Publish
+
+Publish is performed per allowlist package by GitHub Actions through npm Trusted Publishing / OIDC:
+
+```bash
+cd <package-directory>
+npm publish --access public --no-git-checks
+```
+
+The release job has `id-token: write` permission and runs in the protected `npm-publish` environment. Configure npm Trusted Publisher for each package:
+
+- package: `@randomplay/core`, `@randomplay/data`, `@randomplay/cli`
+- repository: `LoTwT/fairy`
+- workflow: `release.yml`
+- environment: `npm-publish`
+
+The first `0.0.1` publish may require manual local publish from the release tag because npm Trusted Publisher setup can require the package to exist first. If manual first publish is used, publish only from the `v0.0.1` tag, run the same local gates, publish the three packages from the tag, and rerun the release workflow afterward; the workflow will verify each npm `gitHead` before continuing.
+
+Manual first publish order:
+
+```bash
+git fetch --tags origin
+git checkout v0.0.1
+pnpm install --frozen-lockfile
+pnpm check
+pnpm test
+pnpm build
+node scripts/prepare-npm-publish.mjs 0.0.1
+
+cd packages/core && npm publish --access public --no-git-checks
+cd ../data && npm publish --access public --no-git-checks
+cd ../cli && npm publish --access public --no-git-checks
+```
+
+Each package has a `prepublishOnly` script that rebuilds `dist/` before `npm publish`, but the explicit root `pnpm build` keeps the manual path aligned with CI.
+
+## Post-Publish Smoke
+
+After publish, CI installs all three packages from npm in a temporary project, then validates:
+
+- `@randomplay/core` can be imported by plain Node ESM
+- `@randomplay/data` can be imported by plain Node ESM
+- cleaned JSON subpaths are importable
+- the `fairy` bin is installed and emits JSON help
+- `fairy calc` can execute the S1 snapshot and return strict JSON
+
+## Rollback
+
+- If a tag or GitHub Release is wrong before npm publish, delete the GitHub Release and tag, fix the release commit, and create a new tag.
+- If a version has been published to npm, do not rely on unpublish. Deprecate the bad version and publish the next patch.
+- If package contents are wrong, revert the offending PR and release a patch.
+- If CI fails before publish, fix the release commit and re-tag only after removing the failed tag.
+- Mark the bad GitHub Release as a pre-release and add a note pointing to the corrected patch.
+
+## Changelog
+
+Fairy uses a hand-written root `CHANGELOG.md` for now. Keep it concise and copy the release-relevant section into the GitHub Release page.

--- a/package.json
+++ b/package.json
@@ -2,18 +2,23 @@
   "name": "fairy-monorepo",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "type": "module",
   "scripts": {
+    "build": "pnpm -r --if-present build",
     "check": "pnpm -r --if-present check",
     "fairy": "node packages/cli/bin/fairy.js",
     "fairy:s1": "node packages/cli/bin/fairy.js calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty",
     "fairy:s2": "node packages/cli/bin/fairy.js calc examples/snapshots/s2-yanagi-disorder.json --lang zh --pretty",
     "fairy:s3": "node packages/cli/bin/fairy.js calc examples/snapshots/s3-team-g22-g23-acceptance.json --lang zh --pretty",
+    "release:bump": "node scripts/release-bump.mjs",
     "test": "pnpm -r --if-present test"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "bumpp": "11.1.0",
+    "tsdown": "0.22.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }

--- a/packages/cli/bin/fairy.js
+++ b/packages/cli/bin/fairy.js
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { tsImport } from "tsx/esm/api"
 
 const binDir = dirname(fileURLToPath(import.meta.url))
-const entry = resolve(binDir, "../src/index.ts")
-const mod = await tsImport(entry, import.meta.url)
+const distEntry = resolve(binDir, "../dist/index.mjs")
+const sourceEntry = resolve(binDir, "../src/index.ts")
+const mod = existsSync(distEntry)
+  ? await import(distEntry)
+  : await import("tsx/esm/api").then(({ tsImport }) => tsImport(sourceEntry, import.meta.url))
+
 const code = await mod.runCli(process.argv.slice(2))
 process.exitCode = code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,30 @@
 {
   "name": "@randomplay/cli",
   "version": "0.0.0",
-  "private": true,
+  "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LoTwT/fairy.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "fairy": "./bin/fairy.js"
   },
+  "files": [
+    "bin",
+    "dist",
+    "README.md",
+    "package.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "build": "tsdown src/index.ts --format esm --dts --clean --out-dir dist --platform node",
     "cli": "tsx src/index.ts",
     "check": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,8 +2,10 @@ import type { CalcResult, Diagnostic } from "@randomplay/core"
 import { calculate, parseBattleSnapshot } from "@randomplay/core"
 import { defineCommand, parseArgs as parseCittyArgs, type ArgsDef } from "citty"
 import { readFile } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath, pathToFileURL } from "node:url"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import enMessages from "../../../docs/ux/i18n/messages.en.json" with { type: "json" }
+import zhMessages from "../../../docs/ux/i18n/messages.zh.json" with { type: "json" }
 import { cliErrorFallbackMessages, isCliErrorCode, type CliErrorCode } from "./errors"
 
 type Lang = "zh" | "en"
@@ -39,7 +41,15 @@ interface CliErrorBody {
 
 const supportedCommands = ["calc", "compare", "scan", "explain", "migrate"] as const
 const defaultLang: Lang = "zh"
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+function toMessageCatalog(raw: Record<string, unknown>): MessageCatalog {
+  return Object.fromEntries(Object.entries(raw).filter(([, value]) => typeof value === "string")) as MessageCatalog
+}
+
+const messageCatalogs = {
+  en: toMessageCatalog(enMessages),
+  zh: toMessageCatalog(zhMessages),
+} satisfies Record<Lang, MessageCatalog>
 
 const commonArgs = {
   help: {
@@ -688,11 +698,7 @@ function nodeIo(): CliIo {
     }),
     stdout: text => process.stdout.write(text),
     stderr: text => process.stderr.write(text),
-    loadMessages: async (lang) => {
-      const path = resolve(repoRoot, "docs", "ux", "i18n", `messages.${lang}.json`)
-      const raw = await readFile(path, "utf8")
-      return JSON.parse(raw) as MessageCatalog
-    },
+    loadMessages: async lang => messageCatalogs[lang],
   }
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,13 +1,31 @@
 {
   "name": "@randomplay/core",
   "version": "0.0.0",
-  "private": true,
+  "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LoTwT/fairy.git",
+    "directory": "packages/core"
+  },
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
+    "build": "tsdown src/index.ts --format esm --dts --clean --out-dir dist",
     "check": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,25 +1,41 @@
 {
   "name": "@randomplay/data",
   "version": "0.0.0",
-  "private": true,
+  "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LoTwT/fairy.git",
+    "directory": "packages/data"
+  },
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./types": {
+      "types": "./dist/types.d.mts",
+      "import": "./dist/types.mjs"
+    },
+    "./cleaned/*": "./cleaned/*"
   },
   "files": [
-    "src",
-    "!src/**/*.test.ts",
     "dist",
     "cleaned",
     "README.md",
     "package.json"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "audit:excel": "node scripts/excel-source.mjs audit --generated-at 2026-05-05T17:40:00+08:00",
     "audit:golden-v1": "tsx scripts/golden-v1-replay.ts audit --generated-at 2026-05-05T18:20:00+08:00",
+    "build": "tsdown src/index.ts src/types.ts --format esm --dts --clean --out-dir dist",
     "check": "tsc -p tsconfig.json --noEmit",
     "fetch:buhflipexplode-da": "node scripts/buhflipexplode-da-source.mjs fetch",
     "fetch:mihoyo-da": "node scripts/mihoyo-da-source.mjs fetch",
+    "prepublishOnly": "pnpm build",
     "sync-cleaned": "node scripts/sync-cleaned.mjs",
     "test": "vitest run",
     "verify:buhflipexplode-da": "node scripts/buhflipexplode-da-source.mjs verify --snapshot 2026-05-05T0445Z",

--- a/packages/data/src/governance.test.ts
+++ b/packages/data/src/governance.test.ts
@@ -47,9 +47,9 @@ describe("S5 data governance", () => {
 
     expect(npmIgnore).toContain("data/source/")
     expect(packageJson.files).toEqual(
-      expect.arrayContaining(["src", "dist", "cleaned"]),
+      expect.arrayContaining(["dist", "cleaned"]),
     )
-    expect(packageJson.files).toContain("!src/**/*.test.ts")
+    expect(packageJson.files).not.toContain("src")
     expect(packageJson.files?.some(entry => entry.includes("source"))).toBe(false)
   })
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -1,0 +1,2 @@
+export type * from "./types/cleaned-data"
+export type * from "./types/source-manifest"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      bumpp:
+        specifier: 11.1.0
+        version: 11.1.0
+      tsdown:
+        specifier: 0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/cli:
     dependencies:
@@ -53,6 +59,27 @@ importers:
         version: 0.18.5
 
 packages:
+
+  '@babel/generator@8.0.0-rc.4':
+    resolution: {integrity: sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-string-parser@8.0.0-rc.4':
+    resolution: {integrity: sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.4':
+    resolution: {integrity: sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/parser@8.0.0-rc.4':
+    resolution: {integrity: sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  '@babel/types@8.0.0-rc.4':
+    resolution: {integrity: sha512-bw30DV880P/VYtsjWWdoWmJpb9S2Vn1/PqayyccTELzRQ/HslIO7+BD9rNoZ4AAFOAjC1vrNeBCkAsyh6Ibfww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -219,8 +246,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -231,16 +268,40 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
@@ -249,17 +310,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
@@ -268,6 +348,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -275,10 +362,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -289,12 +390,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
@@ -303,16 +418,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
@@ -320,11 +452,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
@@ -343,6 +484,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -380,12 +524,35 @@ packages:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
 
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
+  args-tokenizer@0.3.0:
+    resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@3.0.0-beta.1:
+    resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
+    engines: {node: '>=20.19.0'}
+
+  birpc@4.0.0:
+    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bumpp@11.1.0:
+    resolution: {integrity: sha512-jdwOGMyX8JIqpQ0N2RMRR87DHZaoJnUtui5lU9LqFfFK5JC0H8qY9uWqXoa+dEWt/K7rOmmsoyiZB8RBM7RPBQ==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   cfb@1.2.2:
     resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
@@ -424,6 +591,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -440,6 +610,19 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -492,12 +675,35 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  import-without-cache@0.4.0:
+    resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -587,6 +793,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -610,8 +819,35 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rolldown-plugin-dts@0.25.0:
+    resolution: {integrity: sha512-GE3uDZgUuA9l6g+1u928TRmadd5IVhaWiwpWast2kCyLv9tYJJCC6E5HHkV0HGmwC5ZL73xh12/PRZI+KZ2vdQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0
+      typescript: ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
@@ -620,6 +856,11 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -653,6 +894,44 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  tsdown@0.22.0:
+    resolution: {integrity: sha512-FgW0hHb27nGQA/+F3d5+U9wKXkfilk9DVkc5+7x/ZqF03g+Hoz/eeApT32jqxATt9eRoR+1jxk7MUMON+O4CXw==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.0
+      '@tsdown/exe': 0.22.0
+      '@vitejs/devtools': '*'
+      publint: ^0.3.8
+      tsx: '*'
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -665,6 +944,12 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  unconfig@7.5.0:
+    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -784,10 +1069,37 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@babel/generator@8.0.0-rc.4':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.4
+      '@babel/types': 8.0.0-rc.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/helper-string-parser@8.0.0-rc.4': {}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.4': {}
+
+  '@babel/parser@8.0.0-rc.4':
+    dependencies:
+      '@babel/types': 8.0.0-rc.4
+
+  '@babel/types@8.0.0-rc.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.4
+      '@babel/helper-validator-identifier': 8.0.0-rc.4
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -883,7 +1195,19 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -894,40 +1218,89 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@oxc-project/types@0.129.0': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
+
+  '@rolldown/binding-android-arm64@1.0.0':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
@@ -937,11 +1310,19 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
@@ -961,6 +1342,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/jsesc@2.5.1': {}
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -974,13 +1357,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -1008,9 +1391,35 @@ snapshots:
 
   adler-32@1.3.1: {}
 
+  ansis@4.2.0: {}
+
+  args-tokenizer@0.3.0: {}
+
   assertion-error@2.0.1: {}
 
+  ast-kit@3.0.0-beta.1:
+    dependencies:
+      '@babel/parser': 8.0.0-rc.4
+      estree-walker: 3.0.3
+      pathe: 2.0.3
+
+  birpc@4.0.0: {}
+
   boolbase@1.0.0: {}
+
+  bumpp@11.1.0:
+    dependencies:
+      args-tokenizer: 0.3.0
+      cac: 7.0.0
+      jsonc-parser: 3.3.1
+      package-manager-detector: 1.6.0
+      semver: 7.7.4
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      unconfig: 7.5.0
+      yaml: 2.8.4
+
+  cac@7.0.0: {}
 
   cfb@1.2.2:
     dependencies:
@@ -1060,6 +1469,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  defu@6.1.7: {}
+
   detect-libc@2.1.2: {}
 
   dom-serializer@2.0.0:
@@ -1079,6 +1490,10 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dts-resolver@3.0.0: {}
+
+  empathic@2.0.1: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -1141,6 +1556,12 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  hookable@6.1.1: {}
+
   htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -1151,6 +1572,14 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  import-without-cache@0.4.0: {}
+
+  jiti@2.7.0: {}
+
+  jsesc@3.1.0: {}
+
+  jsonc-parser@3.3.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1213,6 +1642,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -1238,7 +1669,46 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  quansync@1.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
+
+  rolldown-plugin-dts@0.25.0(rolldown@1.0.0)(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.4
+      '@babel/helper-validator-identifier': 8.0.0-rc.4
+      '@babel/parser': 8.0.0-rc.4
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.1
+      rolldown: 1.0.0
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -1263,6 +1733,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver@7.7.4: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1286,6 +1758,34 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tree-kill@1.2.2: {}
+
+  tsdown@0.22.0(tsx@4.21.0)(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0
+      rolldown-plugin-dts: 0.25.0(rolldown@1.0.0)(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+    optionalDependencies:
+      tsx: 4.21.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - vue-tsc
+
   tslib@2.8.1:
     optional: true
 
@@ -1298,11 +1798,24 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  unconfig@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      defu: 6.1.7
+      jiti: 2.7.0
+      quansync: 1.0.0
+      unconfig-core: 7.5.0
+
   undici-types@7.19.2: {}
 
   undici@7.25.0: {}
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1313,12 +1826,14 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
+      jiti: 2.7.0
       tsx: 4.21.0
+      yaml: 2.8.4
 
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -1335,7 +1850,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -1366,5 +1881,7 @@ snapshots:
       ssf: 0.11.2
       wmf: 1.0.2
       word: 0.3.0
+
+  yaml@2.8.4: {}
 
   zod@4.4.3: {}

--- a/scripts/prepare-npm-publish.mjs
+++ b/scripts/prepare-npm-publish.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+const [, , version, ...extraArgs] = process.argv
+
+if (!version || extraArgs.length) {
+  console.error("Usage: node scripts/prepare-npm-publish.mjs <version>")
+  process.exit(1)
+}
+
+const publishDirectories = ["packages/core", "packages/data", "packages/cli"]
+const root = process.cwd()
+
+const readJson = path => JSON.parse(readFileSync(path, "utf8"))
+const writeJson = (path, value) => writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+
+const manifests = publishDirectories.map((directory) => {
+  const path = join(root, directory, "package.json")
+  return { directory, path, manifest: readJson(path) }
+})
+const publishNames = new Set(manifests.map(({ manifest }) => manifest.name))
+
+for (const { directory, manifest } of manifests) {
+  if (manifest.version !== version) {
+    console.error(`${directory}/package.json version ${manifest.version} != ${version}`)
+    process.exit(1)
+  }
+  if (manifest.private === true) {
+    console.error(`${manifest.name} is private and cannot be published`)
+    process.exit(1)
+  }
+}
+
+let changed = false
+
+for (const { path, manifest } of manifests) {
+  for (const key of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const dependencies = manifest[key]
+    if (!dependencies) continue
+
+    for (const [name, specifier] of Object.entries(dependencies)) {
+      if (!publishNames.has(name)) continue
+      if (typeof specifier !== "string") continue
+      if (specifier.startsWith("workspace:")) {
+        dependencies[name] = version
+        changed = true
+      }
+    }
+  }
+
+  writeJson(path, manifest)
+}
+
+for (const { directory, manifest } of manifests) {
+  for (const key of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const dependencies = manifest[key] ?? {}
+    for (const [name, specifier] of Object.entries(dependencies)) {
+      if (publishNames.has(name) && specifier !== version) {
+        console.error(`${directory}/package.json ${key}.${name} ${specifier} != ${version}`)
+        process.exit(1)
+      }
+      if (typeof specifier === "string" && specifier.startsWith("workspace:")) {
+        console.error(`${directory}/package.json still contains workspace protocol: ${key}.${name}`)
+        process.exit(1)
+      }
+    }
+  }
+}
+
+console.log(changed ? `Prepared npm publish manifests for ${version}` : `npm publish manifests already prepared for ${version}`)

--- a/scripts/release-bump.mjs
+++ b/scripts/release-bump.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process"
+import { versionBump } from "bumpp"
+
+const usage =
+  "Usage: pnpm release:bump [version|major|minor|patch|premajor|preminor|prepatch|prerelease|next|conventional]"
+const [, , releaseArg, ...extraArgs] = process.argv
+
+if (extraArgs.length) {
+  console.error(usage)
+  process.exit(1)
+}
+
+const sh = (command, args) => execFileSync(command, args, { encoding: "utf8" }).trim()
+const branch = sh("git", ["branch", "--show-current"])
+
+if (branch !== "main") {
+  console.error(`Release bump must run from main, got ${branch || "(detached HEAD)"}`)
+  process.exit(1)
+}
+
+try {
+  sh("git", ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+}
+catch {
+  console.error("Release bump requires main to have an upstream branch before bumpp pushes the release tag.")
+  process.exit(1)
+}
+
+const release = releaseArg ?? "patch"
+
+await versionBump({
+  release,
+  files: [
+    "package.json",
+    "packages/core/package.json",
+    "packages/data/package.json",
+    "packages/cli/package.json",
+  ],
+  commit: true,
+  tag: true,
+  push: true,
+  install: false,
+  recursive: false,
+  noGitCheck: false,
+})


### PR DESCRIPTION
## Slock Context

- Owner: @TechLead
- Task: task #78
- Reviewers: @Product, @QA
- Related decisions: Q1 `v0.0.1`, Q2 npm publish via DS-D-09 OIDC pattern, Q3 hand-written `CHANGELOG.md`, Q6 full rollback runbook
- i18n impact: CLI message catalogs are bundled into the CLI package for installed warning/error paths; user-facing copy unchanged

## Summary

- Add package-readiness for `@randomplay/core`, `@randomplay/data`, and `@randomplay/cli`: public package manifests, MIT license metadata, dist ESM + `.d.mts` exports, and `publishConfig.access = public`.
- Add `tsdown@0.22.0` builds and keep the `fairy` bin stable while making it prefer `dist/index.mjs` and fall back to TS source for repo-local development.
- Bundle CLI diagnostic message catalogs into `@randomplay/cli` so installed CLI warning/error paths do not read repo-local `docs/ux/i18n/messages.*.json`.
- Add `pnpm release:bump` wrapper around `bumpp@11.1.0`, root `CHANGELOG.md` scaffold, release workflow, and `docs/release/release-workflow.md` including manual first publish and rollback.
- Add release CI allowlist publish for `packages/core`, `packages/data`, `packages/cli` with npm Trusted Publishing/OIDC, retry-safe existing-version `gitHead` checks, package manifest guards, **npm-pack tarball validation with no `workspace:` protocol**, and registry install smoke.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data verify:mihoyo-da`
- `pnpm --filter @randomplay/data verify:buhflipexplode-da`
- `pnpm --filter @randomplay/data verify:excel`
- `pnpm --silent fairy:s1 | jq empty`
- `pnpm --silent fairy:s2 | jq empty`
- `pnpm --silent fairy:s3 | jq empty`
- prepared npm publish manifest smoke in a temp repo: `node scripts/prepare-npm-publish.mjs 0.0.0`, then `npm pack --json` for core/data/cli and inspect each tarball `package/package.json` for no `workspace:` protocol
- isolated npm install smoke from actual npm tarballs: plain Node ESM imports for `@randomplay/core` and `@randomplay/data`, cleaned JSON import, `fairy --help | jq empty`, happy-path `fairy calc <S1 snapshot> --lang zh | jq empty`, warning-path installed `fairy calc` with missing `attackSegments[0].source` and `ERR-SRC-001` stderr
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `node --check scripts/release-bump.mjs`
- `node --check scripts/prepare-npm-publish.mjs`
- `git diff --check`

Note: I did not run `pnpm release:bump`; it creates and pushes a release commit/tag by design.
