### PR TITLE
docs(product): V1 errata + v0.0.1 CHANGELOG + release notes draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ First public release of the `@randomplay/data` / `@randomplay/core` / `@randompl
 - **`@randomplay/data`** — `cleaned/` typed-modifier dataset for the Deadly Assault (DA) domain; four export entries `cleaned/`, `cleaned/<domain>`, `types`, `cleaned/i18n/<domain>`; multi-source provenance (`sources[]` + `sourceRefs`).
 - **Mihoyo source pipeline** — list API + `entry_page` detail JSON + cheerio rich-text parsing; CN/EN parity manifest; coverage = 3 buffs + 3 boss attributes + 3 stage buffs per period (35 periods).
 - **buhflipexplode source pipeline** — raw snapshot + `algorithm-manifest.json` + parity drift gate; D-12 boundary preserved (Fairy stays MIT, no GPL JS in runtime).
-- **V1 golden anchor set (19 anchors)** — G01–G12, G14–G17, G21–G23; full passing in CI (`pnpm verify:golden-v1`).
+- **V1 golden anchor set (19 anchors)** — G01–G12, G14–G17, G21–G23; full passing in CI (`pnpm --filter @randomplay/data verify:golden-v1`).
 - **Anby dogfooding fixture** — base attack 583.957 / multiplier 0.747 at lvl 16 / generic Dullahan defense 952.8; `pnpm fairy:s1|s2|s3` aliases for quick smoke.
 - **Dogfooding artifacts** — `docs/product/dogfooding-report-v1.md` (4/5 release-gate evidence) + `docs/product/dogfooding-v1.md` (runbook).
 - **Release tooling** — `bumpp` thin wrapper (`scripts/release-bump.mjs`) + allowlist publish workflow (`@randomplay/data,core,cli`) + GitHub OIDC + Trusted Publisher path + retry-safe `gitHead` check + rollback runbook (`docs/release/release-workflow.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,46 @@
 
 All notable changes to Fairy will be documented in this file.
 
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) (simplified) and Fairy uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
+
+## [v0.0.1] — 2026-05-08
+
+First public release of the `@randomplay/data` / `@randomplay/core` / `@randomplay/cli` packages on npm. Functionally equivalent to the dogfooding-passed V1 milestone (see `docs/product/dogfooding-report-v1.md`).
 
 ### Added
 
-- Release workflow scaffold for `@randomplay/data`, `@randomplay/core`, and `@randomplay/cli`.
+- **`@randomplay/cli`** — `fairy` binary with five subcommands `calc / compare / scan / explain / migrate` built on [`citty`](https://github.com/unjs/citty); JSON-only output; `--lang en|zh` switch; ERR-CLI catalog (bilingual).
+- **`fairy calc` D-19 summary-first output** — `--view brief|verbose` (default `brief`); `summary.lanes.{nonCrit, crit, fixed}` two-lane output; `--result-mode expected` opt-in for expected damage; legacy `--resultMode` alias preserved.
+- **`@randomplay/core`** — five damage classes; handler/DSL pipeline; anomaly + disorder calculation including virtual agent / overflow / seven-attribute disorder / `disorderDazeLevelZone`.
+- **`@randomplay/data`** — `cleaned/` typed-modifier dataset for the Deadly Assault (DA) domain; four export entries `cleaned/`, `cleaned/<domain>`, `types`, `cleaned/i18n/<domain>`; multi-source provenance (`sources[]` + `sourceRefs`).
+- **Mihoyo source pipeline** — list API + `entry_page` detail JSON + cheerio rich-text parsing; CN/EN parity manifest; coverage = 3 buffs + 3 boss attributes + 3 stage buffs per period (35 periods).
+- **buhflipexplode source pipeline** — raw snapshot + `algorithm-manifest.json` + parity drift gate; D-12 boundary preserved (Fairy stays MIT, no GPL JS in runtime).
+- **V1 golden anchor set (19 anchors)** — G01–G12, G14–G17, G21–G23; full passing in CI (`pnpm verify:golden-v1`).
+- **Anby dogfooding fixture** — base attack 583.957 / multiplier 0.747 at lvl 16 / generic Dullahan defense 952.8; `pnpm fairy:s1|s2|s3` aliases for quick smoke.
+- **Dogfooding artifacts** — `docs/product/dogfooding-report-v1.md` (4/5 release-gate evidence) + `docs/product/dogfooding-v1.md` (runbook).
+- **Release tooling** — `bumpp` thin wrapper (`scripts/release-bump.mjs`) + allowlist publish workflow (`@randomplay/data,core,cli`) + GitHub OIDC + Trusted Publisher path + retry-safe `gitHead` check + rollback runbook (`docs/release/release-workflow.md`).
+
+### Changed
+
+- **npm scope** — packages renamed from `@fairy/*` to `@randomplay/{data,core,cli}` (PR #35 commit `dd78a4b`); root monorepo name = `fairy-monorepo` (private); CLI binary stays `fairy`.
+- **米游社 sourceConflict audit (3 records, D-16 + D-17)** — 21 澄意 / 8 灼冽 / 1 破招 resolved as `resolved-prefer-buhflipexplode`; manual three-way verification against `https://zzz.nanoka.cc/boss/` showed nanoka aligned with buhflipexplode (2:1 vs Mihoyo); audit evidence at `data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`.
+
+### Known limitations
+
+- **DD-003 single-person dogfooding (D-18)** — V1 was validated only by `@lo-user` deep dogfood + QA regression; not validated against community usage. Wider validation deferred to V1.x.
+- **Day 3 边界探测 skipped** — `--lang en` cross-locale verification and intentional ERR-* triggering not exercised during dogfooding (lo-user decision); gaps may surface post-release.
+- **Golden anchor V1.x defer** — G13 (data-driven anomaly threshold rule composition) / G18 部位破坏 / G19 凶心疯汉失衡恢复 / G20 装甲哈提失衡恢复 deferred to V1.x with broader scope.
+- **No Web UI / no AI plugin** — V2 (Web UI) and V1.1 (AI plugin / screenshot recognition / Bangboo) remain on the roadmap.
+
+### Decisions referenced
+
+- **D-13** golden anchor scope (19 anchors)
+- **D-16** source priority + multi-source metadata + 2026-05-08 audit
+- **D-17** Mihoyo V1 抓取范围 + 工具栈
+- **D-18** V1 dogfooding gate (DD-003)
+- **D-19** V1 CLI 输出改革 (`--view brief|verbose` summary-first)
+
+[Unreleased]: https://github.com/LoTwT/fairy/compare/v0.0.1...HEAD
+[v0.0.1]: https://github.com/LoTwT/fairy/releases/tag/v0.0.1

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -25,10 +25,12 @@
 | **D-10** | 数据维护责任 | ✅ 锁定（v2.0 修订） | V1 阶段：lo-user 提供 Excel 主源 + 爬虫每版本手动 release；data 包必须做完整角色/音擎/驱动盘/影画/鸣徽/潜能激化数据 | 中 |
 | **D-11** | 命名体系（v2.0 新增） | ✅ 锁定 | 选项 A 全套官方化：公开 schema / core API / data 字段优先使用 ZZZ 官方英文的语义化 camelCase；旧 `breach*` 进 sourceAliases / migration | 中 |
 | **D-12** | buhflipexplode 算法处理 | ✅ 锁定 | 选项 B：Fairy 保持 MIT；buhflipexplode GPL JS 仅 raw 留档/参考，不复制进 runtime；Fairy 独立实现等价算法；每次抓取用 hash + 算法快照文档 + parity 对账监控 drift | 高 |
-| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 cleaned schema 讨论会） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；通用敌人 / 部位破坏 / 失衡恢复时间在 V1.x；V1 黄金集收窄到 20 锚点（去掉 18 部位破坏 / 19 凶心疯汉 / 20 装甲哈提，V1.x 数据扩展时一次性补） | 中 |
+| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；通用敌人 / 部位破坏 / 失衡恢复时间在 V1.x；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x defer = G13 / G18 / G19 / G20 | 中 |
 | **D-14** | cleaned data typed modifier 双层结构 | ✅ 锁定（2026-05-05） | Layer 1 原文层 `sourceText` / `localizedText` + Layer 2 计算层 `modifiers[]` / `calculationEffects[]` + 风险层 `unparsedEffects[]`；bucket 受控 enum 严格匹配 glossary v0.4 D-11；效果 4 级（L1 静态 / L2 静态条件 / L3 动态参数 / L4 时序需 `requiresActivation`）；确定性 pipeline + sourceTextHash + parserVersion + effectTemplateId + 人工 audit gate；AI 候选不能直接入 cleaned | 中 |
 | **D-15** | V1 package exports 4 入口 | ✅ 锁定（2026-05-05） | V1 全做：`@randomplay/data/cleaned`（总入口）/ `@randomplay/data/cleaned/<domain>` / `@randomplay/data/types` / `@randomplay/data/cleaned/i18n/<domain>`；data 包 game labels 源码 `packages/data/src/i18n/` → 发布 `packages/data/cleaned/i18n/`；UX ERR-* `docs/ux/i18n/` 完全独立 | 中 |
 | **D-16** | Source priority + multi-source + unknown policy | ✅ 锁定（2026-05-05） | Excel base / buhflipexplode DA overlay / 米游社 i18n；冲突 fail loud + manual review；entity-level `sources[]` + 关键数值字段级 `sourceRefs`；unknown 分级 blocking（影响计算）/ non-blocking（纯展示）；新增 ERR-DAT-005（multi-source conflict / 未解析 modifier blocking）+ ERR-DAT-006（locale mapping unresolved / 展示缺失 non-blocking，与 PR #21 cleaned schema spec 锁定一致） | 中 |
+| **D-17** | 米游社 V1 抓取范围 + 工具栈 | ✅ 锁定（2026-05-05 升级 + 2026-05-08 audit 决议） | 范围扩展为 DA 详情正文 + 乘区文本 + zh/en alignment；工具：列表 API + entry_page detail JSON + cheerio；2026-05-08 sourceConflict audit accept buhflipexplode（与 nanoka 三方比对 2:1） | 中 |
+| **D-18** | V1 dogfooding gate（DD-003） | ✅ 锁定（2026-05-05） + 通过（2026-05-08 4/5） | V1 release gate 第 2 项从"3+ 社区试用"收窄为 lo-user 单人深度 dogfood + QA 回归；known limitations 显式标注未经社区广泛验证 + Day 3 跳过 | 高 |
 | **D-19** | V1 CLI 输出改革 | ✅ 锁定（2026-05-06） | `fairy calc` 默认 `--view brief` summary-first；完整 trace 通过 `--view verbose`；默认输出 `summary.lanes.nonCrit` / `summary.lanes.crit`，不使用期望伤害；`--result-mode expected` 保留为可选理论分析；其他二元输入差异通过 `fairy compare` | 中 |
 | **D-1=D**（S2 节奏） | V1 推进顺序 | ✅ 锁定 | S2 双门槛：schema discovery + 并行 scraper 准备；S6 全量化最后；不允许 data 全量化阻塞 core 启动 | 中 |
 
@@ -137,14 +139,21 @@
 - `cleaned/enemies` 全局 enemy base 不作为 V1 必交付
 - Excel `敌人属性`（412 unique）保留 raw archive，V1.x+ 扩展源
 - DA boss 能映射 Excel 时补 `baseEnemyRef`；映射不到（如 Sanguine Sweeper）→ `externalBossId + sourceRefs + unresolvedMapping`
-- V1 黄金集 23 锚点收窄到 **20 锚点**：推迟 18 部位破坏 / 19 凶心疯汉失衡恢复 / 20 装甲哈提失衡恢复 到 V1.x
+- V1 黄金集 23 锚点收窄到 ~~20 锚点~~ → **19 锚点**（D-13 errata，2026-05-05 17:53 lo-user 拍板）
+
+**2026-05-05 17:53 D-13 errata（lo-user 拍板）**：黄金集 20 → **19 anchors**。
+- **V1 19 anchors**：G01-G12 + G14-G17 + G21-G23
+- **V1.x defer**：G13（data-driven anomaly threshold rule composition）+ G18 部位破坏 + G19 凶心疯汉失衡恢复 + G20 装甲哈提失衡恢复
+- **G13 defer 理由**：需要 `anomalyThresholdModifiers[]` schema + core 组合逻辑 + source trace + fixture；当前 core 仅有 `thresholdOverride`，保留 V1 会扩大 #43 + 触动 core；defer 可逆，V1.x 与通用/特殊敌人规则一起做更聚焦
+- **状态**：✅ V1 release-ready milestone 时 PR #28 已实施 19 anchors（commit `3f5e67a`）
+- **影响 doc**：`docs/qa/golden-source-coverage.md`（matrix 标 G13 deferred） / `docs/product/meetings/2026-05-05-cleaned-schema-design.md` §2.7
 
 **理由**：
 - 与 lo-user "V1 主要支持危局强袭战 + Excel 后备" 框定一致
 - V1 推进速度优先；4 方一致推荐 A（黄金集收窄）
 - UX 资产损耗极小（仅 starter-scenarios S2 enemy swap）
 
-**来源**：会议纪要 [`docs/product/meetings/2026-05-05-cleaned-schema-design.md`](../meetings/2026-05-05-cleaned-schema-design.md) §2.3 / §2.7
+**来源**：会议纪要 [`docs/product/meetings/2026-05-05-cleaned-schema-design.md`](../meetings/2026-05-05-cleaned-schema-design.md) §2.3 / §2.7；2026-05-05 17:53 thread `#fairy:43-scope` lo-user 同意 G13 defer。
 
 ### D-14 cleaned data typed modifier 双层结构
 
@@ -242,6 +251,64 @@ buhflipexplode 危局强袭战 buff `sourceConflict` 已做人工 audit。lo-use
 - buff active/inactive、敌人状态前后、异常/紊乱触发与否等输入差异使用 `fairy compare`
 
 **来源**：Slock `#fairy:9f8fe6b6` D-19 输出结构讨论；lo-user 2026-05-06 拍板 Q1=`--view brief|verbose`、Q2=summary-first、Q3=保留 expected 可选。
+
+### D-17 米游社 V1 抓取范围 + 工具栈（2026-05-05 升级）
+
+**锁定状态**：@lo-user 2026-05-05 16:46（thread `#fairy:e6993153`）将米游社范围从"i18n 名称源"扩展为"DA 详情正文 + 乘区文本 + zh/en 对照"，作为 V1 必交付。TL 16:52 完成 API discovery 收敛实施方案。
+
+**V1 抓取范围**（每期）：
+- **3 个可选 buff**（含乘区文本）
+- **3 个 boss 属性 + 描述**
+- **3 个 boss 房间场地 buff**（含乘区文本）
+- **CN ↔ EN 对照**：与 buhflipexplode 描述对齐，作为 V1 必交付
+
+**工具栈**：
+- 列表 API：`https://baike.mihoyo.com/zzz/...` 频道 13 list → 子频道 108 取 35 期 `content_id`
+- 详情 API：`https://act-api-takumi-static.mihoyo.com/hoyowiki/zzz/wapi/entry_page?app_sn=zzz_wiki&entry_page_id={content_id}&lang=zh-cn`，请求头 `x-rpc-wiki_app: zzz`
+- 富文本解析：`multi_table` / `rich_row_base_info` HTML 用 cheerio 离线解析
+- **Playwright 不进生产依赖**（仅手工 sanity 检查时使用）
+
+**Source 角色**（与 D-16 一致）：
+- buhflipexplode = DA event/enemy overlay 主源
+- 米游社 = 中文 i18n / 描述源 + DA 详情乘区文本 zh/en alignment
+- Excel = base entity 主源
+- 冲突时 fail loud + manual review
+
+**parity manifest**：抓取产物附 CN/EN parity manifest，alignment 失败 fail loud（ERR-DAT-005 blocking）；V1 不预设 alignment unresolved 的 ERR reason，待真出现再补（保留 ERR-DAT-006 non-blocking 兜底）。
+
+**实施 PR**：#24（commit `4b9ac2a`）— TL 自带 docs 同步（`docs/data-source/mihoyo/*` / `docs/data-contract/cleaned-schema-spec.md` DA domain / `docs/index.md` / `CLAUDE.md` / `robots.txt` / source registry / package README）。
+
+**2026-05-08 sourceConflict audit 决议**（与 D-16 同步）：PR #24 留存的 3 条米游社 vs buhflipexplode 数值冲突（21 澄意 / 8 灼冽 / 1 破招）已人工 audit。lo-user 用 nanoka (`https://zzz.nanoka.cc/boss/`) 作为人工查询源（不接管线），三方比对 nanoka 与 buhflipexplode 一致（2:1 vs Mihoyo），lo-user 决策 `Q1，按 buhflipexplode`。cleaned release evidence 记录为 `resolved-prefer-buhflipexplode`，Mihoyo 原值与 sourceRefs 保留为审计线索。详见 `data/cleaned/audit/mihoyo-buhflipexplode.source-conflicts.json`（PR #33 commit `04e7077`）。
+
+**可逆性**：中（API 形态变更需要重抓 + parity 重核）
+
+**来源**：thread `#fairy:e6993153`（lo-user 16:46 / TL 16:46~16:52 / QA 16:46）+ doc-drift-log DD-001 + PR #24 / #33。
+
+### D-18 V1 dogfooding gate（DD-003）
+
+**锁定状态**：@lo-user 2026-05-05 20:23（thread `#fairy:dogfooding`）将 V1 release gate 第 2 项从 "3+ 社区试用" 收窄为 **lo-user 单人深度 dogfood + QA 回归**。
+
+**Gate 条件**（dogfooding-v1.md §4.1）：
+- B-Calc.blocker：0 件未修
+- B-Calc.non-blocker：已重新分类
+- U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解
+- D-Data：audit gate 决议落地
+- P-Range：全部入 V1.x backlog
+- **lo-user 整体打分 ≥ 4/5**（自评）
+
+**已知限制**（V1 release notes 必须标注）：
+- V1 仅由 lo-user 单人深度 dogfood 验证 + QA 回归，**未经社区广泛验证**
+- dogfooding Day 3 边界探测（`--lang en` / 故意造错 ERR-* 验证）lo-user 决策跳过，V1.x 视真实使用反馈再决定是否回补
+
+**触发 V1.x 扩 dogfood 范围的条件**：
+- 真实社区使用反馈出现重复性 B-Calc / U-* 问题
+- 计算结果与第三方计算器结构性 drift
+
+**实施结果**：dogfooding 期间 lo-user 整体打分 = **4/5**，通过 gate。详见 `docs/product/dogfooding-report-v1.md`。
+
+**可逆性**：高（V1.x 可扩 dogfood 范围）
+
+**来源**：thread `#fairy:dogfooding` 20:22~20:23 lo-user 自荐试用 + 拍方案 B；doc-drift-log DD-003；dogfooding-report-v1.md。
 
 ### D-12 buhflipexplode 算法处理
 

--- a/docs/release/release-notes-v0.0.1.md
+++ b/docs/release/release-notes-v0.0.1.md
@@ -39,7 +39,7 @@ Or clone the repo and run the bundled smoke chain:
 
 ```bash
 pnpm install --frozen-lockfile
-pnpm verify:golden-v1
+pnpm --filter @randomplay/data verify:golden-v1
 pnpm fairy:s1   # Anby S1 baseline
 pnpm fairy:s2
 pnpm fairy:s3
@@ -83,7 +83,12 @@ See `docs/product/decisions/index.md` for the full decisions log and `docs/produ
 If a critical regression surfaces post-release, follow `docs/release/release-workflow.md` rollback section:
 
 1. Mark the GitHub Release as pre-release.
-2. `npm deprecate @randomplay/{data,core,cli}@0.0.1 "<reason + tracking issue>"` from the package owner account.
+2. Deprecate each affected package version separately (npm CLI does not accept brace expansion):
+   ```bash
+   npm deprecate @randomplay/data@0.0.1 "<reason + tracking issue>"
+   npm deprecate @randomplay/core@0.0.1 "<reason + tracking issue>"
+   npm deprecate @randomplay/cli@0.0.1 "<reason + tracking issue>"
+   ```
 3. Open a `revert` PR against `main` and cut a `v0.0.2` patch via the standard release pipeline.
 
 ## Links

--- a/docs/release/release-notes-v0.0.1.md
+++ b/docs/release/release-notes-v0.0.1.md
@@ -1,0 +1,94 @@
+# Fairy v0.0.1 — Release Notes (draft)
+
+> First public release. This document is the source of truth for the GitHub Release page body. Edit here, then paste at release time.
+
+## TL;DR
+
+`@randomplay/cli` (binary: `fairy`) is a TypeScript-first damage calculator for ZZZ Deadly Assault, with deterministic typed-modifier data (`@randomplay/data`) and a pluggable calculation engine (`@randomplay/core`). v0.0.1 ships the dogfooding-passed V1 feature set under a fresh npm scope.
+
+## Highlights
+
+- **CLI** — five subcommands `calc / compare / scan / explain / migrate` on top of `citty`; JSON-only output, `--lang en|zh`, summary-first (`--view brief|verbose`).
+- **Core engine** — five damage classes; anomaly / disorder full pipeline (virtual agent / overflow / seven-attribute disorder / `disorderDazeLevelZone`).
+- **Cleaned data** — DA-domain typed modifier dataset with multi-source provenance; 19-anchor V1 golden set; bundled Anby dogfooding fixture.
+- **Mihoyo + buhflipexplode sources** — Mihoyo `entry_page` detail JSON + cheerio rich-text parsing with CN/EN parity manifest; buhflipexplode raw snapshot + drift gate (no GPL JS in runtime).
+- **Audit-resolved data deltas** — 3 米游社 / buhflipexplode source conflicts manually audited and resolved in favor of buhflipexplode (verified against `zzz.nanoka.cc`, 2:1 alignment).
+- **Release pipeline** — bumpp + allowlist publish + GitHub OIDC + Trusted Publisher + rollback runbook.
+
+## Install
+
+```bash
+# CLI
+pnpm dlx @randomplay/cli fairy --help
+
+# Library
+pnpm add @randomplay/data @randomplay/core
+```
+
+Verified on Node ≥ 22.14.
+
+## Verify
+
+After install, run the golden smoke:
+
+```bash
+fairy calc <your-snapshot.json> --view brief
+```
+
+Or clone the repo and run the bundled smoke chain:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm verify:golden-v1
+pnpm fairy:s1   # Anby S1 baseline
+pnpm fairy:s2
+pnpm fairy:s3
+```
+
+## Known limitations (please read before reporting issues)
+
+- **Single-person dogfooding** — V1 was validated by one user (`@lo-user`) plus QA regression. Community usage paths are not yet covered.
+- **Day 3 edge probing skipped** — cross-locale (`--lang en`) verification and intentional ERR-* triggering were not exercised during dogfooding.
+- **V1.x defer** — G13 anomaly threshold rule composition / G18 part destruction / G19 部位 break disorder recovery / G20 armored Hati disorder recovery are deferred.
+- **No Web UI, no AI plugin** in v0.0.x. Web UI is the V2 milestone; AI plugin / screenshot OCR / Bangboo are V1.1.
+
+If you hit a blocker, open a GitHub issue with: snapshot JSON (sanitized) + the exact CLI command + expected vs actual output.
+
+## Compatibility
+
+- Public schema: `@randomplay/data/cleaned` and `/types` are stable for v0.0.x. Field renames will follow `D-11` (官方化命名 + sourceAliases + migration notes).
+- CLI: `--view brief|verbose` and `--result-mode expected` are stable; legacy `--resultMode` alias is kept transitional.
+- Internal effect handlers (`L4 requiresActivation` etc.) may evolve in v0.0.x as new effect templates land.
+
+## Decisions
+
+This release lands under the formal decisions:
+
+- **D-13** V1 黄金集 19 anchors
+- **D-16** Source priority + multi-source metadata
+- **D-17** 米游社 V1 抓取范围 + 工具栈
+- **D-18** V1 dogfooding gate (DD-003)
+- **D-19** V1 CLI 输出改革
+
+See `docs/product/decisions/index.md` for the full decisions log and `docs/product/dogfooding-report-v1.md` for dogfooding evidence (4/5).
+
+## Acknowledgements
+
+- buhflipexplode (`buhflipexplode.org/zzz/da/`) for the DA reference dataset
+- 米游社 wiki (`baike.mihoyo.com/zzz/`) for CN i18n + 乘区文本
+- `zzz.nanoka.cc/boss/` for third-party manual verification
+
+## Rollback
+
+If a critical regression surfaces post-release, follow `docs/release/release-workflow.md` rollback section:
+
+1. Mark the GitHub Release as pre-release.
+2. `npm deprecate @randomplay/{data,core,cli}@0.0.1 "<reason + tracking issue>"` from the package owner account.
+3. Open a `revert` PR against `main` and cut a `v0.0.2` patch via the standard release pipeline.
+
+## Links
+
+- Repository — https://github.com/LoTwT/fairy
+- Dogfooding report — `docs/product/dogfooding-report-v1.md`
+- Release workflow — `docs/release/release-workflow.md`
+- Decisions log — `docs/product/decisions/index.md`

--- a/docs/release/release-notes-v0.0.1.md
+++ b/docs/release/release-notes-v0.0.1.md
@@ -18,21 +18,29 @@
 ## Install
 
 ```bash
-# CLI
-pnpm dlx @randomplay/cli fairy --help
+# CLI — one-shot via pnpm dlx (no install)
+pnpm dlx @randomplay/cli --help
+pnpm dlx @randomplay/cli calc <your-snapshot.json> --view brief
+
+# CLI — local install in your project
+pnpm add -D @randomplay/cli
+pnpm exec fairy --help
+pnpm exec fairy calc <your-snapshot.json> --view brief
 
 # Library
 pnpm add @randomplay/data @randomplay/core
 ```
 
-Verified on Node ≥ 22.14.
+Verified on Node ≥ 22.14. The `pnpm dlx` invocation runs the CLI's `fairy` bin directly — you don't pass `fairy` as a separate argument.
 
 ## Verify
 
-After install, run the golden smoke:
+After install, run a smoke calc:
 
 ```bash
-fairy calc <your-snapshot.json> --view brief
+pnpm exec fairy calc <your-snapshot.json> --view brief
+# or, without install:
+pnpm dlx @randomplay/cli calc <your-snapshot.json> --view brief
 ```
 
 Or clone the repo and run the bundled smoke chain:

--- a/docs/release/release-notes-v0.0.1.md
+++ b/docs/release/release-notes-v0.0.1.md
@@ -80,12 +80,6 @@ This release lands under the formal decisions:
 
 See `docs/product/decisions/index.md` for the full decisions log and `docs/product/dogfooding-report-v1.md` for dogfooding evidence (4/5).
 
-## Acknowledgements
-
-- buhflipexplode (`buhflipexplode.org/zzz/da/`) for the DA reference dataset
-- 米游社 wiki (`baike.mihoyo.com/zzz/`) for CN i18n + 乘区文本
-- `zzz.nanoka.cc/boss/` for third-party manual verification
-
 ## Rollback
 
 If a critical regression surfaces post-release, follow `docs/release/release-workflow.md` rollback section:


### PR DESCRIPTION
## Summary

Phase 3 (post PR #31) — consolidates doc-drift buffer (DD-001 / DD-002 / DD-003) into formal decisions and prepares the v0.0.1 release artifacts.

## Slock Context

- **Owner**: @Product
- **Task**: V1 release Phase 3 errata + CHANGELOG + release notes
- **Reviewers**: @QA (release-readiness sign-off, evidence consistency), @TechLead (release-notes technical accuracy, rollback section)
- **Related decisions**: D-13 (errata), D-17 (new), D-18 (new), references D-16 / D-19 / DD-003
- **i18n impact**: none (docs only; no UX catalog / runtime string changes)

## Changes

### `docs/product/decisions/index.md`
- **D-13 errata** — V1 golden anchor set 20 → 19 (G13 deferred along with G18 / G19 / G20). Rationale + impact docs listed; status notes V1 release-ready milestone PR #28 has implemented 19 anchors.
- **D-17 (new)** — Mihoyo V1 抓取范围 + 工具栈 — list API + `entry_page` detail JSON + cheerio + CN/EN parity manifest; 2026-05-08 sourceConflict audit decision (accept buhflipexplode after `zzz.nanoka.cc` three-way verification, 2:1 vs Mihoyo); references PR #24 implementation + PR #33 audit evidence.
- **D-18 (new)** — V1 dogfooding gate (DD-003 single-person dogfood + 4/5 self rating). Known limitations (no community validation, Day 3 edge probing skipped) made explicit and traceable to `dogfooding-report-v1.md`.
- Top-of-file table updated for D-13 / D-17 / D-18.

### `CHANGELOG.md`
- Replaces scaffold with Keep-a-Changelog v0.0.1 entry — features, scope rename, audit resolution, known limitations, decision references.

### `docs/release/release-notes-v0.0.1.md` (new)
- GitHub Release page draft: TL;DR, install, verify smoke, known limitations, schema compatibility, decision references, rollback steps, source acknowledgements. Edit at release time and paste.

## Doc-drift buffer cleanup (notes/fairy-doc-drift-log.md)

- DD-001 → absorbed by D-17
- DD-002 → absorbed by D-13 errata
- DD-003 → absorbed by D-18

(Will be marked `merged` in the workspace doc-drift-log post-merge.)

## Test plan

- [ ] @QA verify decisions index errata text accuracy against doc-drift-log + dogfooding-report references
- [ ] @QA `pnpm check` / `pnpm test` / `pnpm verify:golden-v1` on this branch (docs-only PR but smoke ensures no incidental drift)
- [ ] @TechLead skim release-notes-v0.0.1.md for technical accuracy (install command, smoke chain, rollback steps reflect docs/release/release-workflow.md)
- [ ] Lo-user sanity-pass on release notes tone + acknowledgements list