### PR TITLE
ci(release): retry npm install with backoff for CDN propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,28 @@ jobs:
           TMP_DIR="$(mktemp -d)"
           cd "$TMP_DIR"
           npm init -y >/dev/null
-          npm install "@randomplay/core@$VERSION" "@randomplay/data@$VERSION" "@randomplay/cli@$VERSION" >/dev/null
+
+          # Retry npm install with backoff to absorb npm registry CDN
+          # propagation lag immediately after publish. Total budget is
+          # MAX_ATTEMPTS * DELAY ≈ 60s, well under the typical worst-case
+          # propagation window observed for newly-published versions.
+          # Mirrors design-system PR #13 (1f9bf89e) and the canonical
+          # runbook at LoTwT/ai/docs/npm-release-from-zero-to-shipped.md.
+          MAX_ATTEMPTS=6
+          DELAY=10
+          ATTEMPT=1
+          until npm install "@randomplay/core@$VERSION" "@randomplay/data@$VERSION" "@randomplay/cli@$VERSION" >/dev/null 2>&1; do
+            if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "npm install failed after $MAX_ATTEMPTS attempts (npm CDN propagation timeout?)" >&2
+              # Final attempt without redirect so the real error surfaces in logs.
+              npm install "@randomplay/core@$VERSION" "@randomplay/data@$VERSION" "@randomplay/cli@$VERSION"
+              exit 1
+            fi
+            echo "npm install attempt $ATTEMPT failed (likely npm CDN propagation lag); waiting ${DELAY}s before retry..."
+            sleep "$DELAY"
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+          echo "npm install succeeded on attempt $ATTEMPT"
           node --input-type=module <<'NODE'
           import { calculate, parseBattleSnapshot } from '@randomplay/core'
           import * as data from '@randomplay/data'


### PR DESCRIPTION
## Summary
Wraps the `Registry install smoke` step's `npm install` in an `until` retry loop with backoff (6 attempts × 10s = ~60s total budget). Mirrors `LoTwT/design-system` PR #13 (`1f9bf89e`) and Phase 2 of the canonical runbook at `LoTwT/ai/docs/npm-release-from-zero-to-shipped.md`.

## Why
fairy's `release.yml` is the DS-D-09 baseline shape, predating the design-system DD-012 patch. When the OIDC publish path runs end-to-end during the v0.0.2 validation, the smoke `npm install @randomplay/...@$VERSION` is going to race with the npm CDN and return `ETARGET No matching version found` on the first attempt — exactly the bug DD-012 fixed for design-system.

This patch ports the same fix forward so fairy's first OIDC-validated release does not need a manual rerun.

## Behavior change
- Only the registry install smoke step. Suppresses npm output during retries; on final failure, re-runs without redirection so the underlying error appears in the log.
- No change to package, token, environment, or release semantics.
- Existing successful releases (none yet on fairy) would be unaffected.

## Test plan
- [x] YAML structure preserved (10-space indent inside `run: |` block matches the surrounding lines)
- [x] `bash -n` on the extracted step body — no syntax errors
- [x] Retry loop logic walked through: success on first attempt → single npm install + log; ETARGET on attempts 1-5 → retry after 10s; failure on attempt 6 → final unredirected install + exit 1
- [ ] First real validation lands at fairy v0.0.2 OIDC validation (Phase 6 of the runbook); no in-tree way to dry-run the publish workflow

## Slock Context
- **Owner**: @TechLeadClaude
- **Trigger**: @lo-user `108875dc` (audit fairy against runbook, add anything missing) → @Product `e5673df2` (P1 trigger)
- **Pattern source**: design-system PR #13 (`1f9bf89e`) — same `until`-loop, same 60s budget
- **Reviewers**: @QAClaude (bash logic + 60s budget reasonableness + YAML structure)

## Related
- Canonical runbook: `LoTwT/ai/docs/npm-release-from-zero-to-shipped.md` Phase 2 step 7
- design-system worked example: PR #13 merged `1f9bf89e`

## What this PR does NOT cover
P2 from the audit (`npm-publish` GitHub environment + `v*.*.*` tag protection ruleset on this repo) is a separate manual UI-ops step for @lo-user before / after Phase 5.2 manual bootstrap. Routing TBD per @lo-user reply on `e5673df2` (a vs b).