### PR TITLE
ci: normalize release housekeeping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
         run: npx --yes git-cliff@2.13.1 --latest --strip header --output /tmp/release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           name: fairy v${{ steps.release.outputs.version }}
           body_path: /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,36 @@ All notable changes to Fairy are documented in this file.
 ### Changed
 
 - Migrate release flow to v3 runbook (#39)
+
 ## 0.0.1 - 2026-05-10
 
 ### Added
 
+- Add agent data parsing and API endpoints
+- Add middleware for CORS, CSRF, caching, and trailing slash handling
+- Implement OpenAPI integration with agents API and add response schemas
+- Add W-Engines data parsing, API endpoints, and schemas
+- Add Bangboos data parsing, API endpoints, and schemas
+- Add Drive Discs data parsing, API endpoints, schemas, and JSON data
+- Implement web scraper for agent data
+- Add energy limit and regeneration properties to agent schema and data
+- Add type satisfaction for schemas in agents, bangboos, drive discs, and w-engines
+- Add typecheck script to package.json and fix baseUrl path in tsconfig.json
+- Enhance agent scraping logic and update common images structure
+- Implement bangboo scraping and add bangboos data structure
+- Refactor scraping logic to use NAVIGATION_OPTIONS for page navigation
+- Add W-Engines scraping functionality and data structure
+- Add Drive Discs scraping functionality and data structure
+- Rename parse-data script to gen-data and add generate-data functionality
+- Add rarity extraction
+- Add additional properties to agent schema and types
+- Add avatar, sprite, rarity, and rarityIcon fields to Bangboo schema and data
+- Update WEngine schema and type to replace rank with rarity and add new properties
+- Add avatar and sprite fields to DriveDisc schema and data
+- Add timing logs for data generation and scraping processes
+- Scrape deadly assaults
+- Add anomalies schema, API, and data handling
+- Add deadly assaults api, schema and types
 - Add runtime contract schemas (#7)
 - Add formula engine and handler DSL
 - Implement anomaly and disorder formulas
@@ -26,6 +52,7 @@ All notable changes to Fairy are documented in this file.
 
 ### Changed
 
+- Migrate to monorepo (#1)
 - Reinit (#2)
 - Retry npm install with backoff for CDN propagation (#38)
 
@@ -50,4 +77,6 @@ All notable changes to Fairy are documented in this file.
 
 ### Fixed
 
+- Update agent parsing logic to exclude header row and improve data integrity
+- Update release scripts to ensure build before publishing
 - Localize shell error messages

--- a/cliff.toml
+++ b/cliff.toml
@@ -3,10 +3,8 @@ header = """
 # Changelog
 
 All notable changes to Fairy are documented in this file.
-
 """
-body = """
-{% if version %}\
+body = """{% if version %}\
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
 ## Unreleased
@@ -18,7 +16,7 @@ body = """
 {% endfor %}
 {% endfor %}
 """
-trim = true
+trim = false
 
 [git]
 conventional_commits = true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fairy:s1": "node packages/cli/bin/fairy.js calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty",
     "fairy:s2": "node packages/cli/bin/fairy.js calc examples/snapshots/s2-yanagi-disorder.json --lang zh --pretty",
     "fairy:s3": "node packages/cli/bin/fairy.js calc examples/snapshots/s3-team-g22-g23-acceptance.json --lang zh --pretty",
-    "changelog": "git-cliff --tag \"v$npm_package_version\" --output CHANGELOG.md",
+    "changelog": "node scripts/update-changelog.mjs",
     "prepare": "simple-git-hooks",
     "release:bump": "bumpp",
     "test": "pnpm -r --if-present test"

--- a/scripts/update-changelog.mjs
+++ b/scripts/update-changelog.mjs
@@ -1,0 +1,58 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8'))
+const tag = `v${packageJson.version}`
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.stdio ?? 'pipe',
+  })
+}
+
+function tagExists(ref) {
+  try {
+    run('git', ['rev-parse', '--verify', `refs/tags/${ref}`], { stdio: 'ignore' })
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function stripUnreleasedSection(markdown) {
+  const match = /^## Unreleased(?:\r?\n|$)/m.exec(markdown)
+  if (!match)
+    return markdown
+
+  const start = match.index
+  const afterHeading = start + match[0].length
+  const rest = markdown.slice(afterHeading)
+  const nextRelease = /^## /m.exec(rest)
+
+  if (!nextRelease)
+    return markdown.slice(0, start)
+
+  return markdown.slice(0, start) + markdown.slice(afterHeading + nextRelease.index)
+}
+
+function normalizeFinalNewline(markdown) {
+  return `${markdown.replace(/\n+$/, '')}\n`
+}
+
+if (tagExists(tag)) {
+  // During ordinary post-release development, package.json still points at the
+  // latest published version. Regenerate from real tags and drop the transient
+  // Unreleased section so `pnpm changelog` remains stable until the next bump.
+  run('git-cliff', ['--output', 'CHANGELOG.md'], { stdio: 'inherit' })
+  const changelog = readFileSync('CHANGELOG.md', 'utf8')
+  writeFileSync('CHANGELOG.md', normalizeFinalNewline(stripUnreleasedSection(changelog)))
+}
+else {
+  // During `bumpp`, package.json has already moved to the new version but the
+  // tag does not exist yet. Use that future tag as the generated release entry.
+  run('git-cliff', ['--tag', tag, '--output', 'CHANGELOG.md'], { stdio: 'inherit' })
+  const changelog = readFileSync('CHANGELOG.md', 'utf8')
+  writeFileSync('CHANGELOG.md', normalizeFinalNewline(changelog))
+}


### PR DESCRIPTION
## Summary
- normalize `pnpm changelog` after the v0.0.2 tag state by routing it through `scripts/update-changelog.mjs`
- when the package version tag already exists, the script regenerates from real tags and strips the transient `Unreleased` section so post-release housekeeping commits do not get folded into the existing v0.0.2 entry
- when the package version tag does not exist yet, the script keeps the release-time path and generates the future version entry for `bumpp`
- commit the full generated `CHANGELOG.md` output from complete git history so the script is stable in fresh clones and full-history CI checkouts
- update the pinned `softprops/action-gh-release` SHA to `v3.0.0` (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`), which declares `runs.using: node24`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data verify:mihoyo-da`
- `pnpm --filter @randomplay/data verify:buhflipexplode-da`
- `pnpm --filter @randomplay/data verify:excel`
- `pnpm --silent fairy:s1 | jq empty`
- `pnpm --silent fairy:s2 | jq empty`
- `pnpm --silent fairy:s3 | jq empty`
- `pnpm changelog`
- `git diff --exit-code -- CHANGELOG.md`
- `pnpm exec git-cliff --latest --strip header --output /tmp/fairy-release-notes-test.md`
- `git diff --check`

## Notes
- `softprops/action-gh-release@v3.0.0` was verified from upstream action metadata: it uses Node 24 and keeps the `name`, `body_path`, and `make_latest` inputs used by this workflow.
