### PR TITLE
test: add G18 part-break golden anchor

### DIFF
--- a/data/cleaned/golden/v1-replay-report.json
+++ b/data/cleaned/golden/v1-replay-report.json
@@ -3,8 +3,8 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1 true-data replay harness baseline after DD-002: 19 anchors in V1, G13/G18/G19/G20 deferred.",
-    "releaseGate": "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
+    "scope": "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
+    "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
   "v1AnchorIds": [
@@ -24,22 +24,22 @@
     "G15",
     "G16",
     "G17",
+    "G18",
     "G21",
     "G22",
     "G23"
   ],
   "deferredAnchorIds": [
     "G13",
-    "G18",
     "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 19,
-    "passed": 19,
+    "v1AnchorCount": 20,
+    "passed": 20,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 4,
+    "deferred": 3,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -309,6 +309,25 @@
       ]
     },
     {
+      "id": "G18",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "敌人属性!A139:AU139"
+        },
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71"
+        }
+      ],
+      "notes": [
+        "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+      ]
+    },
+    {
       "id": "G21",
       "status": "passed",
       "sourceRefs": [
@@ -372,19 +391,11 @@
       ]
     },
     {
-      "id": "G18",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
-      ]
-    },
-    {
       "id": "G19",
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
+        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
       ]
     },
     {
@@ -392,7 +403,7 @@
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
+        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
       ]
     }
   ]

--- a/docs/data-contract/cleaned-schema-spec.md
+++ b/docs/data-contract/cleaned-schema-spec.md
@@ -35,17 +35,17 @@ V1 focuses on Hollow Zero Assault / Deadly Assault data.
 - Excel `敌人属性` is retained as a source archive and fallback source. It is not
   fully cleaned in V1 unless a V1 calculation/golden case requires a minimal
   subset.
-- V1 golden-data release coverage is narrowed to 19 anchors. Anchors 13, 18,
-  19, and 20 are deferred to V1.x.
+- V1 golden-data release coverage was narrowed to 19 anchors. V1.x Track B has
+  added anchor 18; anchors 13, 19, and 20 remain deferred to V1.x.
 
-Deferred V1.x anchors:
+V1.x anchor status:
 
-| Anchor | Reason |
+| Anchor | Status |
 |---|---|
-| 13 special threshold multipliers | Requires data-driven anomaly-threshold rule composition; V1 core currently supports explicit `thresholdOverride` only. |
-| 18 part-break true damage examples | Requires non-DA enemy/part-break data. |
-| 19 daze recovery example: 凶心疯汉 | Requires non-DA enemy data. |
-| 20 daze recovery example: 装甲哈提 | Requires non-DA enemy data. |
+| 13 special threshold multipliers | Deferred; requires data-driven anomaly-threshold rule composition. |
+| 18 part-break true damage examples | Implemented in executable replay using Excel non-DA enemy data plus guide §1.1 part-break multiplier table. |
+| 19 daze recovery example: 凶心疯汉 | Deferred; requires non-DA enemy recovery data. |
+| 20 daze recovery example: 装甲哈提 | Deferred; requires non-DA enemy recovery data. |
 
 ### 1.2 Source Priority
 
@@ -535,8 +535,9 @@ V1 cleaned-data implementation must add tests for these gates:
 - zh/en i18n key sets are aligned for published data i18n resources;
 - unresolved mapping is machine-readable and fails golden cases when required
   fields are missing;
-- V1 golden true-data replay uses the 19-anchor scope and records anchors 13,
-  18, 19, and 20 as V1.x deferred, not skipped accidentally.
+- Golden true-data replay uses the executable anchor scope and records anchors
+  13, 19, and 20 as V1.x deferred, not skipped accidentally. G18 is now an
+  executable part-break anchor.
 - `verify:golden-v1` passes as an offline freshness gate for the generated V1
   agent source candidates, manual acceptance records, and replay report; V1
   release requires zero `ERR-DAT-005` diagnostics, no `pendingHarness` anchors,
@@ -570,9 +571,9 @@ not UX runtime messages. They must write data i18n resources under
 
 ### 10.3 task #43 True-Data Replay
 
-V1 release gate uses the narrowed 19-anchor golden scope. Anchors 13, 18, 19,
-and 20 remain tracked as V1.x deferred items and must not be interpreted as
-missing QA coverage.
+V1 release gate used the narrowed 19-anchor golden scope. V1.x Track B adds G18
+as an executable part-break anchor. Anchors 13, 19, and 20 remain tracked as
+V1.x deferred items and must not be interpreted as missing QA coverage.
 
 The first replay harness baseline writes:
 
@@ -582,16 +583,16 @@ The first replay harness baseline writes:
 - `data/cleaned/golden/v1-replay-report.json`.
 
 `verify:golden-v1` verifies those artifacts against retained Excel and DA source
-snapshots. The current baseline has 19 V1 anchors passed, zero blocking
+snapshots. The current baseline has 20 executable anchors passed, zero blocking
 diagnostics, and `releaseReady=true`. G04 reproduces the guide breakpoint scan,
 G09 asserts sourced DA daze ratio display flooring, G10 asserts frost/auric
-resistance plus anomaly-buildup-resistance lane mapping, and G22/G23 use
-lo-user manual acceptance records for Nicole/Yanagi active-state and
-polarity-disorder template semantics. The polarity-disorder template requires an
-explicit provider agent in `team` and an explicit supported skill level
-(`skillLevels[skillLevelKey]` in 1-16) plus provider `panel.anomalyProficiency`;
-missing or out-of-range inputs are validation failures, not silent level-1 or
-zero-proficiency fallbacks.
+resistance plus anomaly-buildup-resistance lane mapping, G18 asserts sourced
+part-break true damage, and G22/G23 use lo-user manual acceptance records for
+Nicole/Yanagi active-state and polarity-disorder template semantics. The
+polarity-disorder template requires an explicit provider agent in `team` and an
+explicit supported skill level (`skillLevels[skillLevelKey]` in 1-16) plus
+provider `panel.anomalyProficiency`; missing or out-of-range inputs are
+validation failures, not silent level-1 or zero-proficiency fallbacks.
 
 ## 11. Review Checklist
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,8 +139,9 @@ Feedback routing:
 - V1 is a static `BattleSnapshot` calculator, not a battle timeline simulator.
 - V1 does not yet provide a Web UI or automatic character/equipment resolver.
 - Users provide or edit explicit JSON snapshots.
-- The V1 golden gate is 19 anchors passed with zero blocking diagnostics.
+- The executable golden gate is 20 anchors passed with zero blocking diagnostics.
 - The V1 dogfooding gate is lo-user single-person deep validation plus QA
   regression. It passed 4/5 with zero unresolved B-Calc blockers; broad
   community validation is deferred.
-- G13, G18, G19, and G20 are intentionally deferred to V1.x.
+- G13, G19, and G20 are intentionally deferred to V1.x. G18 has been added as
+  a V1.x executable anchor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 ## V1 release gate 当前重点
 
 1. lo-user 单人 dogfooding 已给出 4/5，B-Calc blocker 当前为 0；V1 仍未经过广泛社区 dogfooding。
-2. V1 golden fixture 真数据复算收窄到 19 个锚点；G13 异常阈值规则组合、G18 部位破坏真实伤害、G19/G20 失衡恢复时间推迟到 V1.x。
-3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；19 个 V1 锚点全部跑通，`releaseReady=true`，G13/G18/G19/G20 仍作为 V1.x deferred 可见。
+2. V1 golden fixture 真数据复算最初收窄到 19 个锚点；V1.x Track B 已补 G18 部位破坏真实伤害，G13 异常阈值规则组合与 G19/G20 失衡恢复时间仍推迟到后续 V1.x。
+3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；20 个 executable 锚点全部跑通，`releaseReady=true`，G13/G19/G20 仍作为 V1.x deferred 可见。
 4. `fairy calc` 默认 `--view brief`，输出 summary-first 的 non-crit / crit lanes；完整 trace 通过 `--view verbose` 查看。
 5. 安比 dogfooding fixture `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` 已进入 `packages/cli/src/examples.test.ts`，因此由根命令 `pnpm test` 固定覆盖。
 6. v0.0.1 已发布；后续 release 流程跟随 canonical v3 runbook（见

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -25,7 +25,7 @@
 | **D-10** | 数据维护责任 | ✅ 锁定（v2.0 修订） | V1 阶段：lo-user 提供 Excel 主源 + 爬虫每版本手动 release；data 包必须做完整角色/音擎/驱动盘/影画/鸣徽/潜能激化数据 | 中 |
 | **D-11** | 命名体系（v2.0 新增） | ✅ 锁定 | 选项 A 全套官方化：公开 schema / core API / data 字段优先使用 ZZZ 官方英文的语义化 camelCase；旧 `breach*` 进 sourceAliases / migration | 中 |
 | **D-12** | buhflipexplode 算法处理 | ✅ 锁定 | 选项 B：Fairy 保持 MIT；buhflipexplode GPL JS 仅 raw 留档/参考，不复制进 runtime；Fairy 独立实现等价算法；每次抓取用 hash + 算法快照文档 + parity 对账监控 drift | 高 |
-| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；通用敌人 / 部位破坏 / 失衡恢复时间在 V1.x；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x defer = G13 / G18 / G19 / G20 | 中 |
+| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors；2026-05-13 G18 V1.x done） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x Track B 已补 G18，remaining defer = G13 / G19 / G20 | 中 |
 | **D-14** | cleaned data typed modifier 双层结构 | ✅ 锁定（2026-05-05） | Layer 1 原文层 `sourceText` / `localizedText` + Layer 2 计算层 `modifiers[]` / `calculationEffects[]` + 风险层 `unparsedEffects[]`；bucket 受控 enum 严格匹配 glossary v0.4 D-11；效果 4 级（L1 静态 / L2 静态条件 / L3 动态参数 / L4 时序需 `requiresActivation`）；确定性 pipeline + sourceTextHash + parserVersion + effectTemplateId + 人工 audit gate；AI 候选不能直接入 cleaned | 中 |
 | **D-15** | V1 package exports 4 入口 | ✅ 锁定（2026-05-05） | V1 全做：`@randomplay/data/cleaned`（总入口）/ `@randomplay/data/cleaned/<domain>` / `@randomplay/data/types` / `@randomplay/data/cleaned/i18n/<domain>`；data 包 game labels 源码 `packages/data/src/i18n/` → 发布 `packages/data/cleaned/i18n/`；UX ERR-* `docs/ux/i18n/` 完全独立 | 中 |
 | **D-16** | Source priority + multi-source + unknown policy | ✅ 锁定（2026-05-05） | Excel base / buhflipexplode DA overlay / 米游社 i18n；冲突 fail loud + manual review；entity-level `sources[]` + 关键数值字段级 `sourceRefs`；unknown 分级 blocking（影响计算）/ non-blocking（纯展示）；新增 ERR-DAT-005（multi-source conflict / 未解析 modifier blocking）+ ERR-DAT-006（locale mapping unresolved / 展示缺失 non-blocking，与 PR #21 cleaned schema spec 锁定一致） | 中 |
@@ -147,6 +147,10 @@
 - **G13 defer 理由**：需要 `anomalyThresholdModifiers[]` schema + core 组合逻辑 + source trace + fixture；当前 core 仅有 `thresholdOverride`，保留 V1 会扩大 #43 + 触动 core；defer 可逆，V1.x 与通用/特殊敌人规则一起做更聚焦
 - **状态**：✅ V1 release-ready milestone 时 PR #28 已实施 19 anchors（commit `3f5e67a`）
 - **影响 doc**：`docs/qa/golden-source-coverage.md`（matrix 标 G13 deferred） / `docs/product/meetings/2026-05-05-cleaned-schema-design.md` §2.7
+
+**2026-05-13 V1.x Track B update**：
+- **G18 implemented**：部位破坏典型真实伤害倍率表已进入 executable replay，使用 Excel `敌人属性` 中格莱特 70 级最大生命值 + 攻略 §1.1 工程机械部位破坏 5% 最大生命值真实伤害规则。
+- **Remaining V1.x deferred**：G13 anomaly-threshold rule composition + G19/G20 失衡恢复时间。
 
 **理由**：
 - 与 lo-user "V1 主要支持危局强袭战 + Excel 后备" 框定一致

--- a/docs/qa/golden-source-coverage.md
+++ b/docs/qa/golden-source-coverage.md
@@ -5,21 +5,24 @@ Owner: @TechLead
 Reviewers: @Product, @QA, @lo-user
 Related tasks: task #40, task #43
 
-This document narrows the original 23 golden anchors to the V1 19-anchor release
-gate locked by D-13 plus DD-002. Anchors G13/G18/G19/G20 are deferred to V1.x:
+This document narrows the original 23 golden anchors to the V1 release gate
+locked by D-13 plus DD-002, then tracks V1.x golden expansion. The executable
+gate currently has 20 anchors: the original 19 V1 anchors plus G18. Anchors
+G13/G19/G20 remain deferred to V1.x:
 G13 requires data-driven anomaly-threshold rule composition that is outside the
-current #43 true-data replay scope, while G18/G19/G20 require non-DA enemy /
-part-break data.
+current #43 true-data replay scope, while G19/G20 require non-DA enemy daze
+recovery data.
 
 The goal of this audit is to decide the minimum source and cleaned-data work
 needed before true-data replay. It does not change QA's fixture assertions.
 
 ## Scope
 
-| Set | Anchor IDs | V1 status |
+| Set | Anchor IDs | Status |
 |---|---|---|
 | V1 release gate | G01-G12, G14-G17, G21-G23 | Must pass before V1 release. |
-| Deferred V1.x | G13, G18-G20 | Not V1 blockers. |
+| V1.x executable expansion | G18 | Passed after non-DA Excel enemy + guide part-break true-damage replay. |
+| Deferred V1.x | G13, G19-G20 | Not current blockers. |
 
 ## Source Status Summary
 
@@ -30,7 +33,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | Mihoyo DA snapshot | PR #24 retained 35 details and zh/en alignment. | Chinese buff/boss/room text and source anchors for later typed-modifier review. |
 | Excel workbook | Raw workbook retained; `workbook-audit.json` records sheet/column shape. | Minimal agent kit data for Yixuan / Nicole / Yanagi team-modifier anchors, if V1 replay uses formal sourced modifiers. |
 
-## 19-Anchor Matrix
+## 20-Anchor Matrix
 
 | ID | V1 source dependency | Current source coverage | Remaining work |
 |---|---|---|---|
@@ -51,6 +54,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | G15 | Seven disorder formulas | Covered by core rules. | Replay fixture only. |
 | G16 | Disorder daze-level zone | Covered by core rules. | Replay fixture only. |
 | G17 | Corrupted-shield cleanse true damage | Core rules covered; DA boss max HP available from buhflipexplode. | Cleaned DA boss slot must expose sourced max HP/effective max HP. |
+| G18 | Part-break true damage multiplier table | Excel provides non-DA Greta max HP; guide §1.1 provides engineering-machine 5% max HP true-damage rule. | Passed with `manualEvents.kind=partBreak`. |
 | G21 | 1-agent Yixuan sheer | Excel has Yixuan agent row; panel values remain user snapshot. | Minimal Excel agent mapping for Yixuan id/attribute/specialty/label/source refs. |
 | G22 | Yixuan + Nicole defense reduction | Excel has Nicole rows/descriptions; lo-user accepted the defense-reduction mapping. | Passed with explicit inactive/active snapshot replay. |
 | G23 | Yixuan + Nicole + Yanagi polarity disorder | Excel has Yanagi rows/descriptions; lo-user accepted the disorder boost and EX Special polarity-disorder template. | Passed with explicit inactive/active replay and skill-level parameterized polarity-disorder template. |
@@ -144,30 +148,32 @@ cleaned artifacts:
 - `data/cleaned/audit/nicole.acceptance.json` and
   `data/cleaned/audit/yanagi.acceptance.json` — lo-user manual acceptance
   records for G22/G23 source-text mappings.
-- `data/cleaned/golden/v1-replay-report.json` — #43 replay baseline for the
-  DD-002 19-anchor scope.
+- `data/cleaned/golden/v1-replay-report.json` — executable replay baseline for
+  the 20-anchor scope after G18.
 
 The current replay report intentionally reports:
 
 | Status | Anchors | Meaning |
 |---|---|---|
-| `passed` | 19 anchors | All V1 anchors pass executable replay with sourced Excel/DA refs and lo-user accepted G22/G23 mappings. |
+| `passed` | 20 anchors | All executable anchors pass replay with sourced Excel/DA/guide refs and lo-user accepted G22/G23 mappings. |
 | `pendingHarness` | none | No V1 anchors are pending harness. |
 | `blocked` | none | G22/G23 `ERR-DAT-005` diagnostics are cleared by acceptance records. |
-| `deferred` | G13, G18-G20 | Explicit V1.x scope. |
+| `deferred` | G13, G19-G20 | Explicit remaining V1.x scope. |
 
 `pnpm --filter @randomplay/data verify:golden-v1` is an offline freshness and shape
 gate. It verifies the artifacts are regenerated from the retained sources and
-that V1 replay has `passed=19`, `pendingHarness=0`, `blocked=0`,
+that executable replay has `passed=20`, `pendingHarness=0`, `blocked=0`,
 `blockingDiagnostics=0`, and `releaseReady=true`.
 
 ## Product / Human Decisions
 
 TL recommendation:
 
-- **G13**: deferred by @lo-user on 2026-05-05. Track with G18/G19/G20 as V1.x
+- **G13**: deferred by @lo-user on 2026-05-05. Track with G19/G20 as V1.x
   golden expansion work. Do not use `thresholdOverride` to claim the anchor in
   V1, because that would bypass sourced rule composition and source trace.
+- **G18**: implemented during V1.x Track B using Excel `敌人属性` Greta max HP
+  plus the guide §1.1 part-break true-damage multiplier table.
 - **Nicole/Yanagi**: @lo-user accepted the G22/G23 mapping semantics on
   2026-05-05. A/B effects are explicit inactive/active snapshot states; C is a
   skill-level-parameterized EX Special polarity-disorder template. C must fail
@@ -176,5 +182,6 @@ TL recommendation:
   changes, the replay harness must fail instead of silently applying a guessed
   modifier.
 
-#43 now has a release-ready replay baseline for the 19 V1 anchors. G13 remains
-listed as an explicit V1.x gap rather than disappearing from QA visibility.
+#43 now has a release-ready replay baseline for the original 19 V1 anchors, and
+V1.x Track B has added G18 as an executable anchor. G13/G19/G20 remain listed as
+explicit V1.x gaps rather than disappearing from QA visibility.

--- a/packages/data/cleaned/golden/v1-replay-report.json
+++ b/packages/data/cleaned/golden/v1-replay-report.json
@@ -3,8 +3,8 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1 true-data replay harness baseline after DD-002: 19 anchors in V1, G13/G18/G19/G20 deferred.",
-    "releaseGate": "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
+    "scope": "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
+    "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
   "v1AnchorIds": [
@@ -24,22 +24,22 @@
     "G15",
     "G16",
     "G17",
+    "G18",
     "G21",
     "G22",
     "G23"
   ],
   "deferredAnchorIds": [
     "G13",
-    "G18",
     "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 19,
-    "passed": 19,
+    "v1AnchorCount": 20,
+    "passed": 20,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 4,
+    "deferred": 3,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -309,6 +309,25 @@
       ]
     },
     {
+      "id": "G18",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "敌人属性!A139:AU139"
+        },
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71"
+        }
+      ],
+      "notes": [
+        "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+      ]
+    },
+    {
       "id": "G21",
       "status": "passed",
       "sourceRefs": [
@@ -372,19 +391,11 @@
       ]
     },
     {
-      "id": "G18",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
-      ]
-    },
-    {
       "id": "G19",
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
+        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
       ]
     },
     {
@@ -392,7 +403,7 @@
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion."
+        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
       ]
     }
   ]

--- a/packages/data/scripts/golden-v1-replay.ts
+++ b/packages/data/scripts/golden-v1-replay.ts
@@ -55,12 +55,13 @@ const v1AnchorIds = [
   "G15",
   "G16",
   "G17",
+  "G18",
   "G21",
   "G22",
   "G23",
 ] as const
 
-const deferredAnchorIds = ["G13", "G18", "G19", "G20"] as const
+const deferredAnchorIds = ["G13", "G19", "G20"] as const
 
 const agentSpecs = {
   nicole: { excelId: 1031, zh: "妮可", en: "Nicole" },
@@ -694,6 +695,41 @@ function loadBuhflipexplodeBoss() {
   }
 }
 
+function loadExcelEnemy(name: string, indexId: number) {
+  const { workbook } = loadWorkbook()
+  const rows = rowsForSheet(workbook, "敌人属性")
+  const headers = headerMap(rows[0] ?? [])
+  const rowIndex = rows.findIndex(row =>
+    String(rowValue(row, headers, "完整名称") ?? "") === name
+    && Number(rowValue(row, headers, "IndexID")) === indexId,
+  )
+  if (rowIndex < 0)
+    throw new Error(`Missing enemy row for ${name} (${indexId})`)
+
+  const row = rows[rowIndex]!
+  const rowNumber = rowIndex + 1
+  const tags = String(rowValue(row, headers, "标签列表") ?? "")
+  const rank = tags.includes("首领")
+    ? "boss"
+    : tags.includes("中体型")
+      ? "elite"
+      : "normal"
+
+  return {
+    enemyId: `excel:${indexId}`,
+    sourceRefs: [sourceRef(`敌人属性!A${rowNumber}:AU${rowNumber}`)],
+    snapshot: {
+      enemyId: `excel:${indexId}`,
+      level: 70,
+      rank,
+      maxHp: numberValue(rowValue(row, headers, "70级最大生命值"), `${name}.70级最大生命值`),
+      baseDaze: numberValue(rowValue(row, headers, "70级最大失衡值上限"), `${name}.70级最大失衡值上限`),
+      dazeCap: numberValue(rowValue(row, headers, "70级最大失衡值上限"), `${name}.70级最大失衡值上限`),
+      defense: numberValue(rowValue(row, headers, "60级及以上防御力"), `${name}.60级及以上防御力`),
+    },
+  }
+}
+
 function agentSnapshot(
   candidates: ReturnType<typeof buildCandidates>,
   agentId: "yixuan" | "nicole" | "yanagi",
@@ -1318,6 +1354,35 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
   }
 
   {
+    const greta = loadExcelEnemy("格莱特", 11301)
+    const guideRef = guideSourceRef("docs/reference/zzz-data-introduction.txt:62-71")
+    const result = calculate({
+      ...snapshot,
+      enemy: greta.snapshot,
+      manualEvents: [
+        {
+          id: "greta-leg-part-break",
+          kind: "partBreak",
+          partId: "leg",
+          partType: "engineering-machine-leg",
+          basePath: "enemy.maxHp",
+          multiplier: 0.05,
+          trueDamageRule: "engineering-machine-part-break-5-percent-max-hp",
+          source: guideRef,
+        },
+      ],
+    })
+    const event = result.events?.find(candidate => candidate.id === "greta-leg-part-break")
+    assertClose(event?.baseValue, greta.snapshot.maxHp, 0.00001, "G18 part-break base HP")
+    assertClose(event?.multiplier, 0.05, 0.00001, "G18 part-break multiplier")
+    assertClose(event?.rawDamage, greta.snapshot.maxHp * 0.05, 0.00001, "G18 part-break true damage")
+    assertClose(result.summary.trueDamage, greta.snapshot.maxHp * 0.05, 0.00001, "G18 summary true damage")
+    anchors.push(passedAnchor("G18", [...greta.sourceRefs, guideRef], [
+      "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier.",
+    ]))
+  }
+
+  {
     const result = calculate({
       ...snapshot,
       attackSegments: [
@@ -1491,7 +1556,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
       notes: [
         anchorId === "G13"
           ? "Deferred to V1.x by @lo-user on 2026-05-05; requires data-driven anomaly-threshold rule composition."
-          : "Deferred to V1.x by D-13; requires non-DA enemy / part-break data expansion.",
+          : "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion.",
       ],
     })
   }
@@ -1514,9 +1579,9 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     generatedAt,
     policy: {
       scope:
-        "V1 true-data replay harness baseline after DD-002: 19 anchors in V1, G13/G18/G19/G20 deferred.",
+        "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
       releaseGate:
-        "releaseReady becomes true only when all V1 anchors pass executable replay and blockingDiagnostics is zero.",
+        "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
       manualAcceptance:
         "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized.",
     },
@@ -1569,8 +1634,8 @@ function verifyCommand(): void {
 
   const report = readJson<{ generatedAt: string; summary: { v1AnchorCount: number; blocked: number; pendingHarness: number; blockingDiagnostics: number; releaseReady: boolean } }>(replayReportPath)
   assertArtifactsFresh(report.generatedAt)
-  if (report.summary.v1AnchorCount !== 19)
-    throw new Error(`Expected 19 V1 anchors, got ${report.summary.v1AnchorCount}`)
+  if (report.summary.v1AnchorCount !== 20)
+    throw new Error(`Expected 20 executable anchors, got ${report.summary.v1AnchorCount}`)
   if (report.summary.blocked !== 0)
     throw new Error(`Expected no blocked anchors after G22/G23 manual acceptance, got ${report.summary.blocked}`)
   if (report.summary.pendingHarness !== 0)
@@ -1578,7 +1643,7 @@ function verifyCommand(): void {
   if (report.summary.blockingDiagnostics !== 0)
     throw new Error(`Expected no blocking diagnostics after G22/G23 manual acceptance, got ${report.summary.blockingDiagnostics}`)
   if (report.summary.releaseReady !== true)
-    throw new Error("Expected V1 golden replay releaseReady=true after all 19 anchors pass")
+    throw new Error("Expected golden replay releaseReady=true after all 20 executable anchors pass")
 }
 
 async function main(): Promise<void> {

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -29,7 +29,7 @@ describe("V1 golden true-data replay baseline", () => {
     )
   })
 
-  it("tracks the 19-anchor V1 gate and deferred anchors explicitly", () => {
+  it("tracks the 20-anchor executable gate and deferred anchors explicitly", () => {
     const report = readJson<{
       v1AnchorIds: string[]
       deferredAnchorIds: string[]
@@ -49,7 +49,7 @@ describe("V1 golden true-data replay baseline", () => {
       }>
     }>(replayReportPath)
 
-    expect(report.v1AnchorIds).toHaveLength(19)
+    expect(report.v1AnchorIds).toHaveLength(20)
     expect(report.v1AnchorIds).toEqual([
       "G01",
       "G02",
@@ -67,14 +67,15 @@ describe("V1 golden true-data replay baseline", () => {
       "G15",
       "G16",
       "G17",
+      "G18",
       "G21",
       "G22",
       "G23",
     ])
-    expect(report.deferredAnchorIds).toEqual(["G13", "G18", "G19", "G20"])
+    expect(report.deferredAnchorIds).toEqual(["G13", "G19", "G20"])
     expect(report.summary).toMatchObject({
-      v1AnchorCount: 19,
-      passed: 19,
+      v1AnchorCount: 20,
+      passed: 20,
       pendingHarness: 0,
       blocked: 0,
       blockingDiagnostics: 0,
@@ -94,6 +95,9 @@ describe("V1 golden true-data replay baseline", () => {
     expect(g10?.notes.join("\n")).toContain("both resistanceZone and anomaly-buildup-resistance")
     const g11 = report.anchors.find(anchor => anchor.id === "G11")
     expect(g11?.status).toBe("passed")
+    const g18 = report.anchors.find(anchor => anchor.id === "G18")
+    expect(g18?.status).toBe("passed")
+    expect(g18?.notes.join("\n")).toContain("Greta level-70 max HP")
     const g22 = report.anchors.find(anchor => anchor.id === "G22")
     expect(g22?.status).toBe("passed")
     expect(g22?.notes.join("\n")).toContain("inactive/active snapshot states")


### PR DESCRIPTION
## Summary

- moves G18 from the deferred set into the executable golden replay gate
- sources the G18 enemy max HP from Excel `敌人属性!A139:AU139` (格莱特 / Greta)
- replays guide §1.1 engineering-machine part-break true damage as a `manualEvents.kind=partBreak` event at 5% enemy max HP
- updates generated replay artifacts and current docs to show 20 executable anchors, with G13/G19/G20 remaining deferred

## Verification

- `pnpm --filter @randomplay/data audit:golden-v1`
- `pnpm --filter @randomplay/data sync-cleaned`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:excel`
- `pnpm --filter @randomplay/data verify:buhflipexplode-da`
- `pnpm --filter @randomplay/data verify:mihoyo-da`
- `pnpm build`
- `git diff --check`
