### PR TITLE
feat: add G13 anomaly threshold composition

### DIFF
--- a/data/cleaned/golden/v1-replay-report.json
+++ b/data/cleaned/golden/v1-replay-report.json
@@ -3,7 +3,7 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
+    "scope": "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
     "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
@@ -20,6 +20,7 @@
     "G10",
     "G11",
     "G12",
+    "G13",
     "G14",
     "G15",
     "G16",
@@ -30,16 +31,15 @@
     "G23"
   ],
   "deferredAnchorIds": [
-    "G13",
     "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 20,
-    "passed": 20,
+    "v1AnchorCount": 21,
+    "passed": 21,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 3,
+    "deferred": 2,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -243,6 +243,21 @@
       ]
     },
     {
+      "id": "G13",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250"
+        }
+      ],
+      "notes": [
+        "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+        "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+      ]
+    },
+    {
       "id": "G14",
       "status": "passed",
       "sourceRefs": [
@@ -380,14 +395,6 @@
         "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
         "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
         "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
-      ]
-    },
-    {
-      "id": "G13",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by @lo-user on 2026-05-05; requires data-driven anomaly-threshold rule composition."
       ]
     },
     {

--- a/docs/data-contract/battle-snapshot.md
+++ b/docs/data-contract/battle-snapshot.md
@@ -234,9 +234,16 @@ interface AnomalyContributionInput {
   triggerCountBefore?: number
   buildup?: number
   thresholdOverride?: number
+  anomalyThresholdModifiers?: AnomalyThresholdModifier[]
   overflowBuildup?: number
   remainingDurationSeconds?: number
   contributors?: AnomalyContributionActorInput[]
+}
+
+interface AnomalyThresholdModifier {
+  id: string
+  multiplier: number
+  source?: SourceRef
 }
 
 interface AnomalyContributionActorInput {
@@ -260,6 +267,10 @@ assert virtual-agent behavior.
 `"disorder"`; core must not infer a default status. `remainingDurationSeconds`
 records the remaining duration `T` used by disorder formula traces. If omitted,
 core may fall back to the current default duration for that anomaly status.
+`anomalyThresholdModifiers[]` records sourced multiplicative threshold rules
+such as special-enemy base-threshold increases and Deadly Assault mode
+modifiers. `thresholdOverride` remains an explicit escape hatch and should not
+be used to satisfy golden anchors that require rule composition evidence.
 
 ## 7. Enemy Snapshot
 

--- a/docs/data-contract/cleaned-schema-spec.md
+++ b/docs/data-contract/cleaned-schema-spec.md
@@ -36,13 +36,13 @@ V1 focuses on Hollow Zero Assault / Deadly Assault data.
   fully cleaned in V1 unless a V1 calculation/golden case requires a minimal
   subset.
 - V1 golden-data release coverage was narrowed to 19 anchors. V1.x Track B has
-  added anchor 18; anchors 13, 19, and 20 remain deferred to V1.x.
+  added anchors 13 and 18; anchors 19 and 20 remain deferred to V1.x.
 
 V1.x anchor status:
 
 | Anchor | Status |
 |---|---|
-| 13 special threshold multipliers | Deferred; requires data-driven anomaly-threshold rule composition. |
+| 13 special threshold multipliers | Implemented in executable replay using sourced `anomalyThresholdModifiers[]` composition. |
 | 18 part-break true damage examples | Implemented in executable replay using Excel non-DA enemy data plus guide §1.1 part-break multiplier table. |
 | 19 daze recovery example: 凶心疯汉 | Deferred; requires non-DA enemy recovery data. |
 | 20 daze recovery example: 装甲哈提 | Deferred; requires non-DA enemy recovery data. |
@@ -536,8 +536,8 @@ V1 cleaned-data implementation must add tests for these gates:
 - unresolved mapping is machine-readable and fails golden cases when required
   fields are missing;
 - Golden true-data replay uses the executable anchor scope and records anchors
-  13, 19, and 20 as V1.x deferred, not skipped accidentally. G18 is now an
-  executable part-break anchor.
+  19 and 20 as V1.x deferred, not skipped accidentally. G13 and G18 are now
+  executable anchors.
 - `verify:golden-v1` passes as an offline freshness gate for the generated V1
   agent source candidates, manual acceptance records, and replay report; V1
   release requires zero `ERR-DAT-005` diagnostics, no `pendingHarness` anchors,
@@ -571,8 +571,8 @@ not UX runtime messages. They must write data i18n resources under
 
 ### 10.3 task #43 True-Data Replay
 
-V1 release gate used the narrowed 19-anchor golden scope. V1.x Track B adds G18
-as an executable part-break anchor. Anchors 13, 19, and 20 remain tracked as
+V1 release gate used the narrowed 19-anchor golden scope. V1.x Track B adds G13
+and G18 as executable anchors. Anchors 19 and 20 remain tracked as
 V1.x deferred items and must not be interpreted as missing QA coverage.
 
 The first replay harness baseline writes:
@@ -583,10 +583,11 @@ The first replay harness baseline writes:
 - `data/cleaned/golden/v1-replay-report.json`.
 
 `verify:golden-v1` verifies those artifacts against retained Excel and DA source
-snapshots. The current baseline has 20 executable anchors passed, zero blocking
+snapshots. The current baseline has 21 executable anchors passed, zero blocking
 diagnostics, and `releaseReady=true`. G04 reproduces the guide breakpoint scan,
 G09 asserts sourced DA daze ratio display flooring, G10 asserts frost/auric
-resistance plus anomaly-buildup-resistance lane mapping, G18 asserts sourced
+resistance plus anomaly-buildup-resistance lane mapping, G13 asserts sourced
+anomaly-threshold rule composition, G18 asserts sourced
 part-break true damage, and G22/G23 use lo-user manual acceptance records for
 Nicole/Yanagi active-state and polarity-disorder template semantics. The
 polarity-disorder template requires an explicit provider agent in `team` and an

--- a/docs/data-source/README.md
+++ b/docs/data-source/README.md
@@ -56,6 +56,7 @@ S5 segment 2 should continue with:
 - buhflipexplode transforms from the retained live-only snapshot into cleaned
   Deadly Assault data and parity fixtures.
 - Raw record schemas and transforms into `GameData`.
-- Golden-anchor source coverage for the V1 20-anchor fixture scope.
+- Golden-anchor source coverage for the current 21-anchor executable fixture
+  scope.
 - Negative validation that formal modifiers and formal rows cannot miss source
   metadata.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,9 +139,9 @@ Feedback routing:
 - V1 is a static `BattleSnapshot` calculator, not a battle timeline simulator.
 - V1 does not yet provide a Web UI or automatic character/equipment resolver.
 - Users provide or edit explicit JSON snapshots.
-- The executable golden gate is 20 anchors passed with zero blocking diagnostics.
+- The executable golden gate is 21 anchors passed with zero blocking diagnostics.
 - The V1 dogfooding gate is lo-user single-person deep validation plus QA
   regression. It passed 4/5 with zero unresolved B-Calc blockers; broad
   community validation is deferred.
-- G13, G19, and G20 are intentionally deferred to V1.x. G18 has been added as
-  a V1.x executable anchor.
+- G19 and G20 are intentionally deferred to V1.x. G13 and G18 have been added
+  as V1.x executable anchors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 ## V1 release gate 当前重点
 
 1. lo-user 单人 dogfooding 已给出 4/5，B-Calc blocker 当前为 0；V1 仍未经过广泛社区 dogfooding。
-2. V1 golden fixture 真数据复算最初收窄到 19 个锚点；V1.x Track B 已补 G18 部位破坏真实伤害，G13 异常阈值规则组合与 G19/G20 失衡恢复时间仍推迟到后续 V1.x。
-3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；20 个 executable 锚点全部跑通，`releaseReady=true`，G13/G19/G20 仍作为 V1.x deferred 可见。
+2. V1 golden fixture 真数据复算最初收窄到 19 个锚点；V1.x Track B 已补 G18 部位破坏真实伤害与 G13 异常阈值规则组合，G19/G20 失衡恢复时间仍推迟到后续 V1.x。
+3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；21 个 executable 锚点全部跑通，`releaseReady=true`，G19/G20 仍作为 V1.x deferred 可见。
 4. `fairy calc` 默认 `--view brief`，输出 summary-first 的 non-crit / crit lanes；完整 trace 通过 `--view verbose` 查看。
 5. 安比 dogfooding fixture `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` 已进入 `packages/cli/src/examples.test.ts`，因此由根命令 `pnpm test` 固定覆盖。
 6. v0.0.1 已发布；后续 release 流程跟随 canonical v3 runbook（见

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -25,7 +25,7 @@
 | **D-10** | 数据维护责任 | ✅ 锁定（v2.0 修订） | V1 阶段：lo-user 提供 Excel 主源 + 爬虫每版本手动 release；data 包必须做完整角色/音擎/驱动盘/影画/鸣徽/潜能激化数据 | 中 |
 | **D-11** | 命名体系（v2.0 新增） | ✅ 锁定 | 选项 A 全套官方化：公开 schema / core API / data 字段优先使用 ZZZ 官方英文的语义化 camelCase；旧 `breach*` 进 sourceAliases / migration | 中 |
 | **D-12** | buhflipexplode 算法处理 | ✅ 锁定 | 选项 B：Fairy 保持 MIT；buhflipexplode GPL JS 仅 raw 留档/参考，不复制进 runtime；Fairy 独立实现等价算法；每次抓取用 hash + 算法快照文档 + parity 对账监控 drift | 高 |
-| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors；2026-05-13 G18 V1.x done） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x Track B 已补 G18，remaining defer = G13 / G19 / G20 | 中 |
+| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors；2026-05-13 G13/G18 V1.x done） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x Track B 已补 G13/G18，remaining defer = G19 / G20 | 中 |
 | **D-14** | cleaned data typed modifier 双层结构 | ✅ 锁定（2026-05-05） | Layer 1 原文层 `sourceText` / `localizedText` + Layer 2 计算层 `modifiers[]` / `calculationEffects[]` + 风险层 `unparsedEffects[]`；bucket 受控 enum 严格匹配 glossary v0.4 D-11；效果 4 级（L1 静态 / L2 静态条件 / L3 动态参数 / L4 时序需 `requiresActivation`）；确定性 pipeline + sourceTextHash + parserVersion + effectTemplateId + 人工 audit gate；AI 候选不能直接入 cleaned | 中 |
 | **D-15** | V1 package exports 4 入口 | ✅ 锁定（2026-05-05） | V1 全做：`@randomplay/data/cleaned`（总入口）/ `@randomplay/data/cleaned/<domain>` / `@randomplay/data/types` / `@randomplay/data/cleaned/i18n/<domain>`；data 包 game labels 源码 `packages/data/src/i18n/` → 发布 `packages/data/cleaned/i18n/`；UX ERR-* `docs/ux/i18n/` 完全独立 | 中 |
 | **D-16** | Source priority + multi-source + unknown policy | ✅ 锁定（2026-05-05） | Excel base / buhflipexplode DA overlay / 米游社 i18n；冲突 fail loud + manual review；entity-level `sources[]` + 关键数值字段级 `sourceRefs`；unknown 分级 blocking（影响计算）/ non-blocking（纯展示）；新增 ERR-DAT-005（multi-source conflict / 未解析 modifier blocking）+ ERR-DAT-006（locale mapping unresolved / 展示缺失 non-blocking，与 PR #21 cleaned schema spec 锁定一致） | 中 |
@@ -143,14 +143,15 @@
 
 **2026-05-05 17:53 D-13 errata（lo-user 拍板）**：黄金集 20 → **19 anchors**。
 - **V1 19 anchors**：G01-G12 + G14-G17 + G21-G23
-- **V1.x defer**：G13（data-driven anomaly threshold rule composition）+ G18 部位破坏 + G19 凶心疯汉失衡恢复 + G20 装甲哈提失衡恢复
-- **G13 defer 理由**：需要 `anomalyThresholdModifiers[]` schema + core 组合逻辑 + source trace + fixture；当前 core 仅有 `thresholdOverride`，保留 V1 会扩大 #43 + 触动 core；defer 可逆，V1.x 与通用/特殊敌人规则一起做更聚焦
+- **原 V1.x defer**：G13（data-driven anomaly threshold rule composition）+ G18 部位破坏 + G19 凶心疯汉失衡恢复 + G20 装甲哈提失衡恢复
+- **G13 原 defer 理由**：需要 `anomalyThresholdModifiers[]` schema + core 组合逻辑 + source trace + fixture；当时 core 仅有 `thresholdOverride`，保留 V1 会扩大 #43 + 触动 core；defer 可逆，V1.x 与通用/特殊敌人规则一起做更聚焦
 - **状态**：✅ V1 release-ready milestone 时 PR #28 已实施 19 anchors（commit `3f5e67a`）
-- **影响 doc**：`docs/qa/golden-source-coverage.md`（matrix 标 G13 deferred） / `docs/product/meetings/2026-05-05-cleaned-schema-design.md` §2.7
+- **原影响 doc**：`docs/qa/golden-source-coverage.md`（当时 matrix 标 G13 deferred） / `docs/product/meetings/2026-05-05-cleaned-schema-design.md` §2.7；2026-05-13 Track B 已更新当前 docs。
 
 **2026-05-13 V1.x Track B update**：
+- **G13 implemented**：异常阈值特殊规则已进入 executable replay，使用攻略 §3.2.2 的基础阈值表、特殊敌人 1.1x/1.2x 阈值提升、危局强袭战第16期 1.1x 阈值提升，并通过 `anomalyThresholdModifiers[]` 乘算组合复现 3960 / 4752(物理) / 3630 / 4356(物理)。
 - **G18 implemented**：部位破坏典型真实伤害倍率表已进入 executable replay，使用 Excel `敌人属性` 中格莱特 70 级最大生命值 + 攻略 §1.1 工程机械部位破坏 5% 最大生命值真实伤害规则。
-- **Remaining V1.x deferred**：G13 anomaly-threshold rule composition + G19/G20 失衡恢复时间。
+- **Remaining V1.x deferred**：G19/G20 失衡恢复时间。
 
 **理由**：
 - 与 lo-user "V1 主要支持危局强袭战 + Excel 后备" 框定一致

--- a/docs/product/dogfooding-report-v1.md
+++ b/docs/product/dogfooding-report-v1.md
@@ -89,7 +89,7 @@ dogfooding 通过 release gate（≥4/5）。
 ## 4. 已知限制（V1 release notes 待标注）
 
 - **DD-003 单人 dogfooding 限制**：V1 仅由 lo-user 单人深度 dogfood 验证 + QA 回归，**未经社区广泛验证**
-- **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 推迟到 V1.x（涉及 data-driven anomaly threshold rule composition / 部位破坏真实伤害 / 失衡恢复时间等扩展功能）
+- **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 原推迟到 V1.x；截至 2026-05-13，G13 / G18 已进入 executable replay，G19 / G20 仍待补（失衡恢复时间扩展功能）
 - **米游社 sourceConflict 3 个**（21 澄意 / 8 灼冽 / 1 破招）：~~non-blocking historical 记录，cleaned typed modifier 发布前需人工 audit gate 触发时再决~~ → ✅ 2026-05-08 已 audit 决议（accept buhflipexplode；F-05 / PR #33），不再属于 known limitation，转记为已解决项
 - **dogfooding 边界探测 Day 3 跳过**：lo-user 决策跳过 Day 3（`--lang en` 验证 / 故意造错 ERR-* 验证），release 后视真实使用反馈再决定是否回补；属 known limitation，不阻塞 release
 
@@ -105,7 +105,7 @@ dogfooding 通过 release gate（≥4/5）。
 | B-Calc.non-blocker：已重新分类 | ✅ F-02 归 U-Scenario，已 absorbed by D-19 |
 | U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解 | ✅ F-01 / F-02 / F-03 / F-06 已修；Day 3 跳过记 known limitation |
 | D-Data：audit gate 决议落地 | ✅ F-05 已决议（accept buhflipexplode），audit 文件入仓 |
-| P-Range：全部入 V1.x backlog | ✅ G13/G18/G19/G20 已 V1.x（D-13）；其他无新增 |
+| P-Range：全部入 V1.x backlog | ✅ G13/G18 已完成；G19/G20 仍为 V1.x backlog（D-13）；其他无新增 |
 | lo-user 整体打分 ≥ 4/5 | ✅ 4/5 |
 
 **通过 release gate**。

--- a/docs/qa/golden-source-coverage.md
+++ b/docs/qa/golden-source-coverage.md
@@ -7,10 +7,8 @@ Related tasks: task #40, task #43
 
 This document narrows the original 23 golden anchors to the V1 release gate
 locked by D-13 plus DD-002, then tracks V1.x golden expansion. The executable
-gate currently has 20 anchors: the original 19 V1 anchors plus G18. Anchors
-G13/G19/G20 remain deferred to V1.x:
-G13 requires data-driven anomaly-threshold rule composition that is outside the
-current #43 true-data replay scope, while G19/G20 require non-DA enemy daze
+gate currently has 21 anchors: the original 19 V1 anchors plus G13 and G18.
+Anchors G19/G20 remain deferred to V1.x because they require non-DA enemy daze
 recovery data.
 
 The goal of this audit is to decide the minimum source and cleaned-data work
@@ -21,8 +19,8 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | Set | Anchor IDs | Status |
 |---|---|---|
 | V1 release gate | G01-G12, G14-G17, G21-G23 | Must pass before V1 release. |
-| V1.x executable expansion | G18 | Passed after non-DA Excel enemy + guide part-break true-damage replay. |
-| Deferred V1.x | G13, G19-G20 | Not current blockers. |
+| V1.x executable expansion | G13, G18 | Passed after guide anomaly-threshold composition and non-DA Excel enemy + guide part-break true-damage replay. |
+| Deferred V1.x | G19-G20 | Not current blockers. |
 
 ## Source Status Summary
 
@@ -33,7 +31,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | Mihoyo DA snapshot | PR #24 retained 35 details and zh/en alignment. | Chinese buff/boss/room text and source anchors for later typed-modifier review. |
 | Excel workbook | Raw workbook retained; `workbook-audit.json` records sheet/column shape. | Minimal agent kit data for Yixuan / Nicole / Yanagi team-modifier anchors, if V1 replay uses formal sourced modifiers. |
 
-## 20-Anchor Matrix
+## 21-Anchor Matrix
 
 | ID | V1 source dependency | Current source coverage | Remaining work |
 |---|---|---|---|
@@ -49,7 +47,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | G10 | Attribute alias mapping (frost/auric -> ice/ether) | Covered by glossary/naming policy/core mapping; replay verifies resistance and anomaly-buildup-resistance lanes. | Passed. |
 | G11 | Attribute damage-bonus alias mapping | Covered by glossary/naming policy/core mapping. | Replay fixture only. |
 | G12 | Core anomaly threshold table | Covered by core rules. | Replay fixture only. |
-| G13 | Special enemy + Deadly Assault anomaly-threshold modifiers | Deferred to V1.x by @lo-user on 2026-05-05. Reference guide / Product v2.0 documents the rule; core currently supports only explicit `thresholdOverride`, not data-driven threshold-rule composition. | V1.x should implement sourced threshold-rule support and replay this anchor. |
+| G13 | Special enemy + Deadly Assault anomaly-threshold modifiers | Guide §3.2.2 documents the base-threshold table, 1.1x/1.2x special enemy modifiers, DA #16 1.1x modifier, and final values. | Passed with sourced `anomalyThresholdModifiers[]` composition; `thresholdOverride` is not used. |
 | G14 | Virtual agent anomaly contribution | Covered by core rules and snapshot input. | Replay fixture only; no formal game row required. |
 | G15 | Seven disorder formulas | Covered by core rules. | Replay fixture only. |
 | G16 | Disorder daze-level zone | Covered by core rules. | Replay fixture only. |
@@ -149,29 +147,30 @@ cleaned artifacts:
   `data/cleaned/audit/yanagi.acceptance.json` — lo-user manual acceptance
   records for G22/G23 source-text mappings.
 - `data/cleaned/golden/v1-replay-report.json` — executable replay baseline for
-  the 20-anchor scope after G18.
+  the 21-anchor scope after G13 and G18.
 
 The current replay report intentionally reports:
 
 | Status | Anchors | Meaning |
 |---|---|---|
-| `passed` | 20 anchors | All executable anchors pass replay with sourced Excel/DA/guide refs and lo-user accepted G22/G23 mappings. |
+| `passed` | 21 anchors | All executable anchors pass replay with sourced Excel/DA/guide refs and lo-user accepted G22/G23 mappings. |
 | `pendingHarness` | none | No V1 anchors are pending harness. |
 | `blocked` | none | G22/G23 `ERR-DAT-005` diagnostics are cleared by acceptance records. |
-| `deferred` | G13, G19-G20 | Explicit remaining V1.x scope. |
+| `deferred` | G19-G20 | Explicit remaining V1.x scope. |
 
 `pnpm --filter @randomplay/data verify:golden-v1` is an offline freshness and shape
 gate. It verifies the artifacts are regenerated from the retained sources and
-that executable replay has `passed=20`, `pendingHarness=0`, `blocked=0`,
+that executable replay has `passed=21`, `pendingHarness=0`, `blocked=0`,
 `blockingDiagnostics=0`, and `releaseReady=true`.
 
 ## Product / Human Decisions
 
 TL recommendation:
 
-- **G13**: deferred by @lo-user on 2026-05-05. Track with G19/G20 as V1.x
-  golden expansion work. Do not use `thresholdOverride` to claim the anchor in
-  V1, because that would bypass sourced rule composition and source trace.
+- **G13**: implemented during V1.x Track B with sourced
+  `anomalyThresholdModifiers[]` composition. Do not use `thresholdOverride` to
+  claim this anchor, because that would bypass sourced rule composition and
+  source trace.
 - **G18**: implemented during V1.x Track B using Excel `敌人属性` Greta max HP
   plus the guide §1.1 part-break true-damage multiplier table.
 - **Nicole/Yanagi**: @lo-user accepted the G22/G23 mapping semantics on
@@ -183,5 +182,5 @@ TL recommendation:
   modifier.
 
 #43 now has a release-ready replay baseline for the original 19 V1 anchors, and
-V1.x Track B has added G18 as an executable anchor. G13/G19/G20 remain listed as
+V1.x Track B has added G13/G18 as executable anchors. G19/G20 remain listed as
 explicit V1.x gaps rather than disappearing from QA visibility.

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -314,12 +314,60 @@ describe("calculate", () => {
     )
 
     expect(thresholdTrace?.inputs).toMatchObject({
+      baseThreshold: 3121,
       enemyRank: "boss",
       triggerCount: 2,
       status: "assault",
       physicalMultiplier: 1.2,
+      anomalyThresholdMultiplier: 1,
     })
     expect(thresholdTrace?.rawValue).toBeCloseTo(3745.2, 1)
+  })
+
+  it("composes sourced anomaly threshold modifiers without thresholdOverride", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      attackSegments: [
+        {
+          ...baseSnapshot.attackSegments[0]!,
+          id: "seg-threshold-modifiers",
+          attribute: "physical",
+          damageType: "anomaly",
+          anomalyContribution: {
+            status: "assault",
+            buildup: 100,
+            triggerCountBefore: 0,
+            anomalyThresholdModifiers: [
+              {
+                id: "enemy-base-threshold-up",
+                multiplier: 1.2,
+                source,
+              },
+              {
+                id: "deadly-assault-threshold-up",
+                multiplier: 1.1,
+                source,
+              },
+            ],
+          },
+        },
+      ],
+    })
+    const thresholdTrace = result.trace.find(event =>
+      event.path === "attackSegments[0].anomalyContribution.anomalyThreshold",
+    )
+
+    expect(thresholdTrace?.inputs).toMatchObject({
+      baseThreshold: 3000,
+      physicalMultiplier: 1.2,
+      anomalyThresholdMultiplier: 1.32,
+      anomalyThresholdModifiers: [
+        { id: "enemy-base-threshold-up", multiplier: 1.2 },
+        { id: "deadly-assault-threshold-up", multiplier: 1.1 },
+      ],
+    })
+    expect(thresholdTrace?.formula).toContain("anomalyThresholdMultiplier")
+    expect(thresholdTrace?.rawValue).toBeCloseTo(4752, 5)
   })
 
   it("floors anomaly mastery before emitting anomaly buildup", () => {

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -629,7 +629,7 @@ function getFormulaActor(
       kind: "formula",
       path: `attackSegments[${index}].anomalyContribution.anomalyThreshold`,
       inputs: threshold,
-      formula: "anomalyThreshold = rankTriggerTable[enemy.rank][triggerCount] * physicalMultiplier",
+      formula: "anomalyThreshold = rankTriggerTable[enemy.rank][triggerCount] * physicalMultiplier * anomalyThresholdMultiplier",
       rawValue: threshold.threshold,
       displayValue: "anomalyThreshold",
     }),
@@ -1060,10 +1060,18 @@ function getEffectiveBuildupByContributor(
 
 function getAnomalyThreshold(snapshot: BattleSnapshot, segment: AttackSegment): {
   threshold: number
+  baseThreshold: number
   enemyRank: EnemyRank
   triggerCount: number
   status: AnomalyStatus | undefined
   physicalMultiplier: number
+  anomalyThresholdMultiplier: number
+  anomalyThresholdModifiers: Array<{
+    id: string
+    multiplier: number
+    source?: SourceRef
+  }>
+  thresholdOverride?: number
 } {
   const status = segment.anomalyContribution?.status
   const triggerCount = clampTriggerCount(
@@ -1073,12 +1081,27 @@ function getAnomalyThreshold(snapshot: BattleSnapshot, segment: AttackSegment): 
   const rank = snapshot.enemy.rank === "special" ? "boss" : snapshot.enemy.rank
   const physicalMultiplier = isPhysicalAnomaly(segment) ? 1.2 : 1
   const baseThreshold = anomalyThresholdTable[rank][triggerCount] ?? anomalyThresholdTable[rank][0]!
+  const anomalyThresholdModifiers = segment.anomalyContribution?.anomalyThresholdModifiers ?? []
+  const anomalyThresholdMultiplier = anomalyThresholdModifiers.reduce(
+    (total, modifier) => total * modifier.multiplier,
+    1,
+  )
+  const composedThreshold = baseThreshold * physicalMultiplier * anomalyThresholdMultiplier
+  const thresholdOverride = segment.anomalyContribution?.thresholdOverride
   return {
-    threshold: segment.anomalyContribution?.thresholdOverride ?? baseThreshold * physicalMultiplier,
+    threshold: thresholdOverride ?? composedThreshold,
+    baseThreshold,
     enemyRank: snapshot.enemy.rank,
     triggerCount,
     status,
     physicalMultiplier,
+    anomalyThresholdMultiplier,
+    anomalyThresholdModifiers: anomalyThresholdModifiers.map(modifier => ({
+      id: modifier.id,
+      multiplier: modifier.multiplier,
+      ...(modifier.source === undefined ? {} : { source: modifier.source }),
+    })),
+    ...(thresholdOverride === undefined ? {} : { thresholdOverride }),
   }
 }
 

--- a/packages/core/src/schema/battle-snapshot.ts
+++ b/packages/core/src/schema/battle-snapshot.ts
@@ -115,12 +115,21 @@ export const anomalyContributionActorInputSchema = z
   })
   .strict()
 
+export const anomalyThresholdModifierSchema = z
+  .object({
+    id: z.string().min(1),
+    multiplier: z.number().finite().positive(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
 export const anomalyContributionInputSchema = z
   .object({
     status: anomalyStatusSchema,
     triggerCountBefore: z.number().int().nonnegative().optional(),
     buildup: z.number().finite().optional(),
     thresholdOverride: z.number().finite().optional(),
+    anomalyThresholdModifiers: z.array(anomalyThresholdModifierSchema).optional(),
     overflowBuildup: z.number().finite().optional(),
     remainingDurationSeconds: z.number().finite().nonnegative().optional(),
     contributors: z.array(anomalyContributionActorInputSchema).optional(),
@@ -348,6 +357,7 @@ export const battleSnapshotSchema = z
 export type BattleContext = z.infer<typeof battleContextSchema>
 export type AgentPanelSnapshot = z.infer<typeof agentPanelSnapshotSchema>
 export type AgentSnapshot = z.infer<typeof agentSnapshotSchema>
+export type AnomalyThresholdModifier = z.infer<typeof anomalyThresholdModifierSchema>
 export type AnomalyContributionInput = z.infer<typeof anomalyContributionInputSchema>
 export type AttackSegment = z.infer<typeof attackSegmentSchema>
 export type EnemySnapshot = z.infer<typeof enemySnapshotSchema>

--- a/packages/data/cleaned/golden/v1-replay-report.json
+++ b/packages/data/cleaned/golden/v1-replay-report.json
@@ -3,7 +3,7 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
+    "scope": "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
     "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
@@ -20,6 +20,7 @@
     "G10",
     "G11",
     "G12",
+    "G13",
     "G14",
     "G15",
     "G16",
@@ -30,16 +31,15 @@
     "G23"
   ],
   "deferredAnchorIds": [
-    "G13",
     "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 20,
-    "passed": 20,
+    "v1AnchorCount": 21,
+    "passed": 21,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 3,
+    "deferred": 2,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -243,6 +243,21 @@
       ]
     },
     {
+      "id": "G13",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250"
+        }
+      ],
+      "notes": [
+        "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+        "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+      ]
+    },
+    {
       "id": "G14",
       "status": "passed",
       "sourceRefs": [
@@ -380,14 +395,6 @@
         "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
         "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
         "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
-      ]
-    },
-    {
-      "id": "G13",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by @lo-user on 2026-05-05; requires data-driven anomaly-threshold rule composition."
       ]
     },
     {

--- a/packages/data/scripts/golden-v1-replay.ts
+++ b/packages/data/scripts/golden-v1-replay.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { calculate } from "@randomplay/core"
+import { calculate } from "../../core/src/index"
 import * as XLSX from "xlsx"
 
 const packageDir = fileURLToPath(new URL("..", import.meta.url))
@@ -51,6 +51,7 @@ const v1AnchorIds = [
   "G10",
   "G11",
   "G12",
+  "G13",
   "G14",
   "G15",
   "G16",
@@ -61,7 +62,7 @@ const v1AnchorIds = [
   "G23",
 ] as const
 
-const deferredAnchorIds = ["G13", "G19", "G20"] as const
+const deferredAnchorIds = ["G19", "G20"] as const
 
 const agentSpecs = {
   nicole: { excelId: 1031, zh: "妮可", en: "Nicole" },
@@ -1246,6 +1247,91 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
   }
 
   {
+    const guideRef = guideSourceRef("docs/reference/zzz-data-introduction.txt:247-250")
+    const buildSegment = (
+      enemyThresholdMultiplier: number,
+      attribute: "electric" | "physical",
+      id: string,
+    ) => ({
+      ...snapshot.attackSegments[0]!,
+      id,
+      attribute,
+      damageType: "anomaly" as const,
+      anomalyContribution: {
+        status: attribute === "physical" ? "assault" as const : "shock" as const,
+        buildup: 100,
+        triggerCountBefore: 0,
+        anomalyThresholdModifiers: [
+          {
+            id: "enemy-base-anomaly-threshold-up",
+            multiplier: enemyThresholdMultiplier,
+            source: guideRef,
+          },
+          {
+            id: "deadly-assault-16-anomaly-threshold-up",
+            multiplier: 1.1,
+            source: guideRef,
+          },
+        ],
+      },
+    })
+    const priest = calculate({
+      ...snapshot,
+      enemy: {
+        ...snapshot.enemy,
+        enemyId: "guide:corruption-priest",
+      },
+      attackSegments: [buildSegment(1.2, "electric", "seg-g13-priest")],
+    })
+    const priestPhysical = calculate({
+      ...snapshot,
+      enemy: {
+        ...snapshot.enemy,
+        enemyId: "guide:corruption-priest",
+      },
+      attackSegments: [buildSegment(1.2, "physical", "seg-g13-priest-physical")],
+    })
+    const pompey = calculate({
+      ...snapshot,
+      enemy: {
+        ...snapshot.enemy,
+        enemyId: "guide:notorious-pompey",
+      },
+      attackSegments: [buildSegment(1.1, "electric", "seg-g13-pompey")],
+    })
+    const pompeyPhysical = calculate({
+      ...snapshot,
+      enemy: {
+        ...snapshot.enemy,
+        enemyId: "guide:notorious-pompey",
+      },
+      attackSegments: [buildSegment(1.1, "physical", "seg-g13-pompey-physical")],
+    })
+    const priestTrace = trace(priest, "attackSegments[0].anomalyContribution.anomalyThreshold")
+    const pompeyTrace = trace(pompey, "attackSegments[0].anomalyContribution.anomalyThreshold")
+    assertClose(priestTrace.rawValue as number, 3960, 0.00001, "G13 priest anomaly threshold")
+    assertClose(
+      trace(priestPhysical, "attackSegments[0].anomalyContribution.anomalyThreshold").rawValue as number,
+      4752,
+      0.00001,
+      "G13 priest physical anomaly threshold",
+    )
+    assertClose(pompeyTrace.rawValue as number, 3630, 0.00001, "G13 pompey anomaly threshold")
+    assertClose(
+      trace(pompeyPhysical, "attackSegments[0].anomalyContribution.anomalyThreshold").rawValue as number,
+      4356,
+      0.00001,
+      "G13 pompey physical anomaly threshold",
+    )
+    assertClose((priestTrace.inputs?.anomalyThresholdMultiplier as number | undefined), 1.32, 0.00001, "G13 priest modifier product")
+    assertClose((pompeyTrace.inputs?.anomalyThresholdMultiplier as number | undefined), 1.21, 0.00001, "G13 pompey modifier product")
+    anchors.push(passedAnchor("G13", [guideRef], [
+      "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+      "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical.",
+    ]))
+  }
+
+  {
     const result = calculate({
       ...snapshot,
       team: [
@@ -1554,9 +1640,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
       status: "deferred",
       sourceRefs: [],
       notes: [
-        anchorId === "G13"
-          ? "Deferred to V1.x by @lo-user on 2026-05-05; requires data-driven anomaly-threshold rule composition."
-          : "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion.",
+        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion.",
       ],
     })
   }
@@ -1579,7 +1663,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     generatedAt,
     policy: {
       scope:
-        "V1.x true-data replay harness after G18: 20 anchors pass executable replay, G13/G19/G20 remain deferred.",
+        "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
       releaseGate:
         "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
       manualAcceptance:
@@ -1634,8 +1718,8 @@ function verifyCommand(): void {
 
   const report = readJson<{ generatedAt: string; summary: { v1AnchorCount: number; blocked: number; pendingHarness: number; blockingDiagnostics: number; releaseReady: boolean } }>(replayReportPath)
   assertArtifactsFresh(report.generatedAt)
-  if (report.summary.v1AnchorCount !== 20)
-    throw new Error(`Expected 20 executable anchors, got ${report.summary.v1AnchorCount}`)
+  if (report.summary.v1AnchorCount !== 21)
+    throw new Error(`Expected 21 executable anchors, got ${report.summary.v1AnchorCount}`)
   if (report.summary.blocked !== 0)
     throw new Error(`Expected no blocked anchors after G22/G23 manual acceptance, got ${report.summary.blocked}`)
   if (report.summary.pendingHarness !== 0)
@@ -1643,7 +1727,7 @@ function verifyCommand(): void {
   if (report.summary.blockingDiagnostics !== 0)
     throw new Error(`Expected no blocking diagnostics after G22/G23 manual acceptance, got ${report.summary.blockingDiagnostics}`)
   if (report.summary.releaseReady !== true)
-    throw new Error("Expected golden replay releaseReady=true after all 20 executable anchors pass")
+    throw new Error("Expected golden replay releaseReady=true after all 21 executable anchors pass")
 }
 
 async function main(): Promise<void> {

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -29,7 +29,7 @@ describe("V1 golden true-data replay baseline", () => {
     )
   })
 
-  it("tracks the 20-anchor executable gate and deferred anchors explicitly", () => {
+  it("tracks the 21-anchor executable gate and deferred anchors explicitly", () => {
     const report = readJson<{
       v1AnchorIds: string[]
       deferredAnchorIds: string[]
@@ -49,7 +49,7 @@ describe("V1 golden true-data replay baseline", () => {
       }>
     }>(replayReportPath)
 
-    expect(report.v1AnchorIds).toHaveLength(20)
+    expect(report.v1AnchorIds).toHaveLength(21)
     expect(report.v1AnchorIds).toEqual([
       "G01",
       "G02",
@@ -63,6 +63,7 @@ describe("V1 golden true-data replay baseline", () => {
       "G10",
       "G11",
       "G12",
+      "G13",
       "G14",
       "G15",
       "G16",
@@ -72,10 +73,10 @@ describe("V1 golden true-data replay baseline", () => {
       "G22",
       "G23",
     ])
-    expect(report.deferredAnchorIds).toEqual(["G13", "G19", "G20"])
+    expect(report.deferredAnchorIds).toEqual(["G19", "G20"])
     expect(report.summary).toMatchObject({
-      v1AnchorCount: 20,
-      passed: 20,
+      v1AnchorCount: 21,
+      passed: 21,
       pendingHarness: 0,
       blocked: 0,
       blockingDiagnostics: 0,
@@ -83,7 +84,8 @@ describe("V1 golden true-data replay baseline", () => {
     })
 
     const g13 = report.anchors.find(anchor => anchor.id === "G13")
-    expect(g13?.status).toBe("deferred")
+    expect(g13?.status).toBe("passed")
+    expect(g13?.notes.join("\n")).toContain("3960 and 4752 physical")
     const g04 = report.anchors.find(anchor => anchor.id === "G04")
     expect(g04?.status).toBe("passed")
     expect(g04?.notes.join("\n")).toContain("199.17%, 268.61%, and 161.67%")


### PR DESCRIPTION
## Summary

- Add sourced `anomalyThresholdModifiers[]` to `anomalyContribution` and compose them with the existing rank/trigger threshold and physical 1.2x multiplier.
- Promote G13 from deferred to executable golden replay, covering the guide values `3960`, `4752` physical, `3630`, and `4356` physical without using `thresholdOverride`.
- Regenerate the replay report to `21 passed / 2 deferred` and update current docs for the remaining G19/G20 scope.
- Point the golden replay script at the workspace core source so source-level schema changes are picked up without relying on a stale local `dist` build.

## Verification

- `pnpm --filter @randomplay/data audit:golden-v1`
- `pnpm --filter @randomplay/data sync-cleaned`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/core check`
- `pnpm --filter @randomplay/core test`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @randomplay/data verify:excel`
- `pnpm --filter @randomplay/data verify:buhflipexplode-da`
- `pnpm --filter @randomplay/data verify:mihoyo-da`
- `git diff --check`

## Review focus

- Confirm `thresholdOverride` is not used for G13.
- Confirm trace inputs expose `baseThreshold`, `physicalMultiplier`, `anomalyThresholdMultiplier`, and sourced modifier rows.
- Confirm current docs consistently say G13/G18 are executable and only G19/G20 remain deferred.
