### PR TITLE
feat: add G19 daze recovery anchor

### DIFF
--- a/data/cleaned/golden/v1-replay-report.json
+++ b/data/cleaned/golden/v1-replay-report.json
@@ -3,7 +3,7 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
+    "scope": "V1.x true-data replay harness after G19: 22 anchors pass executable replay, G20 remains deferred.",
     "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
@@ -26,20 +26,20 @@
     "G16",
     "G17",
     "G18",
+    "G19",
     "G21",
     "G22",
     "G23"
   ],
   "deferredAnchorIds": [
-    "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 21,
-    "passed": 21,
+    "v1AnchorCount": 22,
+    "passed": 22,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 2,
+    "deferred": 1,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -343,6 +343,25 @@
       ]
     },
     {
+      "id": "G19",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "敌人属性!A216:AU216"
+        },
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202"
+        }
+      ],
+      "notes": [
+        "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+      ]
+    },
+    {
       "id": "G21",
       "status": "passed",
       "sourceRefs": [
@@ -398,19 +417,11 @@
       ]
     },
     {
-      "id": "G19",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
-      ]
-    },
-    {
       "id": "G20",
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
+        "Deferred to V1.x by D-13; requires remaining non-DA enemy daze-recovery data expansion."
       ]
     }
   ]

--- a/docs/data-contract/battle-snapshot.md
+++ b/docs/data-contract/battle-snapshot.md
@@ -285,6 +285,8 @@ interface EnemySnapshot {
   dazeCap?: number
   resistance?: Partial<Record<ResistanceAttribute, number>>
   dazeResistance?: number
+  dazeRecoveryRate?: number
+  dazeRecoveryModifiers?: DazeRecoveryModifier[]
   anomalyBuildupResistance?: Partial<Record<ResistanceAttribute, number>>
   anomalyTriggerCounts?: Partial<Record<AnomalyStatus, number>>
   states?: EnemyState[]
@@ -292,10 +294,23 @@ interface EnemySnapshot {
   fieldProvenance?: FieldProvenanceMap
   overrides?: FieldOverride[]
 }
+
+interface DazeRecoveryModifier {
+  id: string
+  value: number
+  source?: SourceRef
+}
 ```
 
 `frost` damage maps to ice resistance and ice damage bonus. `auricInk` maps to
 ether resistance and ether damage bonus. Attribute mapping must be traceable.
+`dazeRecoveryRate` records the enemy's base recovery speed as a per-second
+ratio. `dazeRecoveryModifiers[]` records sourced additive rate modifiers such
+as guide §2.3.2's +60% / -9% effects; core traces
+`enemy.dazeRecoveryTime = 1 / effectiveDazeRecoveryRate`.
+If `dazeRecoveryModifiers[]` is non-empty, `dazeRecoveryRate` is required and
+the composed `1 + sum(dazeRecoveryModifiers[].value)` multiplier must stay
+positive.
 
 ## 8. Typed Modifiers
 

--- a/docs/data-contract/cleaned-schema-spec.md
+++ b/docs/data-contract/cleaned-schema-spec.md
@@ -36,7 +36,7 @@ V1 focuses on Hollow Zero Assault / Deadly Assault data.
   fully cleaned in V1 unless a V1 calculation/golden case requires a minimal
   subset.
 - V1 golden-data release coverage was narrowed to 19 anchors. V1.x Track B has
-  added anchors 13 and 18; anchors 19 and 20 remain deferred to V1.x.
+  added anchors 13, 18, and 19; anchor 20 remains deferred to V1.x.
 
 V1.x anchor status:
 
@@ -44,7 +44,7 @@ V1.x anchor status:
 |---|---|
 | 13 special threshold multipliers | Implemented in executable replay using sourced `anomalyThresholdModifiers[]` composition. |
 | 18 part-break true damage examples | Implemented in executable replay using Excel non-DA enemy data plus guide §1.1 part-break multiplier table. |
-| 19 daze recovery example: 凶心疯汉 | Deferred; requires non-DA enemy recovery data. |
+| 19 daze recovery example: 凶心疯汉 | Implemented in executable replay using Excel base recovery rate plus guide §2.3.2 recovery-rate modifier composition. |
 | 20 daze recovery example: 装甲哈提 | Deferred; requires non-DA enemy recovery data. |
 
 ### 1.2 Source Priority
@@ -535,8 +535,8 @@ V1 cleaned-data implementation must add tests for these gates:
 - zh/en i18n key sets are aligned for published data i18n resources;
 - unresolved mapping is machine-readable and fails golden cases when required
   fields are missing;
-- Golden true-data replay uses the executable anchor scope and records anchors
-  19 and 20 as V1.x deferred, not skipped accidentally. G13 and G18 are now
+- Golden true-data replay uses the executable anchor scope and records anchor
+  20 as V1.x deferred, not skipped accidentally. G13, G18, and G19 are now
   executable anchors.
 - `verify:golden-v1` passes as an offline freshness gate for the generated V1
   agent source candidates, manual acceptance records, and replay report; V1
@@ -571,9 +571,9 @@ not UX runtime messages. They must write data i18n resources under
 
 ### 10.3 task #43 True-Data Replay
 
-V1 release gate used the narrowed 19-anchor golden scope. V1.x Track B adds G13
-and G18 as executable anchors. Anchors 19 and 20 remain tracked as
-V1.x deferred items and must not be interpreted as missing QA coverage.
+V1 release gate used the narrowed 19-anchor golden scope. V1.x Track B adds G13,
+G18, and G19 as executable anchors. Anchor 20 remains tracked as a V1.x
+deferred item and must not be interpreted as missing QA coverage.
 
 The first replay harness baseline writes:
 
@@ -583,13 +583,14 @@ The first replay harness baseline writes:
 - `data/cleaned/golden/v1-replay-report.json`.
 
 `verify:golden-v1` verifies those artifacts against retained Excel and DA source
-snapshots. The current baseline has 21 executable anchors passed, zero blocking
+snapshots. The current baseline has 22 executable anchors passed, zero blocking
 diagnostics, and `releaseReady=true`. G04 reproduces the guide breakpoint scan,
 G09 asserts sourced DA daze ratio display flooring, G10 asserts frost/auric
 resistance plus anomaly-buildup-resistance lane mapping, G13 asserts sourced
 anomaly-threshold rule composition, G18 asserts sourced
-part-break true damage, and G22/G23 use lo-user manual acceptance records for
-Nicole/Yanagi active-state and polarity-disorder template semantics. The
+part-break true damage, G19 asserts sourced daze recovery-rate composition for
+凶心疯汉, and G22/G23 use lo-user manual acceptance records for Nicole/Yanagi
+active-state and polarity-disorder template semantics. The
 polarity-disorder template requires an explicit provider agent in `team` and an
 explicit supported skill level (`skillLevels[skillLevelKey]` in 1-16) plus
 provider `panel.anomalyProficiency`; missing or out-of-range inputs are

--- a/docs/data-contract/trace.md
+++ b/docs/data-contract/trace.md
@@ -137,7 +137,8 @@ Daze trace must expose:
 - `dazeInflictZone`
 - `dazeReceiveZone`
 - `dazeRatio` raw/display values
-- `dazeRecoveryTime` and recovery-rate contributors
+- `dazeRecoveryTime`, `effectiveDazeRecoveryRate`, and sourced recovery-rate
+  modifier contributors
 - Resonium source ids for Lost Void examples
 
 ## 8. Version Trace

--- a/docs/data-source/README.md
+++ b/docs/data-source/README.md
@@ -56,7 +56,7 @@ S5 segment 2 should continue with:
 - buhflipexplode transforms from the retained live-only snapshot into cleaned
   Deadly Assault data and parity fixtures.
 - Raw record schemas and transforms into `GameData`.
-- Golden-anchor source coverage for the current 21-anchor executable fixture
+- Golden-anchor source coverage for the current 22-anchor executable fixture
   scope.
 - Negative validation that formal modifiers and formal rows cannot miss source
   metadata.

--- a/docs/data-source/excel/README.md
+++ b/docs/data-source/excel/README.md
@@ -30,8 +30,10 @@ The V1 replay baseline uses a narrower generated artifact:
 That artifact extracts only Yixuan / Nicole / Yanagi identity rows and
 calculation-relevant source text candidates needed by the DD-002 19-anchor
 golden scope. The acceptance artifacts record lo-user-approved G22/G23 mappings.
-The reader does not read Excel enemy rows and does not publish trusted typed
-modifiers without deterministic template support or manual acceptance.
+The replay harness reads minimal Excel enemy rows only when V1.x golden anchors
+require them (currently Greta for G18 and 匪祸侵蚀体·凶心疯汉 for G19). It does not
+publish trusted typed modifiers without deterministic template support or manual
+acceptance.
 
 ## V1 Candidate Sheets
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,9 +139,9 @@ Feedback routing:
 - V1 is a static `BattleSnapshot` calculator, not a battle timeline simulator.
 - V1 does not yet provide a Web UI or automatic character/equipment resolver.
 - Users provide or edit explicit JSON snapshots.
-- The executable golden gate is 21 anchors passed with zero blocking diagnostics.
+- The executable golden gate is 22 anchors passed with zero blocking diagnostics.
 - The V1 dogfooding gate is lo-user single-person deep validation plus QA
   regression. It passed 4/5 with zero unresolved B-Calc blockers; broad
   community validation is deferred.
-- G19 and G20 are intentionally deferred to V1.x. G13 and G18 have been added
-  as V1.x executable anchors.
+- G20 is intentionally deferred to V1.x. G13, G18, and G19 have been added as
+  V1.x executable anchors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 ## V1 release gate 当前重点
 
 1. lo-user 单人 dogfooding 已给出 4/5，B-Calc blocker 当前为 0；V1 仍未经过广泛社区 dogfooding。
-2. V1 golden fixture 真数据复算最初收窄到 19 个锚点；V1.x Track B 已补 G18 部位破坏真实伤害与 G13 异常阈值规则组合，G19/G20 失衡恢复时间仍推迟到后续 V1.x。
-3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；21 个 executable 锚点全部跑通，`releaseReady=true`，G19/G20 仍作为 V1.x deferred 可见。
+2. V1 golden fixture 真数据复算最初收窄到 19 个锚点；V1.x Track B 已补 G13 异常阈值规则组合、G18 部位破坏真实伤害、G19 凶心疯汉失衡恢复时间，G20 装甲哈提失衡恢复时间仍推迟到后续 V1.x。
+3. `data/cleaned/audit/v1-agent-source-candidates.json`、`data/cleaned/audit/*.acceptance.json` 与 `data/cleaned/golden/v1-replay-report.json` 已生成；22 个 executable 锚点全部跑通，`releaseReady=true`，G20 仍作为 V1.x deferred 可见。
 4. `fairy calc` 默认 `--view brief`，输出 summary-first 的 non-crit / crit lanes；完整 trace 通过 `--view verbose` 查看。
 5. 安比 dogfooding fixture `examples/snapshots/dogfood-anby-core-f-basic16-dullahan-9528.json` 已进入 `packages/cli/src/examples.test.ts`，因此由根命令 `pnpm test` 固定覆盖。
 6. v0.0.1 已发布；后续 release 流程跟随 canonical v3 runbook（见

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -25,7 +25,7 @@
 | **D-10** | 数据维护责任 | ✅ 锁定（v2.0 修订） | V1 阶段：lo-user 提供 Excel 主源 + 爬虫每版本手动 release；data 包必须做完整角色/音擎/驱动盘/影画/鸣徽/潜能激化数据 | 中 |
 | **D-11** | 命名体系（v2.0 新增） | ✅ 锁定 | 选项 A 全套官方化：公开 schema / core API / data 字段优先使用 ZZZ 官方英文的语义化 camelCase；旧 `breach*` 进 sourceAliases / migration | 中 |
 | **D-12** | buhflipexplode 算法处理 | ✅ 锁定 | 选项 B：Fairy 保持 MIT；buhflipexplode GPL JS 仅 raw 留档/参考，不复制进 runtime；Fairy 独立实现等价算法；每次抓取用 hash + 算法快照文档 + parity 对账监控 drift | 高 |
-| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors；2026-05-13 G13/G18 V1.x done） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x Track B 已补 G13/G18，remaining defer = G19 / G20 | 中 |
+| **D-13** | V1 范围收窄到危局强袭战 | ✅ 锁定（2026-05-05 errata：黄金集 19 anchors；2026-05-13 G13/G18/G19 V1.x done） | V1 = DA 计算器；buhflipexplode = DA overlay 主源；Excel `敌人属性`保留 raw archive 作为 V1.x+ 扩展源；V1 黄金集 19 anchors（G01-G12 + G14-G17 + G21-G23）；V1.x Track B 已补 G13/G18/G19，remaining defer = G20 | 中 |
 | **D-14** | cleaned data typed modifier 双层结构 | ✅ 锁定（2026-05-05） | Layer 1 原文层 `sourceText` / `localizedText` + Layer 2 计算层 `modifiers[]` / `calculationEffects[]` + 风险层 `unparsedEffects[]`；bucket 受控 enum 严格匹配 glossary v0.4 D-11；效果 4 级（L1 静态 / L2 静态条件 / L3 动态参数 / L4 时序需 `requiresActivation`）；确定性 pipeline + sourceTextHash + parserVersion + effectTemplateId + 人工 audit gate；AI 候选不能直接入 cleaned | 中 |
 | **D-15** | V1 package exports 4 入口 | ✅ 锁定（2026-05-05） | V1 全做：`@randomplay/data/cleaned`（总入口）/ `@randomplay/data/cleaned/<domain>` / `@randomplay/data/types` / `@randomplay/data/cleaned/i18n/<domain>`；data 包 game labels 源码 `packages/data/src/i18n/` → 发布 `packages/data/cleaned/i18n/`；UX ERR-* `docs/ux/i18n/` 完全独立 | 中 |
 | **D-16** | Source priority + multi-source + unknown policy | ✅ 锁定（2026-05-05） | Excel base / buhflipexplode DA overlay / 米游社 i18n；冲突 fail loud + manual review；entity-level `sources[]` + 关键数值字段级 `sourceRefs`；unknown 分级 blocking（影响计算）/ non-blocking（纯展示）；新增 ERR-DAT-005（multi-source conflict / 未解析 modifier blocking）+ ERR-DAT-006（locale mapping unresolved / 展示缺失 non-blocking，与 PR #21 cleaned schema spec 锁定一致） | 中 |
@@ -151,7 +151,8 @@
 **2026-05-13 V1.x Track B update**：
 - **G13 implemented**：异常阈值特殊规则已进入 executable replay，使用攻略 §3.2.2 的基础阈值表、特殊敌人 1.1x/1.2x 阈值提升、危局强袭战第16期 1.1x 阈值提升，并通过 `anomalyThresholdModifiers[]` 乘算组合复现 3960 / 4752(物理) / 3630 / 4356(物理)。
 - **G18 implemented**：部位破坏典型真实伤害倍率表已进入 executable replay，使用 Excel `敌人属性` 中格莱特 70 级最大生命值 + 攻略 §1.1 工程机械部位破坏 5% 最大生命值真实伤害规则。
-- **Remaining V1.x deferred**：G19/G20 失衡恢复时间。
+- **G19 implemented**：凶心疯汉失衡恢复时间已进入 executable replay，使用 Excel `敌人属性` 中匪祸侵蚀体·凶心疯汉基础失衡恢复速度 7.69%/s + 攻略 §2.3.2 `+60% -9%` 失衡恢复速度组合复现 8.61 秒。
+- **Remaining V1.x deferred**：G20 装甲哈提失衡恢复时间。
 
 **理由**：
 - 与 lo-user "V1 主要支持危局强袭战 + Excel 后备" 框定一致

--- a/docs/product/dogfooding-report-v1.md
+++ b/docs/product/dogfooding-report-v1.md
@@ -89,7 +89,7 @@ dogfooding 通过 release gate（≥4/5）。
 ## 4. 已知限制（V1 release notes 待标注）
 
 - **DD-003 单人 dogfooding 限制**：V1 仅由 lo-user 单人深度 dogfood 验证 + QA 回归，**未经社区广泛验证**
-- **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 原推迟到 V1.x；截至 2026-05-13，G13 / G18 已进入 executable replay，G19 / G20 仍待补（失衡恢复时间扩展功能）
+- **V1 黄金集 = 19 anchors**（D-13 errata）：G13 / G18 / G19 / G20 原推迟到 V1.x；截至 2026-05-13，G13 / G18 / G19 已进入 executable replay，G20 仍待补（失衡恢复时间扩展功能）
 - **米游社 sourceConflict 3 个**（21 澄意 / 8 灼冽 / 1 破招）：~~non-blocking historical 记录，cleaned typed modifier 发布前需人工 audit gate 触发时再决~~ → ✅ 2026-05-08 已 audit 决议（accept buhflipexplode；F-05 / PR #33），不再属于 known limitation，转记为已解决项
 - **dogfooding 边界探测 Day 3 跳过**：lo-user 决策跳过 Day 3（`--lang en` 验证 / 故意造错 ERR-* 验证），release 后视真实使用反馈再决定是否回补；属 known limitation，不阻塞 release
 
@@ -105,7 +105,7 @@ dogfooding 通过 release gate（≥4/5）。
 | B-Calc.non-blocker：已重新分类 | ✅ F-02 归 U-Scenario，已 absorbed by D-19 |
 | U-ErrCopy / U-Scenario：可修已修，不修加 known limitation 注解 | ✅ F-01 / F-02 / F-03 / F-06 已修；Day 3 跳过记 known limitation |
 | D-Data：audit gate 决议落地 | ✅ F-05 已决议（accept buhflipexplode），audit 文件入仓 |
-| P-Range：全部入 V1.x backlog | ✅ G13/G18 已完成；G19/G20 仍为 V1.x backlog（D-13）；其他无新增 |
+| P-Range：全部入 V1.x backlog | ✅ G13/G18/G19 已完成；G20 仍为 V1.x backlog（D-13）；其他无新增 |
 | lo-user 整体打分 ≥ 4/5 | ✅ 4/5 |
 
 **通过 release gate**。

--- a/docs/qa/golden-source-coverage.md
+++ b/docs/qa/golden-source-coverage.md
@@ -7,9 +7,9 @@ Related tasks: task #40, task #43
 
 This document narrows the original 23 golden anchors to the V1 release gate
 locked by D-13 plus DD-002, then tracks V1.x golden expansion. The executable
-gate currently has 21 anchors: the original 19 V1 anchors plus G13 and G18.
-Anchors G19/G20 remain deferred to V1.x because they require non-DA enemy daze
-recovery data.
+gate currently has 22 anchors: the original 19 V1 anchors plus G13, G18, and
+G19. Anchor G20 remains deferred to V1.x because it requires remaining non-DA
+enemy daze recovery data.
 
 The goal of this audit is to decide the minimum source and cleaned-data work
 needed before true-data replay. It does not change QA's fixture assertions.
@@ -19,8 +19,8 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | Set | Anchor IDs | Status |
 |---|---|---|
 | V1 release gate | G01-G12, G14-G17, G21-G23 | Must pass before V1 release. |
-| V1.x executable expansion | G13, G18 | Passed after guide anomaly-threshold composition and non-DA Excel enemy + guide part-break true-damage replay. |
-| Deferred V1.x | G19-G20 | Not current blockers. |
+| V1.x executable expansion | G13, G18, G19 | Passed after guide anomaly-threshold composition, non-DA Excel enemy + guide part-break true-damage replay, and daze recovery-rate composition replay. |
+| Deferred V1.x | G20 | Not current blocker. |
 
 ## Source Status Summary
 
@@ -31,7 +31,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | Mihoyo DA snapshot | PR #24 retained 35 details and zh/en alignment. | Chinese buff/boss/room text and source anchors for later typed-modifier review. |
 | Excel workbook | Raw workbook retained; `workbook-audit.json` records sheet/column shape. | Minimal agent kit data for Yixuan / Nicole / Yanagi team-modifier anchors, if V1 replay uses formal sourced modifiers. |
 
-## 21-Anchor Matrix
+## 22-Anchor Matrix
 
 | ID | V1 source dependency | Current source coverage | Remaining work |
 |---|---|---|---|
@@ -53,6 +53,7 @@ needed before true-data replay. It does not change QA's fixture assertions.
 | G16 | Disorder daze-level zone | Covered by core rules. | Replay fixture only. |
 | G17 | Corrupted-shield cleanse true damage | Core rules covered; DA boss max HP available from buhflipexplode. | Cleaned DA boss slot must expose sourced max HP/effective max HP. |
 | G18 | Part-break true damage multiplier table | Excel provides non-DA Greta max HP; guide §1.1 provides engineering-machine 5% max HP true-damage rule. | Passed with `manualEvents.kind=partBreak`. |
+| G19 | Daze recovery time example: 凶心疯汉 | Excel provides base daze recovery rate 7.69%/s for 匪祸侵蚀体·凶心疯汉; guide §2.3.2 provides +60% and -9% recovery-rate modifiers and the 8.61s example. | Passed with `enemy.dazeRecoveryRate` plus sourced `dazeRecoveryModifiers[]`; no fixed time override is used. |
 | G21 | 1-agent Yixuan sheer | Excel has Yixuan agent row; panel values remain user snapshot. | Minimal Excel agent mapping for Yixuan id/attribute/specialty/label/source refs. |
 | G22 | Yixuan + Nicole defense reduction | Excel has Nicole rows/descriptions; lo-user accepted the defense-reduction mapping. | Passed with explicit inactive/active snapshot replay. |
 | G23 | Yixuan + Nicole + Yanagi polarity disorder | Excel has Yanagi rows/descriptions; lo-user accepted the disorder boost and EX Special polarity-disorder template. | Passed with explicit inactive/active replay and skill-level parameterized polarity-disorder template. |
@@ -147,20 +148,20 @@ cleaned artifacts:
   `data/cleaned/audit/yanagi.acceptance.json` — lo-user manual acceptance
   records for G22/G23 source-text mappings.
 - `data/cleaned/golden/v1-replay-report.json` — executable replay baseline for
-  the 21-anchor scope after G13 and G18.
+  the 22-anchor scope after G13, G18, and G19.
 
 The current replay report intentionally reports:
 
 | Status | Anchors | Meaning |
 |---|---|---|
-| `passed` | 21 anchors | All executable anchors pass replay with sourced Excel/DA/guide refs and lo-user accepted G22/G23 mappings. |
+| `passed` | 22 anchors | All executable anchors pass replay with sourced Excel/DA/guide refs and lo-user accepted G22/G23 mappings. |
 | `pendingHarness` | none | No V1 anchors are pending harness. |
 | `blocked` | none | G22/G23 `ERR-DAT-005` diagnostics are cleared by acceptance records. |
-| `deferred` | G19-G20 | Explicit remaining V1.x scope. |
+| `deferred` | G20 | Explicit remaining V1.x scope. |
 
 `pnpm --filter @randomplay/data verify:golden-v1` is an offline freshness and shape
 gate. It verifies the artifacts are regenerated from the retained sources and
-that executable replay has `passed=21`, `pendingHarness=0`, `blocked=0`,
+that executable replay has `passed=22`, `pendingHarness=0`, `blocked=0`,
 `blockingDiagnostics=0`, and `releaseReady=true`.
 
 ## Product / Human Decisions
@@ -173,6 +174,10 @@ TL recommendation:
   source trace.
 - **G18**: implemented during V1.x Track B using Excel `敌人属性` Greta max HP
   plus the guide §1.1 part-break true-damage multiplier table.
+- **G19**: implemented during V1.x Track B using Excel `敌人属性` base daze
+  recovery rate for 匪祸侵蚀体·凶心疯汉 plus guide §2.3.2 recovery-rate
+  modifier composition. Do not use a fixed recovery-time override to claim this
+  anchor.
 - **Nicole/Yanagi**: @lo-user accepted the G22/G23 mapping semantics on
   2026-05-05. A/B effects are explicit inactive/active snapshot states; C is a
   skill-level-parameterized EX Special polarity-disorder template. C must fail
@@ -182,5 +187,5 @@ TL recommendation:
   modifier.
 
 #43 now has a release-ready replay baseline for the original 19 V1 anchors, and
-V1.x Track B has added G13/G18 as executable anchors. G19/G20 remain listed as
-explicit V1.x gaps rather than disappearing from QA visibility.
+V1.x Track B has added G13/G18/G19 as executable anchors. G20 remains listed as
+an explicit V1.x gap rather than disappearing from QA visibility.

--- a/docs/ux/starter-scenarios.md
+++ b/docs/ux/starter-scenarios.md
@@ -11,7 +11,7 @@
 > 用途：AI plugin 让 LLM 引用作为 prompt context；CLI 用户复制后改自己面板；QA 黄金集对账参考。
 
 > **v0.4.1 erratum（D-13 V1 = DA 收窄）**：
-> - V1 黄金集收窄到 20 锚点（参见 `docs/product/decisions/index.md` D-13）。**部位破坏典型真实伤害**（黄金集锚点 18）与**失衡恢复时间算例**（锚点 19 凶心疯汉 / 锚点 20 装甲哈提）所对应的 starter scenario 推迟到 V1.x，等 cleaned/enemies + Excel 非 DA enemy 派生数据落地后补。当前 v0.4.1 只覆盖 V1 DA 主场景（S1 / S2 / S3）。
+> - V1 黄金集收窄到 19 锚点（参见 `docs/product/decisions/index.md` D-13）。V1.x Track B 已补黄金集锚点 13 / 18 / 19；**失衡恢复时间算例**锚点 20（装甲哈提）所对应的 starter scenario 仍推迟到后续 V1.x，等剩余 cleaned/enemies + Excel 非 DA enemy 派生数据落地后补。当前 v0.4.1 只覆盖 V1 DA 主场景（S1 / S2 / S3）。
 > - 所有 `enemyId` 在 V1 cleaned 体系下指向 `cleaned/deadly-assault` 的 `externalBossId`（buhflipexplode raw）；能映射 Excel 时附 `baseEnemyRef`。详见 `docs/data-contract/cleaned-schema-spec.md` §5.2 / §5.3。
 
 ---

--- a/packages/core/src/engine/calculate.test.ts
+++ b/packages/core/src/engine/calculate.test.ts
@@ -255,6 +255,75 @@ describe("calculate", () => {
     expect(result.buckets.some(bucket => bucket.bucketId === "dazeInflictZone")).toBe(true)
   })
 
+  it("traces enemy daze recovery time with sourced rate modifiers", () => {
+    const result = calculate({
+      ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        enemyId: "excel:11521",
+        dazeRecoveryRate: 0.0769,
+        dazeRecoveryModifiers: [
+          {
+            id: "hypnotic-watch-before-rework",
+            value: 0.6,
+            source,
+          },
+          {
+            id: "duel-t-cane-pre-catalyst",
+            value: -0.09,
+            source,
+          },
+        ],
+      },
+    })
+    const recoveryTrace = result.trace.find(event => event.path === "enemy.dazeRecoveryTime")
+
+    expect(recoveryTrace?.inputs).toMatchObject({
+      enemyId: "excel:11521",
+      baseDazeRecoveryRate: 0.0769,
+      dazeRecoveryRateMultiplier: 1.51,
+      dazeRecoveryModifiers: [
+        { id: "hypnotic-watch-before-rework", value: 0.6 },
+        { id: "duel-t-cane-pre-catalyst", value: -0.09 },
+      ],
+    })
+    expect(recoveryTrace?.inputs?.effectiveDazeRecoveryRate).toBeCloseTo(0.116119, 6)
+    expect(recoveryTrace?.rawValue).toBeCloseTo(8.611857141552806, 5)
+  })
+
+  it("rejects daze recovery modifiers without a base recovery rate", () => {
+    expect(() => calculate({
+      ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        dazeRecoveryModifiers: [
+          {
+            id: "orphan-recovery-modifier",
+            value: 0.6,
+            source,
+          },
+        ],
+      },
+    })).toThrow(/dazeRecoveryRate is required/)
+  })
+
+  it("rejects non-positive effective daze recovery rates", () => {
+    expect(() => calculate({
+      ...baseSnapshot,
+      enemy: {
+        ...baseSnapshot.enemy,
+        dazeRecoveryRate: 0.0769,
+        dazeRecoveryModifiers: [
+          {
+            id: "invalid-negative-recovery",
+            value: -1,
+            source,
+          },
+        ],
+      },
+    })).toThrow(/positive effective daze recovery rate/)
+  })
+
   it("computes anomaly damage without the standard crit bucket", () => {
     const result = calculate({
       ...baseSnapshot,

--- a/packages/core/src/engine/calculate.ts
+++ b/packages/core/src/engine/calculate.ts
@@ -58,6 +58,7 @@ export function calculate(input: unknown, options: CalculateOptions = {}): CalcR
   const manualEventResults = (snapshot.manualEvents ?? []).map((event, index) =>
     calculateManualEvent(snapshot, event, index),
   )
+  const enemyTrace = getEnemyTrace(snapshot)
 
   for (const segment of segmentComputations) {
     warnings.push(...segment.warnings)
@@ -70,6 +71,7 @@ export function calculate(input: unknown, options: CalculateOptions = {}): CalcR
   }
 
   const trace = [
+    ...enemyTrace,
     ...segmentComputations.flatMap(segment => segment.trace),
     ...manualEventResults.flatMap(event => event.trace),
   ]
@@ -915,6 +917,38 @@ function getAnomalyBuildup(snapshot: BattleSnapshot, activeActor: AgentSnapshot,
 
 function getAnomalyBuildupResistanceMultiplier(resistance: number): number {
   return clamp(1 - resistance, 0, 2)
+}
+
+function getEnemyTrace(snapshot: BattleSnapshot): TraceEvent[] {
+  const baseDazeRecoveryRate = snapshot.enemy.dazeRecoveryRate
+  if (baseDazeRecoveryRate === undefined)
+    return []
+
+  const dazeRecoveryModifiers = snapshot.enemy.dazeRecoveryModifiers ?? []
+  const dazeRecoveryRateMultiplier = 1 + sum(dazeRecoveryModifiers.map(modifier => modifier.value))
+  const effectiveDazeRecoveryRate = baseDazeRecoveryRate * dazeRecoveryRateMultiplier
+  const dazeRecoveryTime = 1 / effectiveDazeRecoveryRate
+
+  return [
+    makeTraceEvent({
+      kind: "formula",
+      path: "enemy.dazeRecoveryTime",
+      inputs: {
+        enemyId: snapshot.enemy.enemyId,
+        baseDazeRecoveryRate,
+        dazeRecoveryModifiers: dazeRecoveryModifiers.map(modifier => ({
+          id: modifier.id,
+          value: modifier.value,
+          ...(modifier.source === undefined ? {} : { source: modifier.source }),
+        })),
+        dazeRecoveryRateMultiplier,
+        effectiveDazeRecoveryRate,
+      },
+      formula: "dazeRecoveryTime = 1 / (baseDazeRecoveryRate * (1 + sum(dazeRecoveryModifiers)))",
+      rawValue: dazeRecoveryTime,
+      displayValue: "dazeRecoveryTime",
+    }),
+  ]
 }
 
 function getDamageBonus(activeActor: AgentSnapshot, segment: AttackSegment): number {

--- a/packages/core/src/schema/battle-snapshot.ts
+++ b/packages/core/src/schema/battle-snapshot.ts
@@ -178,6 +178,14 @@ export const attackSegmentSchema = z
     }
   })
 
+export const dazeRecoveryModifierSchema = z
+  .object({
+    id: z.string().min(1),
+    value: z.number().finite(),
+    source: sourceRefSchema.optional(),
+  })
+  .strict()
+
 export const enemySnapshotSchema = z
   .object({
     enemyId: z.string().min(1).optional(),
@@ -189,6 +197,8 @@ export const enemySnapshotSchema = z
     dazeCap: z.number().finite().optional(),
     resistance: z.partialRecord(resistanceAttributeSchema, z.number().finite()).optional(),
     dazeResistance: z.number().finite().optional(),
+    dazeRecoveryRate: z.number().finite().positive().optional(),
+    dazeRecoveryModifiers: z.array(dazeRecoveryModifierSchema).optional(),
     anomalyBuildupResistance: z
       .partialRecord(resistanceAttributeSchema, z.number().finite())
       .optional(),
@@ -207,6 +217,32 @@ export const enemySnapshotSchema = z
     overrides: z.array(fieldOverrideSchema).optional(),
   })
   .strict()
+  .superRefine((enemy, ctx) => {
+    const dazeRecoveryModifiers = enemy.dazeRecoveryModifiers ?? []
+    if (dazeRecoveryModifiers.length > 0 && enemy.dazeRecoveryRate === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dazeRecoveryRate"],
+        message: "enemy.dazeRecoveryRate is required when dazeRecoveryModifiers are provided",
+      })
+      return
+    }
+
+    if (enemy.dazeRecoveryRate === undefined)
+      return
+
+    const dazeRecoveryRateMultiplier = 1 + dazeRecoveryModifiers.reduce(
+      (total, modifier) => total + modifier.value,
+      0,
+    )
+    if (dazeRecoveryRateMultiplier <= 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dazeRecoveryModifiers"],
+        message: "dazeRecoveryModifiers must compose to a positive effective daze recovery rate",
+      })
+    }
+  })
 
 const baseManualEventSchema = z.object({
   id: z.string().min(1),
@@ -360,6 +396,7 @@ export type AgentSnapshot = z.infer<typeof agentSnapshotSchema>
 export type AnomalyThresholdModifier = z.infer<typeof anomalyThresholdModifierSchema>
 export type AnomalyContributionInput = z.infer<typeof anomalyContributionInputSchema>
 export type AttackSegment = z.infer<typeof attackSegmentSchema>
+export type DazeRecoveryModifier = z.infer<typeof dazeRecoveryModifierSchema>
 export type EnemySnapshot = z.infer<typeof enemySnapshotSchema>
 export type ManualEvent = z.infer<typeof manualEventSchema>
 export type BattleSnapshot = z.infer<typeof battleSnapshotSchema>

--- a/packages/data/cleaned/golden/v1-replay-report.json
+++ b/packages/data/cleaned/golden/v1-replay-report.json
@@ -3,7 +3,7 @@
   "parserVersion": "golden-v1-replay-v0.1.0",
   "generatedAt": "2026-05-05T18:20:00+08:00",
   "policy": {
-    "scope": "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
+    "scope": "V1.x true-data replay harness after G19: 22 anchors pass executable replay, G20 remains deferred.",
     "releaseGate": "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
     "manualAcceptance": "G22/G23 use lo-user manual acceptance records tied to the sourceTextHash values in v1-agent-source-candidates.json; A/B effects are replayed as explicit inactive/active snapshot states, and C is skill-level parameterized."
   },
@@ -26,20 +26,20 @@
     "G16",
     "G17",
     "G18",
+    "G19",
     "G21",
     "G22",
     "G23"
   ],
   "deferredAnchorIds": [
-    "G19",
     "G20"
   ],
   "summary": {
-    "v1AnchorCount": 21,
-    "passed": 21,
+    "v1AnchorCount": 22,
+    "passed": 22,
     "pendingHarness": 0,
     "blocked": 0,
-    "deferred": 2,
+    "deferred": 1,
     "blockingDiagnostics": 0,
     "releaseReady": true
   },
@@ -343,6 +343,25 @@
       ]
     },
     {
+      "id": "G19",
+      "status": "passed",
+      "sourceRefs": [
+        {
+          "sourceId": "lo-user-excel",
+          "sourceVersion": "2.6.0_R14028417",
+          "sourceAnchor": "敌人属性!A216:AU216"
+        },
+        {
+          "sourceId": "zzz-data-introduction",
+          "sourceVersion": "2026-05-05",
+          "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202"
+        }
+      ],
+      "notes": [
+        "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+      ]
+    },
+    {
       "id": "G21",
       "status": "passed",
       "sourceRefs": [
@@ -398,19 +417,11 @@
       ]
     },
     {
-      "id": "G19",
-      "status": "deferred",
-      "sourceRefs": [],
-      "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
-      ]
-    },
-    {
       "id": "G20",
       "status": "deferred",
       "sourceRefs": [],
       "notes": [
-        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion."
+        "Deferred to V1.x by D-13; requires remaining non-DA enemy daze-recovery data expansion."
       ]
     }
   ]

--- a/packages/data/scripts/golden-v1-replay.ts
+++ b/packages/data/scripts/golden-v1-replay.ts
@@ -57,12 +57,13 @@ const v1AnchorIds = [
   "G16",
   "G17",
   "G18",
+  "G19",
   "G21",
   "G22",
   "G23",
 ] as const
 
-const deferredAnchorIds = ["G19", "G20"] as const
+const deferredAnchorIds = ["G20"] as const
 
 const agentSpecs = {
   nicole: { excelId: 1031, zh: "妮可", en: "Nicole" },
@@ -719,6 +720,7 @@ function loadExcelEnemy(name: string, indexId: number) {
   return {
     enemyId: `excel:${indexId}`,
     sourceRefs: [sourceRef(`敌人属性!A${rowNumber}:AU${rowNumber}`)],
+    defaultDazeRecoveryTime: numberValue(rowValue(row, headers, "默认失衡恢复时间"), `${name}.默认失衡恢复时间`),
     snapshot: {
       enemyId: `excel:${indexId}`,
       level: 70,
@@ -727,6 +729,7 @@ function loadExcelEnemy(name: string, indexId: number) {
       baseDaze: numberValue(rowValue(row, headers, "70级最大失衡值上限"), `${name}.70级最大失衡值上限`),
       dazeCap: numberValue(rowValue(row, headers, "70级最大失衡值上限"), `${name}.70级最大失衡值上限`),
       defense: numberValue(rowValue(row, headers, "60级及以上防御力"), `${name}.60级及以上防御力`),
+      dazeRecoveryRate: numberValue(rowValue(row, headers, "基础失衡恢复速度"), `${name}.基础失衡恢复速度`),
     },
   }
 }
@@ -1469,6 +1472,39 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
   }
 
   {
+    const mad = loadExcelEnemy("匪祸侵蚀体·凶心疯汉", 11521)
+    const guideRef = guideSourceRef("docs/reference/zzz-data-introduction.txt:181-202")
+    const result = calculate({
+      ...snapshot,
+      enemy: {
+        ...mad.snapshot,
+        dazeRecoveryModifiers: [
+          {
+            id: "hypnotic-watch-before-rework",
+            value: 0.6,
+            source: guideRef,
+          },
+          {
+            id: "duel-t-cane-pre-catalyst",
+            value: -0.09,
+            source: guideRef,
+          },
+        ],
+      },
+    })
+    const recoveryTrace = trace(result, "enemy.dazeRecoveryTime")
+    const inputs = recoveryTrace.inputs as Record<string, unknown>
+    assertClose(mad.snapshot.dazeRecoveryRate, 0.0769, 0.000001, "G19 base daze recovery rate")
+    assertClose(mad.defaultDazeRecoveryTime, 13.0039, 0.0001, "G19 default daze recovery time")
+    assertClose(inputs.dazeRecoveryRateMultiplier as number, 1.51, 0.000001, "G19 daze recovery modifier sum")
+    assertClose(inputs.effectiveDazeRecoveryRate as number, 0.116119, 0.000001, "G19 effective daze recovery rate")
+    assertClose(recoveryTrace.rawValue as number, 8.611857, 0.00001, "G19 daze recovery time")
+    anchors.push(passedAnchor("G19", [...mad.sourceRefs, guideRef], [
+      "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s.",
+    ]))
+  }
+
+  {
     const result = calculate({
       ...snapshot,
       attackSegments: [
@@ -1640,7 +1676,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
       status: "deferred",
       sourceRefs: [],
       notes: [
-        "Deferred to V1.x by D-13; requires non-DA enemy daze-recovery data expansion.",
+        "Deferred to V1.x by D-13; requires remaining non-DA enemy daze-recovery data expansion.",
       ],
     })
   }
@@ -1663,7 +1699,7 @@ function buildReplayReport(generatedAt: string, candidates = buildCandidates(gen
     generatedAt,
     policy: {
       scope:
-        "V1.x true-data replay harness after G13: 21 anchors pass executable replay, G19/G20 remain deferred.",
+        "V1.x true-data replay harness after G19: 22 anchors pass executable replay, G20 remains deferred.",
       releaseGate:
         "releaseReady becomes true only when all executable anchors pass replay and blockingDiagnostics is zero.",
       manualAcceptance:
@@ -1718,8 +1754,8 @@ function verifyCommand(): void {
 
   const report = readJson<{ generatedAt: string; summary: { v1AnchorCount: number; blocked: number; pendingHarness: number; blockingDiagnostics: number; releaseReady: boolean } }>(replayReportPath)
   assertArtifactsFresh(report.generatedAt)
-  if (report.summary.v1AnchorCount !== 21)
-    throw new Error(`Expected 21 executable anchors, got ${report.summary.v1AnchorCount}`)
+  if (report.summary.v1AnchorCount !== v1AnchorIds.length)
+    throw new Error(`Expected ${v1AnchorIds.length} executable anchors, got ${report.summary.v1AnchorCount}`)
   if (report.summary.blocked !== 0)
     throw new Error(`Expected no blocked anchors after G22/G23 manual acceptance, got ${report.summary.blocked}`)
   if (report.summary.pendingHarness !== 0)
@@ -1727,7 +1763,7 @@ function verifyCommand(): void {
   if (report.summary.blockingDiagnostics !== 0)
     throw new Error(`Expected no blocking diagnostics after G22/G23 manual acceptance, got ${report.summary.blockingDiagnostics}`)
   if (report.summary.releaseReady !== true)
-    throw new Error("Expected golden replay releaseReady=true after all 21 executable anchors pass")
+    throw new Error(`Expected golden replay releaseReady=true after all ${v1AnchorIds.length} executable anchors pass`)
 }
 
 async function main(): Promise<void> {

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -29,7 +29,7 @@ describe("V1 golden true-data replay baseline", () => {
     )
   })
 
-  it("tracks the 21-anchor executable gate and deferred anchors explicitly", () => {
+  it("tracks the 22-anchor executable gate and deferred anchors explicitly", () => {
     const report = readJson<{
       v1AnchorIds: string[]
       deferredAnchorIds: string[]
@@ -49,7 +49,7 @@ describe("V1 golden true-data replay baseline", () => {
       }>
     }>(replayReportPath)
 
-    expect(report.v1AnchorIds).toHaveLength(21)
+    expect(report.v1AnchorIds).toHaveLength(22)
     expect(report.v1AnchorIds).toEqual([
       "G01",
       "G02",
@@ -69,14 +69,15 @@ describe("V1 golden true-data replay baseline", () => {
       "G16",
       "G17",
       "G18",
+      "G19",
       "G21",
       "G22",
       "G23",
     ])
-    expect(report.deferredAnchorIds).toEqual(["G19", "G20"])
+    expect(report.deferredAnchorIds).toEqual(["G20"])
     expect(report.summary).toMatchObject({
-      v1AnchorCount: 21,
-      passed: 21,
+      v1AnchorCount: 22,
+      passed: 22,
       pendingHarness: 0,
       blocked: 0,
       blockingDiagnostics: 0,
@@ -100,6 +101,9 @@ describe("V1 golden true-data replay baseline", () => {
     const g18 = report.anchors.find(anchor => anchor.id === "G18")
     expect(g18?.status).toBe("passed")
     expect(g18?.notes.join("\n")).toContain("Greta level-70 max HP")
+    const g19 = report.anchors.find(anchor => anchor.id === "G19")
+    expect(g19?.status).toBe("passed")
+    expect(g19?.notes.join("\n")).toContain("8.61s")
     const g22 = report.anchors.find(anchor => anchor.id === "G22")
     expect(g22?.status).toBe("passed")
     expect(g22?.notes.join("\n")).toContain("inactive/active snapshot states")


### PR DESCRIPTION
## Summary

- Adds `enemy.dazeRecoveryRate` and sourced `dazeRecoveryModifiers[]` snapshot support, with a stable `enemy.dazeRecoveryTime` trace.
- Moves G19 from deferred to executable replay using Excel `敌人属性!A216:AU216` for 匪祸侵蚀体·凶心疯汉 and guide §2.3.2 `+60% -9%` recovery-rate composition.
- Updates generated replay artifacts and current docs from 21 executable anchors / G19-G20 deferred to 22 executable anchors / G20 deferred.

## Verification

- `pnpm --filter @randomplay/data audit:golden-v1`
- `pnpm --filter @randomplay/data sync-cleaned`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/core check`
- `pnpm --filter @randomplay/core test`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @randomplay/data verify:excel`
- `pnpm --filter @randomplay/data verify:buhflipexplode-da`
- `pnpm --filter @randomplay/data verify:mihoyo-da`
- `git diff --check`
