### PR TITLE
docs: document golden changelog convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@ All notable changes to Fairy are documented in this file.
 
 ## 0.0.3 - 2026-05-14
 
-### Added
-
-- Add G13 anomaly threshold composition (#42)
-- Add G19 daze recovery anchor (#43)
-
 ### Changed
 
 - Normalize release housekeeping (#40)
+
+### Golden Anchors
+
+- Add G18 part-break golden anchor (#41)
+- Add G13 anomaly threshold composition (#42)
+- Add G19 daze recovery anchor (#43)
+- Add G20 daze recovery anchor (#44)
 
 ## 0.0.2 - 2026-05-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,13 +22,20 @@ Fairy is a ZZZ static snapshot damage calculator for 1-3 agents.
 - Current Mihoyo DA ingestion uses public JSON APIs plus Cheerio for embedded
   rich-text fragments; Playwright/browser rendering is discovery-only unless a
   new decision explicitly approves it.
+- Release workflow A3: npm publish success creates GitHub Release before
+  registry install smoke. Registry smoke remains a red post-publish consumer
+  check with 20 x 60s retry; if it fails, do not blindly rerun the same tag.
+  Verify npm versions, provenance, and fresh install/import/CLI smoke before
+  declaring release-ready.
+- Commit messages use Conventional Commits with release-visible semantics.
+  Ordinary test-only work stays `test:` and is skipped from release notes.
+  Golden-anchor or release-readiness contract additions use `feat(golden):` so
+  they enter CHANGELOG and GitHub Release notes.
 
 ## Current Phase
 
-V1 release gate preparation. lo-user dogfooding has passed 4/5 with zero
-unresolved B-Calc blockers; Product errata, release notes, and QA
-release-readiness review remain before any V1 tag. Current engineering entry
-points:
+V0.0.3 is shipped. V1.x golden consolidation is complete with 23 passed / 0
+deferred anchors and `releaseReady=true`. Current engineering entry points:
 
 - `docs/architecture/naming-policy.md`
 - `docs/architecture/monorepo-development.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## Commit Messages
+
+This repository uses Conventional Commits. Squash-merge PR titles should be the
+release-note-quality commit message.
+
+Use the commit type that reflects release-visible value, not only the file paths
+changed:
+
+- Use `feat:` for user-visible product or API additions.
+- Use `fix:` for user-visible bug fixes.
+- Use `docs:` for documentation-only changes.
+- Use `ci:` for CI and release workflow changes.
+- Use `test:` for ordinary test coverage, regression tests, and fixture-only
+  maintenance that should not appear in release notes.
+- Use `feat(golden):` for golden-anchor or release-readiness contract additions.
+
+Golden anchors are project-visible contract additions: they change the published
+golden replay coverage and release-readiness evidence. Even when the diff is
+mostly fixtures or replay data, use `feat(golden): add G* ...` so the change is
+included in `CHANGELOG.md` and GitHub Release notes.
+
+Historical V0.0.3 anchor commits that landed before this convention are mapped in
+`cliff.toml`; future golden-anchor PRs should use `feat(golden):`.

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,6 +24,11 @@ filter_unconventional = false
 filter_commits = false
 tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
 commit_parsers = [
+  { message = "^feat\\(golden\\)", group = "Golden Anchors" },
+  # Historical compatibility for v0.0.3 anchors that landed before the
+  # `feat(golden):` convention was documented.
+  { message = "^feat: add G(13|19) ", group = "Golden Anchors" },
+  { message = "^test: add G(18|20) ", group = "Golden Anchors" },
   { message = "^feat",     group = "Added" },
   { message = "^fix",      group = "Fixed" },
   { message = "^docs",     group = "Documentation" },


### PR DESCRIPTION
## Summary
- add `feat(golden):` as the convention for golden-anchor / release-readiness contract additions
- keep ordinary `test:` commits skipped from release notes
- map the historical v0.0.3 G13/G18/G19/G20 anchor commits into a `Golden Anchors` changelog section
- add `CONTRIBUTING.md` commit guidance and refresh `CLAUDE.md` with release workflow / golden commit rules

## Verification
- `pnpm changelog`
- changelog stability check (`pnpm changelog` leaves `CHANGELOG.md` unchanged)
- `pnpm exec git-cliff --latest --strip header --output /tmp/fairy-release-notes-after-100.md`
- `printf '%s\n' 'feat(golden): add G21 sample anchor' | pnpm exec commitlint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Refs task #100.