### PR TITLE
docs: audit source migration candidates

### DIFF
--- a/data/cleaned/audit/source-migration-field-diff.json
+++ b/data/cleaned/audit/source-migration-field-diff.json
@@ -1,0 +1,407 @@
+{
+  "schemaVersion": "fairy-source-migration-field-diff-v1",
+  "generatedAt": "2026-05-14T23:35:00+08:00",
+  "scope": "Phase 1 initial sample audit. This file records machine-readable fixture coverage for sampled source fields only; it does not replace runtime cleaned data. Nanoka detail endpoints were added after the initial list-endpoint sample.",
+  "statusValues": [
+    "same",
+    "changed",
+    "missing-in-new",
+    "missing-in-excel",
+    "semantic-unknown"
+  ],
+  "sourceGateSummary": {
+    "prydwen": {
+      "sourceId": "prydwen-zzz",
+      "liveOnlyGate": "pass-with-weak-version-metadata",
+      "redistributionRisk": "accepted-by-owner",
+      "snapshotability": "html-snapshot",
+      "notes": "Public live-facing pages sampled. No explicit data redistribution license found."
+    },
+    "nanoka": {
+      "sourceId": "nanoka-zzz",
+      "liveOnlyGate": "pass-for-versioned-static-public-snapshot",
+      "redistributionRisk": "accepted-by-owner",
+      "snapshotability": "versioned-static-json",
+      "notes": "List endpoints are identity summaries, but detail endpoints under /zh|en|ja|ko/{character|bangboo|monster}/{id}.json expose calculation numeric fields for sampled agents, Bangboos, and monsters."
+    },
+    "gachabase": {
+      "sourceId": "gachabase-zzz",
+      "liveOnlyGate": "fail-beta-branch",
+      "redistributionRisk": "forbidden",
+      "snapshotability": "html-serialized-payload",
+      "notes": "All tested routes canonicalized to /beta and embedded branch beta. Numeric coverage is strong but cannot enter npm payload under current D-20 rules."
+    }
+  },
+  "entities": [
+    {
+      "entityType": "agent",
+      "entityId": "yixuan",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#代理人属性!A37:AF37"
+      ],
+      "fields": [
+        {
+          "fieldPath": "baseStatsByLevel.60.maxHp",
+          "excelValue": 7953.8621,
+          "candidates": {
+            "prydwen": {
+              "value": 8373,
+              "status": "changed",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters-stats/#Yixuan row",
+              "notes": "Visible rendered table value. Difference likely reflects source drift or stat interpretation; requires ruling before baseline update.",
+              "promotable": false,
+              "blockedBy": [
+                "field:changed-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "hp_max": 673,
+                  "hp_growth": 842519
+                },
+                "level6": {
+                  "hp_max": 2310,
+                  "level_min": 50,
+                  "level_max": 60
+                },
+                "extraLevel6": {
+                  "prop": 11101,
+                  "value": 420
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#stats.hp_max+hp_growth+level.6+extra_level.6",
+              "notes": "Detail endpoint exposes raw base/growth/level/extra HP fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 8373,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#Base HP",
+              "notes": "Value present, but source route canonicalizes to beta and is blocked by live-only gate.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "baseStatsByLevel.60.attack",
+          "excelValue": 872.5748,
+          "candidates": {
+            "prydwen": {
+              "value": 872,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters-stats/#Yixuan row",
+              "notes": "Rendered value is rounded/truncated.",
+              "promotable": false,
+              "blockedBy": [
+                "field:semantic-unknown-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "attack": 126,
+                  "attack_growth": 88572
+                },
+                "level6": {
+                  "attack": 224,
+                  "level_min": 50,
+                  "level_max": 60
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#stats.attack+attack_growth+level.6",
+              "notes": "Detail endpoint exposes raw base/growth/level attack fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 872,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#Base ATK",
+              "notes": "Rendered value is rounded and beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.basicAttack.hit1.damageMultiplier",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters/yixuan/#Basic Attack",
+              "notes": "Visible row: 1st-Hit DMG Multiplier 45.80%.",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#skill.basic.description.param.Skill1371001.Prop1001",
+              "notes": "Detail endpoint exposes deterministic skill params: damage_percentage=4580, stun_ratio=2860, attribute_infliction=2596.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#skill_data id 1371001",
+              "notes": "Serialized value damage_multiplier_base=4580, but beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "plugboo",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#邦布属性!A18:T18",
+        "data/source/excel/data.xlsx#邦布技能!A29:H30"
+      ],
+      "fields": [
+        {
+          "fieldPath": "baseStatsByLevel.60.attack",
+          "excelValue": 8057.0996,
+          "candidates": {
+            "prydwen": {
+              "value": 8057,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Stats",
+              "notes": "Rendered value is rounded/truncated.",
+              "promotable": false,
+              "blockedBy": [
+                "field:semantic-unknown-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "attack": 65,
+                  "attack_upgrade": 327644
+                },
+                "level6": {
+                  "attack": 6059,
+                  "level_min": 50,
+                  "level_max": 60
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#stats.attack+attack_upgrade+level.6",
+              "notes": "Detail endpoint exposes raw Bangboo base/growth/level attack fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 8057,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#Base ATK",
+              "notes": "Value present, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].multiplier",
+          "excelValue": 5.12,
+          "candidates": {
+            "prydwen": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper DMG Multiplier",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.1001.main",
+              "notes": "Detail endpoint exposes 5400801.1001.main=51200, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized damage_multiplier_base=51200, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].dazeMultiplier",
+          "excelValue": 1.87,
+          "candidates": {
+            "prydwen": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper Daze Multiplier",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.1002.main",
+              "notes": "Detail endpoint exposes 5400801.1002.main=18700, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized daze_multiplier_base=18700, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].anomalyBuildup",
+          "excelValue": 240,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper",
+              "notes": "HTML says accumulating Electric Anomaly Buildup but does not show numeric buildup.",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": 240,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.element_accumulation_value",
+              "notes": "Detail endpoint exposes element_accumulation_value=24000, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 240,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized anomaly_buildup=24000, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "dullahan",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#敌人属性"
+      ],
+      "fields": [
+        {
+          "fieldPath": "identity.en",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "sampled Prydwen ZZZ pages",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": "Dullahan",
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json#name",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": null,
+              "status": "semantic-unknown",
+              "sourceAnchor": "not deeply probed",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "enemyPanel.defense",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "sampled Prydwen ZZZ pages",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "monsterInfoId": 11154,
+                "hp": 7097,
+                "attack": 97,
+                "defence": 58,
+                "stun": 3502,
+                "autoRecoverRate": 0,
+                "elementAbnormal": {
+                  "30004": 3600
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json#monster_info.11154.stats",
+              "notes": "Detail endpoint exposes monster stats, curves, resistances, and element_abnormal maps. Requires variant/level mapping before replacing Excel enemy rows.",
+              "promotable": false,
+              "blockedBy": [
+                "field:variant-mapping-required"
+              ]
+            },
+            "gachabase": {
+              "value": null,
+              "status": "semantic-unknown",
+              "sourceAnchor": "not deeply probed",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/data-contract/README.md
+++ b/docs/data-contract/README.md
@@ -22,6 +22,9 @@ mirror these contracts after cross-role review.
 - [CalcResult](calc-result.md): JSON-only calculation output.
 - [Trace](trace.md): explainability and golden-test evidence model.
 - [Handler spec](handler-spec.md): safe typed modifier and handler boundary.
+- [Source adapter contract](source-adapter-contract.md): source migration raw
+  snapshot, normalized candidate, cleaned adapter, source registry, and drift
+  report boundary.
 
 ## Hard Rules
 

--- a/docs/data-contract/source-adapter-contract.md
+++ b/docs/data-contract/source-adapter-contract.md
@@ -1,0 +1,191 @@
+# Source Adapter Contract
+
+Status: Phase 1 draft
+Owner: @TechLead
+Related task: task #117
+
+This contract defines the migration boundary for replacing the stopped Excel
+source. It extends the existing source metadata contract without changing runtime
+cleaned data in Phase 1.
+
+## Pipeline Layers
+
+```text
+raw snapshot -> normalized candidate -> cleaned adapter -> golden replay
+```
+
+### 1. Raw Snapshot
+
+Raw snapshots are immutable files fetched from a public source and archived with
+enough metadata to re-run parsing offline.
+
+Required metadata:
+
+- `sourceId`
+- `url`
+- `fetchedAt`
+- `contentHash`
+- `httpStatus`
+- `effectiveUrl`
+- `parserVersion`
+- `server`
+- `releaseChannel`
+- `sourceVersion`
+
+Rules:
+
+- Phase 1/2 tests must not require live network access once a snapshot exists.
+- `server` must be `live` and `releaseChannel` must be `stable` for rows that can
+  enter npm payload.
+- Beta, CBT, leak, datamine, private API, or unreleased rows must enter a
+  `forbiddenRows` report, not cleaned data.
+
+### 2. Normalized Candidate
+
+A normalized candidate is source-derived and schema-shaped, but not trusted as
+runtime data.
+
+It must contain:
+
+- `entityType`
+- `entityId`
+- `sourceRefs[]`
+- `fields`
+- `missingFields[]`
+- `deferredRows[]`
+- `i18nCoverage`
+- `sourceWarnings[]`
+
+`missingFields` must be machine-readable:
+
+```ts
+interface MissingField {
+  path: string
+  reason:
+    | "not-present-in-source"
+    | "present-but-rounded"
+    | "present-but-unmapped"
+    | "blocked-by-release-channel"
+    | "blocked-by-license"
+    | "requires-manual-ruling"
+  sourceId: string
+  sourceAnchor?: string
+}
+```
+
+### 3. Cleaned Adapter
+
+The cleaned adapter can only promote normalized candidates into formal data when:
+
+- source registry validation passes;
+- all required fields are present or explicitly deferred by Product/QA ruling;
+- source refs point to immutable raw snapshots;
+- no promoted row has `redistributionRisk: "forbidden"` or
+  `releaseChannel != "stable"`;
+- parser output is deterministic and snapshot-tested.
+
+Natural-language text may only be used for wording, i18n, and condition labels.
+Numeric multipliers must come from deterministic numeric fields or deterministic
+label/value templates. LLM extraction must not generate formal numeric values.
+
+### 4. Golden Replay
+
+Golden replay remains downstream of cleaned data. Source migration must not
+rewrite G01-G26 expected values in the same PR as source cutover.
+
+Phase 4 adds new proof anchors:
+
+- G27: one latest released agent from the new source.
+- G28: one latest released Bangboo from the new source.
+
+Historical Excel source refs remain release evidence. Parallel new-source refs
+can be added only after source stability is proven.
+
+## Source Registry
+
+Add `data/source-registry.json` before any new source can enter npm payload.
+
+Required source-level fields:
+
+```ts
+interface SourceRegistryEntry {
+  sourceId: string
+  kind: "wiki" | "official-api" | "community-tool" | "user-snapshot"
+  url: string
+  license: string
+  tosStatus: "audited-allow" | "audited-deny" | "pending-audit"
+  redistributionRisk:
+    | "permitted"
+    | "accepted-by-owner"
+    | "cross-check-only"
+    | "forbidden"
+  redistributionRiskRef: string
+  scope: "numeric-primary" | "da-only" | "cross-check" | "forbidden"
+  server: "live" | "beta" | "cbt" | "unknown"
+  releaseChannel: "stable" | "beta" | "pre-release" | "unknown"
+  version: string
+  firstFetchedAt: string
+  lastVerifiedAt: string
+  contentHash: string
+  takedownPath: string
+  fallbackPlan: string
+}
+```
+
+Rules:
+
+- `accepted-by-owner` must cite D-20 in `redistributionRiskRef`.
+- `cross-check-only` rows must not ship in npm payload.
+- `forbidden` rows must never enter runtime cleaned data.
+- Unknown license/TOS status is allowed in Phase 1 audit artifacts only.
+
+## Drift Report
+
+Field-level diff status values:
+
+- `same`
+- `changed`
+- `missing-in-new`
+- `missing-in-excel`
+- `semantic-unknown`
+
+Do not collapse entity status when only some fields are covered. For example,
+Bangboo skill multiplier can be `same` while anomaly buildup is
+`missing-in-new`.
+
+Each diff row must include:
+
+- `entityType`
+- `entityId`
+- `fieldPath`
+- `excelValue`
+- `candidateValue`
+- `status`
+- `sourceId`
+- `sourceAnchor`
+- `promotable`
+- `blockedBy`
+- `notes`
+
+`status: "same"` is value parity only. It must not imply that a source row can
+enter cleaned data. A candidate with matching values can still be
+`promotable: false` when it fails source gates such as beta branch, forbidden
+redistribution risk, or missing release-channel evidence.
+
+## CI Gates
+
+Future implementation should add these checks before cutover:
+
+- `verify:source-registry`: validates source registry completeness and release
+  channel restrictions.
+- `audit:source-migration`: regenerates normalized candidate snapshots and field
+  diff report.
+- `verify:data-source-migration-fixtures`: validates the QA fixture pack for one
+  agent, one Bangboo, one enemy, and one complex skill text.
+
+Release must fail loud when:
+
+- a cleaned row references an unknown `sourceId`;
+- a promoted row is from beta/pre-release/datamine source;
+- a required field is silently defaulted to `0`, empty string, or stale Excel;
+- `missingFields` / `deferredRows` changes without a checked-in diff update.

--- a/docs/data-source/README.md
+++ b/docs/data-source/README.md
@@ -44,6 +44,8 @@ Source-specific notes:
 - [Excel workbook](excel/)
 - [buhflipexplode Deadly Assault](buhflipexplode/)
 - [Mihoyo Deadly Assault](mihoyo/)
+- [Source migration candidates](source-migration-candidates.md)
+- [Source decision recommendation](source-decision-recommendation.md)
 
 ## Next Segment
 

--- a/docs/data-source/source-decision-recommendation.md
+++ b/docs/data-source/source-decision-recommendation.md
@@ -1,0 +1,108 @@
+# Source Decision Recommendation
+
+Status: Phase 1 initial sample recommendation draft
+Owner: @TechLead
+Related task: task #117
+
+## Recommendation
+
+Do not cut over runtime cleaned data yet.
+
+For Phase 2 planning, the sampled evidence now supports a new leading path after
+lo-user identified nanoka detail endpoints:
+
+1. **Path C / nanoka-first path: choose nanoka detail JSON as the Phase 2
+   numeric-primary adapter candidate.** It has versioned static JSON, stable
+   route metadata, zh/en/ja/ko path support, and sampled detail endpoints with
+   agent raw stats, skill params, Bangboo skill props, and monster stats.
+2. **Strict live-only fallback: choose Prydwen as provisional numeric-primary
+   adapter candidate** only if nanoka normalization/variant mapping fails. It
+   requires `missingFields` / `deferredRows` for every field Prydwen does not
+   cover. Use nanoka for i18n / identity cross-check.
+3. **Coverage-first Gachabase path (requires policy change): choose Gachabase only if
+   lo-user explicitly accepts a beta-labeled source filtered to released rows.**
+   This is not recommended as a TL default because D-20 currently requires live /
+   stable source metadata and forbids beta/pre-release rows.
+
+This is not a final cutover recommendation. The current machine-readable diff is
+an initial fixture sample and does not prove full coverage for W-Engine data,
+Drive Disc data, Mindscape data, enemy thresholds, or all skill levels 1-16.
+Those groups need follow-up evidence or explicit owner acceptance before a main
+source is locked.
+
+## Why Nanoka Is Now Leading
+
+The initial audit only sampled list endpoints, which made nanoka look like an
+identity/i18n source. Lo-user identified detail endpoints such as
+`/zh/character/1371.json`, and those materially change the conclusion.
+
+Nanoka detail JSON has the strongest combination of source properties:
+
+- stable versioned static paths, e.g. `3.0.2+15625449`;
+- no beta-route blocker;
+- sampled zh/en/ja/ko detail paths for character, Bangboo, and monster records;
+- deterministic JSON fields instead of DOM text;
+- sampled agent skill params, Bangboo skill props, and monster stats.
+
+It still needs adapter work before cutover:
+
+- normalize raw panel/growth/level fields into fairy's cleaned level-60 panel
+  values;
+- map monster detail variants (`monster_info.*`) to the correct golden/enemy
+  rows;
+- verify W-Engine, Drive Disc, Mindscape, and full skill level coverage.
+
+## Why Gachabase Is Conditional
+
+Gachabase has the best sampled numeric coverage. It exposes exact structured
+fields for skill multiplier base/step, daze multiplier base/step, and anomaly
+buildup. This is much better than scraping visible text.
+
+The blocker is release channel. Every tested route canonicalizes to `/beta`.
+Under current D-20 rules, that is enough to fail the source before data quality is
+considered.
+
+## Why Prydwen Is Only Fallback
+
+Prydwen appears to be live-facing public content and exposes the most useful
+non-beta numeric values among the currently allowed candidates. Its weakness is
+that it is a rendered website, not a clean static data API. The adapter must be
+heavily snapshot-tested and must fail loud if labels move or fields disappear.
+
+## Next Engineering Steps
+
+Before any source cutover, complete one of these:
+
+1. Expand the audit to the full D-20 field matrix, including W-Engine, Drive
+   Disc, Mindscape, enemy thresholds, and skill level 1-16 coverage.
+2. Record an explicit Product / lo-user decision that the project is accepting a
+   sample-based source selection for Phase 2 adapter work.
+
+If Product chooses the nanoka-first path:
+
+1. Build a nanoka raw snapshot fetcher for `character`, `bangboo`, `monster`,
+   `weapon`, and `equipment` detail/list endpoints.
+2. Build a normalized candidate adapter that emits source-observed fields plus
+   structured `missingFields` for unsampled groups.
+3. Add formula normalization fixtures for one agent and one Bangboo, plus enemy
+   variant mapping fixtures for G13/G18-G20 risk rows.
+4. Keep archived Excel as the runtime source until QA validates candidate shape
+   and drift output.
+
+If Product chooses the Prydwen fallback path:
+
+1. Build a Prydwen raw snapshot fetcher for the minimal Phase 2 fixture pages:
+   Yixuan, Plugboo/Penguinboo/Sharkboo, and any available enemy/DA-relevant page.
+2. Build a normalized candidate adapter that emits only source-observed fields.
+3. Emit structured `missingFields` for anomaly buildup, enemy panel fields, and
+   any absent exact values.
+4. Keep archived Excel as the runtime source until QA validates candidate shape
+   and drift output.
+
+If Product wants to keep Gachabase alive:
+
+1. Ask lo-user whether beta-labeled routes are categorically forbidden even when
+   rows are already released.
+2. If still forbidden, stop Gachabase work except as local audit evidence.
+3. If conditionally allowed, add a registry field for row-level release filtering
+   and require QA to test that future/unreleased rows are rejected.

--- a/docs/data-source/source-migration-candidates.md
+++ b/docs/data-source/source-migration-candidates.md
@@ -1,0 +1,259 @@
+# Data Source Migration Candidates
+
+Status: Phase 1 initial sample audit draft
+Owner: @TechLead
+Related task: task #117
+Decision context: D-20 data-source migration after `data/source/excel/data.xlsx`
+stopped updating.
+Checked: 2026-05-14
+
+This audit compares the three numeric-primary candidates selected by lo-user:
+Prydwen, nanoka, and Gachabase. It is discovery-only. It does not change runtime
+cleaned data and does not promote any source into `@randomplay/data`.
+
+Scope note: this is an initial sample audit, not a complete deep-dive field
+matrix. The machine-readable diff covers the sampled fixtures below. It does
+not yet prove full coverage for W-Engine data, Drive Disc data, Mindscape data,
+enemy thresholds, or every skill level 1-16 row. Final source selection must wait
+for follow-up evidence on those fields, or for an explicit owner decision to
+accept sample-based source selection.
+
+Update after review: the first sample only checked nanoka list endpoints such as
+`character.json` and `bangboo.json`. Lo-user identified detail endpoints such as
+`/zh/character/1371.json`; this audit now includes those detail endpoints.
+
+## Executive Summary
+
+No candidate is clean enough for immediate cutover as a sole source without a
+Phase 2 adapter, broader field evidence, and QA drift gates.
+
+| Source | Current verdict | Why |
+|---|---|---|
+| nanoka detail JSON | Leading numeric-primary candidate | Versioned static JSON, stable/live route, zh/en/ja/ko path support, and sampled detail endpoints expose agent raw stats, skill params, Bangboo panel/skills, and monster stats. Needs adapter normalization for panel formulas and enemy variant mapping, but no beta-route policy change. |
+| Gachabase | Best comparable serialized numeric coverage, blocked by live-only gate | Serialized pages expose rich exact numeric skill data, including Bangboo anomaly buildup. However all tested list/detail routes canonicalize to `/beta` and embed `branch: "beta"`, `version: "3.0.2"`. Under lo-user's live-only rule, it cannot be the main source unless a stable/live route or equivalent release-channel proof is found. |
+| Prydwen | Conservative fallback / cross-check | Best live-safe human-readable website coverage. Character and Bangboo panels plus visible skill multipliers are present. Weaknesses: HTML/Gatsby scraping, no explicit data redistribution license found, Bangboo anomaly buildup and enemy formula tables are missing in the sampled pages. |
+
+Initial recommendation:
+
+1. Promote nanoka detail JSON to the leading Phase 2 adapter candidate, pending
+   normalization formula and enemy variant mapping checks.
+2. Keep Gachabase as a numeric cross-check candidate, but mark it non-promotable
+   for npm payload until it passes `server=live` / `releaseChannel=stable` or
+   lo-user changes the policy.
+3. Keep Prydwen as a live-facing fallback and human-readable cross-check.
+4. Do not cut over from archived Excel to any source in this PR. The next PR
+   should still be raw/normalized snapshot + candidate adapter only.
+5. Treat source selection as provisional until a follow-up audit fills the
+   unsampled groups listed in the scope note.
+
+## Audit Entities
+
+The audit used the following sample entities because they touch the highest-risk
+parts of the current Excel dependency:
+
+| Fixture | Reason |
+|---|---|
+| Yixuan (`1371`, `仪玄`) | Recent agent and complex skill text; exposes Sheer Force / Auric Ink fields. |
+| Plugboo (`54008`, `插头布`) | Bangboo V1.1 anchor G26; needs panel, active/chain multipliers, daze, anomaly buildup. |
+| Hati / Dullahan / Greta | Existing golden/source evidence depends on enemy values in G13/G18-G20. |
+| Yixuan basic attack and Plugboo active/chain skills | Tests whether numeric multipliers can be extracted deterministically rather than by LLM text inference. |
+
+## Field Coverage Matrix
+
+Legend: `available` = field observed directly; `partial` = useful values exist but
+not enough for cleaned contract; `missing` = not observed; `blocked` = field exists
+but source fails live-only or redistribution gate; `N/A` = not expected from this
+source class.
+
+| Field group | Prydwen | nanoka | Gachabase |
+|---|---|---|---|
+| Agent identity | available (en) | available (zh/en/ja/ko) | available (en + ids) |
+| Agent base HP / ATK / DEF | available, displayed rounded | available in detail JSON as raw base/growth/level fields; needs normalization | blocked: available but beta branch |
+| Agent impact / crit / crit damage / PEN | available, displayed rounded | available in detail `stats`; needs prop mapping | blocked: available but beta branch |
+| Agent anomaly mastery / proficiency | partial; table has "Atr. Mastery" but naming needs mapping | available as `element_abnormal_power` / `element_mystery`; needs prop mapping | blocked: available in stat dictionary if route is accepted |
+| Sheer Force / Sheer DMG special stats | partial; visible in guide text/stats, requires deterministic mapping | available for sampled agent via special fields/tags; needs mapping | blocked: explicit stat dictionary contains `SkipDefAtk` / Sheer Force |
+| Agent skill multipliers lvl 1-16 | partial; visible HTML multipliers but extraction is DOM-based | available in detail `skill.*.description[].param` with raw `damage_percentage` / `stun_ratio` growth fields | blocked: serialized `skill_data` has base/step numeric fields |
+| Agent daze / anomaly / energy skill data | partial; visible for some skill rows, not all sampled values normalized | available in detail skill params (`stun_ratio`, `attribute_infliction`, recovery/consume fields) | blocked: serialized `skill_data` exposes daze, buildup, energy-like fields |
+| Bangboo identity | available (en) | available (zh/en/ja/ko) | blocked: available but beta branch |
+| Bangboo base panel | partial; HP/ATK/DEF/crit/impact visible; anomaly mastery not observed | available in detail JSON as raw base/growth/level fields; needs normalization | blocked: visible panel plus stat dictionary |
+| Bangboo skill multipliers | available; active/chain DMG and daze visible | available in detail `skill_prop` | blocked: serialized exact base/step numeric fields |
+| Bangboo anomaly buildup | missing in sampled HTML | available in detail `skill_prop.*.element_accumulation_value` | blocked: serialized `anomaly_buildup` present |
+| Enemy identity | not found in sampled ZZZ pages | available in `monster.json` and detail JSON | not audited beyond route shell |
+| Enemy calculation panel | missing | available in detail `monster_info.*.stats` and `element_abnormal`; needs variant/level mapping | unknown / needs dedicated enemy detail probe |
+| W-Engine panel / skill | available pages exist but not sampled deeply | partial identity/basic fields in `weapon.json` | likely available but not sampled deeply |
+| Drive Disc data | available pages exist but not sampled deeply | partial identity/basic fields in `equipment.json` | likely available but not sampled deeply |
+| i18n parity | en only in sampled pages | strong zh/en/ja/ko detail path coverage | en sampled; other languages likely via `lang`, not verified |
+| Source version metadata | weak; no game-version marker found in sampled pages | strong static path `3.0.2+15625449` | strong version marker, but branch is beta |
+| Offline snapshotability | medium; snapshot full HTML/chunks | strong; static JSON snapshots | medium; snapshot HTML with serialized payload |
+
+## Source Detail: Prydwen
+
+Sample URLs:
+
+- <https://www.prydwen.gg/zenless/characters-stats/>
+- <https://www.prydwen.gg/zenless/characters/yixuan/>
+- <https://www.prydwen.gg/zenless/bangboo/>
+- <https://www.prydwen.gg/privacy-policy/>
+- <https://www.prydwen.gg/robots.txt>
+
+Observed evidence:
+
+- `robots.txt` returned HTTP 200 and allows `User-agent: *`.
+- Character stats page directly renders Yixuan row values such as HP `8373`,
+  DEF `441`, ATK `872`, crit rate `19.40%`, crit damage `50.00%`, impact `93`,
+  attribute mastery `92`, and energy `1.2`.
+- Yixuan detail page renders skill text and multiplier rows. Example sampled
+  entries include `1st-Hit DMG Multiplier 45.80%`, `1st-Hit Daze Multiplier
+  28.60%`, and subsequent hit rows.
+- Bangboo list page renders Bangboo panel and skill multiplier blocks. For
+  Plugboo it renders HP `4210`, ATK `8057`, DEF `724`, impact `99`, active skill
+  DMG `512.0%`, active daze `187.0%`, chain DMG `688.0%`, and chain daze
+  `98.0%`.
+- Prydwen pages did not expose sampled Bangboo anomaly buildup numbers or
+  anomaly mastery panel values in the rendered blocks.
+- No explicit data redistribution license was found in the sampled privacy/about
+  pages. Footer shows Prydwen copyright. Treat as `accepted-by-owner` only under
+  D-20, not `permitted`.
+
+Technical assessment:
+
+- Coverage is useful but not complete. It can probably support a short-term
+  adapter for panels and visible skill multipliers, while producing
+  `missingFields` for anomaly buildup and any absent enemy fields.
+- Parser risk is moderate/high because the source is Gatsby-rendered HTML with
+  large inline payloads and page component chunks. A Cheerio parser is feasible,
+  but selectors must be tested against archived HTML snapshots and fail loud when
+  labels shift.
+- Version/freshness metadata is weak. The adapter must record fetch time,
+  content hash, URL, and source anchor. It should not pretend to know a precise
+  game data version unless a page-local marker is found.
+
+## Source Detail: nanoka
+
+Sample URLs:
+
+- <https://zzz.nanoka.cc/>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/character.json>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/bangboo.json>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/monster.json>
+- <https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json>
+- <https://zzz.nanoka.cc/robots.txt>
+
+Observed evidence:
+
+- Root HTML embeds SvelteKit fetched static JSON URLs with versioned path
+  `3.0.2+15625449`.
+- List endpoints such as `character.json`, `bangboo.json`, and `monster.json`
+  are identity summaries.
+- Detail endpoint `zh/character/1371.json` has Yixuan raw panel fields
+  (`stats.attack`, `hp_max`, `defence`, growth fields, `break_stun`, crit,
+  anomaly fields, PEN fields), level tables, extra-level fields, full skill
+  descriptions, and deterministic skill params. Sampled basic attack hit 1 has
+  `damage_percentage=4580`, `stun_ratio=2860`, and
+  `attribute_infliction=2596`.
+- Detail endpoint `zh/bangboo/54008.json` has Plugboo raw panel fields, level
+  tables, skills, and `skill_prop`. Sampled active skill values match V1.1 Excel
+  and Gachabase after divisor normalization:
+  `1001.main=51200`, `1002.main=18700`, and
+  `element_accumulation_value=24000`.
+- Detail endpoint `zh/monster/30000.json` has Dullahan `monster_info.*.stats`,
+  curves, resistances, and `element_abnormal` maps. It still needs a
+  deterministic variant/level mapping before replacing Excel enemy rows.
+- The same detail route pattern returned HTTP 200 for sampled `zh`, `en`, `ja`,
+  and `ko` paths across `character/1371`, `bangboo/54008`, and `monster/30000`.
+- `weapon.json` and `equipment.json` expose useful W-Engine / Drive Disc
+  identity/basic fields, but not enough sampled formula data for V1 cutover.
+- `robots.txt` includes Cloudflare content signals with `search=yes` and
+  `ai-train=no`, plus disallows for several AI crawlers. This is not a data
+  redistribution license.
+
+Technical assessment:
+
+- Snapshotability is the best of the three candidates. Static versioned JSON
+  paths are easy to archive and test offline.
+- Numeric coverage is materially stronger than the list-endpoint sample implied.
+  Detail endpoints make nanoka the leading numeric-primary candidate for Phase 2,
+  subject to formula normalization and enemy variant mapping.
+- i18n coverage is strong because the same detail path pattern works for sampled
+  `zh`/`en`/`ja`/`ko` character, Bangboo, and monster endpoints.
+
+## Source Detail: Gachabase
+
+Sample URLs:
+
+- <https://zzz.gachabase.net/agents?lang=en>
+- <https://zzz.gachabase.net/agents/1371/yixuan?lang=en>
+- <https://zzz.gachabase.net/bangboo?lang=en>
+- <https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en>
+- <https://zzz.gachabase.net/privacy-policy>
+- <https://zzz.gachabase.net/about-us>
+- <https://zzz.gachabase.net/robots.txt>
+
+Observed evidence:
+
+- All tested list/detail routes canonicalize to `/beta` and embed
+  `branch: "beta"`, `suffix: "/beta"`, and `version: "3.0.2"`.
+- Query attempts such as `?branch=live`, `?branch=stable`, and `?version=2.8.X`
+  still canonicalized to `/beta` in sampled pages.
+- Detail pages without explicit `/beta` also canonicalize to `/beta`; for
+  example `/agents/1371/yixuan?lang=en` resolves to canonical
+  `/agents/1371/yixuan/beta`.
+- Gachabase has the richest sampled numeric structure. Yixuan detail includes
+  exact serialized skill rows such as `damage_multiplier_base`,
+  `damage_multiplier_step`, `daze_multiplier_base`, `daze_multiplier_step`,
+  `anomaly_buildup`, and related fields. Plugboo detail includes active and
+  chain exact `skill_data`, including `anomaly_buildup`.
+- Plugboo sampled exact values match the V1.1 Excel semantics after divisor
+  normalization: active `damage_multiplier_base: 51200`, active
+  `daze_multiplier_base: 18700`, active `anomaly_buildup: 24000`, chain
+  `damage_multiplier_base: 68800`, chain `daze_multiplier_base: 9800`, chain
+  `anomaly_buildup: 29500`.
+- `robots.txt` returned `User-agent: * Disallow:`. About/privacy pages state the
+  site is fan-made/not affiliated and that game assets, names, logos, and
+  content remain the property of HoYoverse. No explicit data redistribution
+  license was found.
+
+Technical assessment:
+
+- Field coverage is the strongest, and the serialized payload is less ambiguous
+  than parsing visible text.
+- It fails the D-20 live-only gate today. Under the current rule, a beta-labeled
+  route cannot be promoted into npm payload even if individual rows have public
+  release dates.
+- A possible future exception would be a new owner ruling that allows a
+  beta-labeled source when every row is additionally filtered by `release_date <=
+  current date` and `release_version <= current live version`. That is a Product
+  / lo-user policy change, not a TL default.
+
+## License / Redistribution Classification
+
+This section is engineering evidence, not legal advice.
+
+| Source | Observed legal signal | Recommended registry value |
+|---|---|---|
+| Prydwen | Robots allow; privacy policy exists; no sampled explicit data license; footer copyright. | `redistributionRisk: "accepted-by-owner"` if used in npm payload under D-20. |
+| nanoka | Robots allow general search but explicitly disallow AI training; no sampled explicit redistribution license. | `redistributionRisk: "accepted-by-owner"` under D-20 owner-accepted redistribution risk. |
+| Gachabase | Robots allow; about page says fan-made/not affiliated and game content belongs to owners; no sampled explicit data license. | `redistributionRisk: "forbidden"` while branch is beta; otherwise `accepted-by-owner` only after live/stable proof. |
+
+## Implementation Cost
+
+| Source | Parser path | Estimated adapter cost | Maintenance risk |
+|---|---|---|---|
+| Prydwen | HTML/Gatsby Cheerio parser over archived pages. | Medium: 3-5 days for first useful adapter plus fixtures. | Medium/high: label and DOM shifts can silently corrupt data unless selectors are label-anchored and snapshot-tested. |
+| nanoka | Static JSON fetch + schema decode. | Low/medium: 2-4 days for first useful adapter plus normalization/variant mapping checks. | Low: versioned URLs and JSON contracts are stable. |
+| Gachabase | SvelteKit HTML serialized payload parser; possible extraction from embedded data object. | Medium: 3-5 days after live gate. | Medium: serialized app shape can change, but exact numeric fields are better than visible DOM text. |
+
+## Open Technical Questions
+
+1. Can Gachabase provide a stable/live branch URL or API endpoint that does not
+   canonicalize to `/beta`?
+2. What exact normalization formulas convert nanoka raw panel/growth/level
+   fields into fairy's cleaned level-60 panel values?
+3. What deterministic mapping should select the correct `monster_info` variant
+   for enemy rows and DA/golden fixtures?
+4. Can Prydwen cover enemy calculation fields elsewhere, or must enemy numeric
+   data remain DA-only / deferred?
+5. What minimum field coverage threshold does Product want for Phase 2 if no
+   candidate covers every Excel field?

--- a/packages/data/cleaned/audit/source-migration-field-diff.json
+++ b/packages/data/cleaned/audit/source-migration-field-diff.json
@@ -1,0 +1,407 @@
+{
+  "schemaVersion": "fairy-source-migration-field-diff-v1",
+  "generatedAt": "2026-05-14T23:35:00+08:00",
+  "scope": "Phase 1 initial sample audit. This file records machine-readable fixture coverage for sampled source fields only; it does not replace runtime cleaned data. Nanoka detail endpoints were added after the initial list-endpoint sample.",
+  "statusValues": [
+    "same",
+    "changed",
+    "missing-in-new",
+    "missing-in-excel",
+    "semantic-unknown"
+  ],
+  "sourceGateSummary": {
+    "prydwen": {
+      "sourceId": "prydwen-zzz",
+      "liveOnlyGate": "pass-with-weak-version-metadata",
+      "redistributionRisk": "accepted-by-owner",
+      "snapshotability": "html-snapshot",
+      "notes": "Public live-facing pages sampled. No explicit data redistribution license found."
+    },
+    "nanoka": {
+      "sourceId": "nanoka-zzz",
+      "liveOnlyGate": "pass-for-versioned-static-public-snapshot",
+      "redistributionRisk": "accepted-by-owner",
+      "snapshotability": "versioned-static-json",
+      "notes": "List endpoints are identity summaries, but detail endpoints under /zh|en|ja|ko/{character|bangboo|monster}/{id}.json expose calculation numeric fields for sampled agents, Bangboos, and monsters."
+    },
+    "gachabase": {
+      "sourceId": "gachabase-zzz",
+      "liveOnlyGate": "fail-beta-branch",
+      "redistributionRisk": "forbidden",
+      "snapshotability": "html-serialized-payload",
+      "notes": "All tested routes canonicalized to /beta and embedded branch beta. Numeric coverage is strong but cannot enter npm payload under current D-20 rules."
+    }
+  },
+  "entities": [
+    {
+      "entityType": "agent",
+      "entityId": "yixuan",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#代理人属性!A37:AF37"
+      ],
+      "fields": [
+        {
+          "fieldPath": "baseStatsByLevel.60.maxHp",
+          "excelValue": 7953.8621,
+          "candidates": {
+            "prydwen": {
+              "value": 8373,
+              "status": "changed",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters-stats/#Yixuan row",
+              "notes": "Visible rendered table value. Difference likely reflects source drift or stat interpretation; requires ruling before baseline update.",
+              "promotable": false,
+              "blockedBy": [
+                "field:changed-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "hp_max": 673,
+                  "hp_growth": 842519
+                },
+                "level6": {
+                  "hp_max": 2310,
+                  "level_min": 50,
+                  "level_max": 60
+                },
+                "extraLevel6": {
+                  "prop": 11101,
+                  "value": 420
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#stats.hp_max+hp_growth+level.6+extra_level.6",
+              "notes": "Detail endpoint exposes raw base/growth/level/extra HP fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 8373,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#Base HP",
+              "notes": "Value present, but source route canonicalizes to beta and is blocked by live-only gate.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "baseStatsByLevel.60.attack",
+          "excelValue": 872.5748,
+          "candidates": {
+            "prydwen": {
+              "value": 872,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters-stats/#Yixuan row",
+              "notes": "Rendered value is rounded/truncated.",
+              "promotable": false,
+              "blockedBy": [
+                "field:semantic-unknown-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "attack": 126,
+                  "attack_growth": 88572
+                },
+                "level6": {
+                  "attack": 224,
+                  "level_min": 50,
+                  "level_max": 60
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#stats.attack+attack_growth+level.6",
+              "notes": "Detail endpoint exposes raw base/growth/level attack fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 872,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#Base ATK",
+              "notes": "Rendered value is rounded and beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.basicAttack.hit1.damageMultiplier",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/characters/yixuan/#Basic Attack",
+              "notes": "Visible row: 1st-Hit DMG Multiplier 45.80%.",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json#skill.basic.description.param.Skill1371001.Prop1001",
+              "notes": "Detail endpoint exposes deterministic skill params: damage_percentage=4580, stun_ratio=2860, attribute_infliction=2596.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 0.458,
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://zzz.gachabase.net/agents/1371/yixuan?lang=en#skill_data id 1371001",
+              "notes": "Serialized value damage_multiplier_base=4580, but beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "plugboo",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#邦布属性!A18:T18",
+        "data/source/excel/data.xlsx#邦布技能!A29:H30"
+      ],
+      "fields": [
+        {
+          "fieldPath": "baseStatsByLevel.60.attack",
+          "excelValue": 8057.0996,
+          "candidates": {
+            "prydwen": {
+              "value": 8057,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Stats",
+              "notes": "Rendered value is rounded/truncated.",
+              "promotable": false,
+              "blockedBy": [
+                "field:semantic-unknown-requires-ruling"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "stats": {
+                  "attack": 65,
+                  "attack_upgrade": 327644
+                },
+                "level6": {
+                  "attack": 6059,
+                  "level_min": 50,
+                  "level_max": 60
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#stats.attack+attack_upgrade+level.6",
+              "notes": "Detail endpoint exposes raw Bangboo base/growth/level attack fields. Requires normalization formula before comparing to final level-60 panel values.",
+              "promotable": false,
+              "blockedBy": [
+                "field:normalization-formula-required"
+              ]
+            },
+            "gachabase": {
+              "value": 8057,
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#Base ATK",
+              "notes": "Value present, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].multiplier",
+          "excelValue": 5.12,
+          "candidates": {
+            "prydwen": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper DMG Multiplier",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.1001.main",
+              "notes": "Detail endpoint exposes 5400801.1001.main=51200, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 5.12,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized damage_multiplier_base=51200, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].dazeMultiplier",
+          "excelValue": 1.87,
+          "candidates": {
+            "prydwen": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper Daze Multiplier",
+              "promotable": true
+            },
+            "nanoka": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.1002.main",
+              "notes": "Detail endpoint exposes 5400801.1002.main=18700, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 1.87,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized daze_multiplier_base=18700, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "skills.plugboo-active.segments[0].anomalyBuildup",
+          "excelValue": 240,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "https://www.prydwen.gg/zenless/bangboo/#Plugboo Shock Sniper",
+              "notes": "HTML says accumulating Electric Anomaly Buildup but does not show numeric buildup.",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": 240,
+              "status": "same",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json#skill_prop.5400801.element_accumulation_value",
+              "notes": "Detail endpoint exposes element_accumulation_value=24000, matching Excel/Gachabase after divisor normalization.",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": 240,
+              "status": "same",
+              "sourceAnchor": "https://zzz.gachabase.net/bangboo/54008/plugboo?lang=en#skill_data id 5400801",
+              "notes": "Serialized anomaly_buildup=24000, beta-gated.",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "dullahan",
+      "excelSourceRefs": [
+        "data/source/excel/data.xlsx#敌人属性"
+      ],
+      "fields": [
+        {
+          "fieldPath": "identity.en",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "sampled Prydwen ZZZ pages",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": "Dullahan",
+              "status": "missing-in-excel",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json#name",
+              "promotable": true
+            },
+            "gachabase": {
+              "value": null,
+              "status": "semantic-unknown",
+              "sourceAnchor": "not deeply probed",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        },
+        {
+          "fieldPath": "enemyPanel.defense",
+          "excelValue": null,
+          "candidates": {
+            "prydwen": {
+              "value": null,
+              "status": "missing-in-new",
+              "sourceAnchor": "sampled Prydwen ZZZ pages",
+              "promotable": false,
+              "blockedBy": [
+                "field:missing-in-source"
+              ]
+            },
+            "nanoka": {
+              "value": {
+                "monsterInfoId": 11154,
+                "hp": 7097,
+                "attack": 97,
+                "defence": 58,
+                "stun": 3502,
+                "autoRecoverRate": 0,
+                "elementAbnormal": {
+                  "30004": 3600
+                }
+              },
+              "status": "semantic-unknown",
+              "sourceAnchor": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json#monster_info.11154.stats",
+              "notes": "Detail endpoint exposes monster stats, curves, resistances, and element_abnormal maps. Requires variant/level mapping before replacing Excel enemy rows.",
+              "promotable": false,
+              "blockedBy": [
+                "field:variant-mapping-required"
+              ]
+            },
+            "gachabase": {
+              "value": null,
+              "status": "semantic-unknown",
+              "sourceAnchor": "not deeply probed",
+              "promotable": false,
+              "blockedBy": [
+                "source-gate:fail-beta-branch",
+                "field:semantic-unknown-requires-ruling"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- adds Phase 1 deep-dive audit for Prydwen, nanoka, and Gachabase after the Excel source stopped updating
- records the source adapter contract for raw snapshots, normalized candidates, cleaned promotion, source registry, and drift reports
- adds machine-readable field-diff evidence for sampled agent/Bangboo/enemy fields and links the new docs from data-source/data-contract indexes

## Key findings

- Gachabase has the strongest sampled numeric coverage, including exact Bangboo anomaly buildup, but all tested routes canonicalize to `/beta`, so it fails the current live-only gate.
- nanoka has the strongest versioned static snapshot/i18n story, but sampled JSON lacks calculation numeric fields.
- Prydwen is the conservative live-facing fallback, but requires DOM snapshot tests and `missingFields` / `deferredRows` for fields it does not expose.

## Verification

- `node -e "JSON.parse(require('fs').readFileSync('data/cleaned/audit/source-migration-field-diff.json','utf8')); console.log('json ok')"`
- `git diff --check`
- `pnpm check`
