### PR TITLE
docs: update nanoka matrix for locked scope

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T00:21:07+08:00",
-  "status": "phase-0-draft",
-  "sourceVersion": "3.0.2+15625449",
+  "generatedAt": "2026-05-15T02:55:00+08:00",
+  "status": "phase-0-r1-r6-locked",
+  "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
     "packages/core/src/schema/battle-snapshot.ts",
@@ -19,8 +19,9 @@
     "nanoka",
     "derived-from-source-registry",
     "implementation-owned",
-    "retained-non-nanoka",
-    "out-of-scope"
+    "archived-audit-baseline",
+    "out-of-scope",
+    "removed-out-of-product-scope"
   ],
   "sampleSources": [
     {
@@ -29,10 +30,12 @@
       "entityId": "1371",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "6cb0a652f92d9daf0e6cd382d757c7755d543f9013defb61799b747aaf2b8868",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-character-nekomata-1021",
@@ -40,10 +43,12 @@
       "entityId": "1021",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1021.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "85186a7568c11ff9f56e2085bf561485f0548ff29fc70e686c8aa3dca2b0f961",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-character-soldier11-1041",
@@ -51,10 +56,12 @@
       "entityId": "1041",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1041.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "8acde3e5c3849a371c5a2fefe32bd38e2b96397067a73e27cd5a69296550fcc1",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-bangboo-plugboo-54008",
@@ -62,10 +69,12 @@
       "entityId": "54008",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "2afc34c8b72b3a7dc6e18d945e83c12784a742817e4ce760ee8c4c17aa3b0261",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-monster-dullahan-30000",
@@ -73,10 +82,12 @@
       "entityId": "30000",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "46eebea2270e748a6057d152a05a3296f2601efaccf299667318025f44bf492a",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-weapon-yixuan-signature-14137",
@@ -84,10 +95,12 @@
       "entityId": "14137",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/weapon/14137.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "a0d7dfe24f24a5cfc623e750c33bbea7aead9952283d670861b9a67e814a667d",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-equipment-woodpecker-31000",
@@ -95,10 +108,64 @@
       "entityId": "31000",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/equipment/31000.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "6af7dcce6a1863b1d801e54621056b2f92baab2c31672a4ed6c2cb1ff3fcf508",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
+    },
+    {
+      "id": "nanoka-manifest",
+      "entityType": "sourceManifest",
+      "entityId": "zzz",
+      "url": "https://static.nanoka.cc/manifest.json",
+      "version": "manifest",
+      "releaseChannel": "source-registry",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "6213ac3b71f5827e850691c2f8547ec6657b7d8ab7e546c50b80252387e613b8",
+      "server": "source-registry",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "live-version-gate"
+    },
+    {
+      "id": "nanoka-character-nekomata-live-1021",
+      "entityType": "agent",
+      "entityId": "1021",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1021.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:32:00+08:00",
+      "contentSha256": "85186a7568c11ff9f56e2085bf561485f0548ff29fc70e686c8aa3dca2b0f961",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-boss-live-index-2.8",
+      "entityType": "deadlyAssaultIndex",
+      "entityId": "boss",
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "3379eba07fe6c77e821dc403fc31a9f304148666ee5f5a51706ac5e203393ec0",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-boss-live-69036",
+      "entityType": "deadlyAssaultPeriod",
+      "entityId": "69036",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "8f31e1f15918797e8e28c8a350fba6934077b73a35855778d8c0a660815d276b",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
     }
   ],
   "rows": [
@@ -108,15 +175,20 @@
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
       "status": "needs-tl-research",
-      "nanokaEndpoint": "https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
-      "rawFieldPaths": [],
-      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, and stable-version allowlist",
-      "sampleEntity": "nanoka-character-yixuan-1371",
+      "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
+      "rawFieldPaths": [
+        "/zzz/live",
+        "/zzz/latest",
+        "/zzz/available"
+      ],
+      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, liveVersionRef=manifest.zzz.live, approvedLiveVersions[], and stable-version allowlist",
+      "sampleEntity": "nanoka-manifest",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
         "source-registry-contract-required",
-        "content-hash-capture-required"
+        "content-hash-capture-required",
+        "live-version-policy-ci-required"
       ]
     },
     {
@@ -127,13 +199,36 @@
       "status": "needs-tl-research",
       "nanokaEndpoint": "all promoted nanoka rows",
       "rawFieldPaths": [],
-      "transformRule": "attach endpoint URL, JSON pointer, and sourceVersion to every promoted field",
+      "transformRule": "attach endpoint URL, JSON pointer, content hash, approved sourceVersion, and liveVersionRef to every promoted field",
       "sampleEntity": "nanoka-bangboo-plugboo-54008",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
-        "adapter-source-ref-emission-required"
+        "adapter-source-ref-emission-required",
+        "json-pointer-convention-required"
       ]
+    },
+    {
+      "fieldId": "metadata.snapshotDiffHistory",
+      "canonicalPath": "planned GameData.sources[].snapshotDiffHistory / package audit metadata",
+      "fieldClass": "derived",
+      "sourcePolicy": "derived-from-source-registry",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and approved versioned nanoka snapshots",
+      "rawFieldPaths": [
+        "/zzz/available",
+        "/zzz/live",
+        "/zzz/latest"
+      ],
+      "transformRule": "R4.a: derive numeric patch history by diffing approved-live snapshot hashes and raw JSON paths; latest/pre-release snapshots are research-only unless lo-user approves them",
+      "sampleEntity": "nanoka-manifest",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "snapshot-diff-tool-required",
+        "approved-live-version-allowlist-required"
+      ],
+      "notes": "No dedicated patch-note/changelog prose endpoint was found in PR #54. This row represents snapshot-derived numeric diff history only."
     },
     {
       "fieldId": "metadata.aliases",
@@ -362,6 +457,86 @@
       "promotable": false,
       "blockedBy": [
         "typed-modifier-template-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.rpMax",
+      "canonicalPath": "planned V0.1.0 GameData.agents.*.sentinel.rpMax / AgentSnapshot.panel",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/stats/rp_max"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.rpRecover",
+      "canonicalPath": "planned V0.1.0 GameData.agents.*.sentinel.rpRecover / AgentSnapshot.panel",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/stats/rp_recover"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.skillFeverRecovery",
+      "canonicalPath": "planned V0.1.0 GameData.skills.*.sentinel.feverRecovery",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/skill/*/description/*/param/*/param/*/fever_recovery",
+        "/skill/*/description/*/param/*/param/*/fever_recovery_growth"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming, level-growth handling, and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required",
+        "field:skill-level-growth-transform-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.skillRpRecovery",
+      "canonicalPath": "planned V0.1.0 GameData.skills.*.sentinel.rpRecovery",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/skill/*/description/*/param/*/param/*/rp_recovery",
+        "/skill/*/description/*/param/*/param/*/rp_recovery_growth"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming, level-growth handling, and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required",
+        "field:skill-level-growth-transform-required"
       ]
     },
     {
@@ -733,36 +908,38 @@
       ]
     },
     {
-      "fieldId": "resonium.lostVoid",
-      "canonicalPath": "GameData.resonium",
-      "fieldClass": "deferred",
-      "sourcePolicy": "out-of-scope",
-      "status": "deferred",
-      "nanokaEndpoint": null,
-      "rawFieldPaths": [],
-      "transformRule": "Lost Void / Resonium is deferred unless Product reopens V1.x scope",
-      "sampleEntity": null,
-      "rawAvailable": false,
-      "promotable": false,
-      "blockedBy": [
-        "scope:deferred-v1x"
-      ]
-    },
-    {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
       "canonicalPath": "BattleContext gameMode=hollowZeroAssault / DA source artifacts",
-      "fieldClass": "retained-non-nanoka",
-      "sourcePolicy": "retained-non-nanoka",
-      "status": "deferred",
-      "nanokaEndpoint": null,
-      "rawFieldPaths": [],
-      "transformRule": "retain existing Mihoyo D-17 and buhflipexplode D-12 scope unless lo-user changes the decision",
-      "sampleEntity": null,
-      "rawAvailable": false,
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/boss.json and /{locale}/boss/{id}.json",
+      "rawFieldPaths": [
+        "/begin_time",
+        "/end_time",
+        "/zone/*/name",
+        "/zone/*/monster_level",
+        "/zone/*/layer_buff/*/title",
+        "/zone/*/layer_buff/*/desc",
+        "/zone/*/selectable_buff/*/title",
+        "/zone/*/selectable_buff/*/desc",
+        "/zone/*/layer_room/*/monster_list",
+        "/zone/*/layer_room/*/monster_weakness",
+        "/boss_adjust/*"
+      ],
+      "transformRule": "derive Deadly Assault period, zone, buff, monster, weakness, and boss-adjust raw records from the approved nanoka live version; reject period rows with begin_time after configuredLiveSnapshotDate; runtime promotion requires boss_adjust and score/HP semantic mapping",
+      "sampleEntity": "nanoka-boss-live-69036",
+      "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
-        "scope:explicit-da-exception-required"
-      ]
+        "field:boss-adjust-semantics-required",
+        "field:score-hp-semantics-required",
+        "field:period-live-filter-required"
+      ],
+      "supportingSamples": [
+        "nanoka-boss-live-index-2.8"
+      ],
+      "notes": "R1/R6 lock DA to nanoka. D-17/D-12 remain archived audit baselines and the runtime path is retained until Phase 4 cutover; this row does not authorize adapter/runtime removal."
     },
     {
       "fieldId": "modifiers.formalTemplateContract",
@@ -906,28 +1083,48 @@
     }
   ],
   "summary": {
-    "totalRows": 41,
-    "verifiedFromNanoka": 25,
+    "totalRows": 45,
+    "verifiedFromNanoka": 31,
     "needsTlResearch": 8,
     "needsOwnerResearch": 0,
-    "deferred": 8,
+    "deferred": 6,
     "promotableNow": 9,
-    "notPromotableYet": 32
+    "notPromotableYet": 36
   },
   "openResearchItems": [
-    "source registry contract and content hash capture",
+    "source registry contract, liveVersionRef policy, approvedLiveVersions[], and content hash capture",
     "adapter source-ref emission and JSON pointer convention",
     "agent promotion extra stats / final snapshot panel semantics",
     "agent stat unit mapping for crit/pen/anomaly/impact/adrenaline",
     "rupture rbl semantic mapping",
     "skill tag/damageType/hitCount mapping",
     "mindscape/potential semantic mapping",
-    "typed modifier templates for passives, W-Engines, Drive Discs, and enemy rules",
+    "typed modifier templates for passives, W-Engines, Drive Discs, enemy rules, DA buffs, and Sentinel rows",
     "Bangboo element/attribute source field",
     "enemy monster_info variant mapping for cleaned/golden rows",
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics",
     "W-Engine stat/refine mapping",
     "Drive Disc slot main stat and substat table source",
+    "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
+    "Sentinel canonical naming and unit normalization",
+    "snapshot-derived patch history diff tool and approved-live-version allowlist",
     "disorder formula and disorder daze-level source/config endpoint"
-  ]
+  ],
+  "liveVersionRef": "manifest.zzz.live",
+  "sourceVersionResolved": "2.8",
+  "latestResearchVersion": "3.0.2+15625449",
+  "approvedLiveVersions": [
+    "2.8"
+  ],
+  "sourceVersionPolicy": {
+    "liveVersionRef": "manifest.zzz.live",
+    "defaultReleaseSourceVersion": "2.8",
+    "approvedLiveVersions": [
+      "2.8"
+    ],
+    "latestResearchVersion": "3.0.2+15625449",
+    "latestUsage": "research-and-drift-only",
+    "cleanedOutputRule": "cleaned output must use manifest.zzz.live or an explicitly owner-approved version",
+    "timeWindowRule": "time-windowed rows such as Deadly Assault periods must satisfy begin_time <= configuredLiveSnapshotDate"
+  }
 }

--- a/docs/data-contract/cleaned-schema-contract.md
+++ b/docs/data-contract/cleaned-schema-contract.md
@@ -29,7 +29,28 @@ Every cleaned field in the inventory must be assigned one class:
 | `derived` | Derived from source-backed fields by a documented transform rule. The transform must be deterministic and testable. |
 | `deferred` | In scope for the product area but not promotable yet. It must appear in `missingFields` / `deferredRows`. |
 | `implementation-owned` | Owned by fairy formulas, deterministic templates, compatibility aliases, or CI metadata rather than nanoka gameplay rows. |
-| `retained-non-nanoka` | Explicitly retained under the existing Mihoyo / buhflipexplode Deadly Assault scope. |
+| `archived-audit-baseline` | Retained only as historical audit evidence during the nanoka migration. It is not a runtime source after Phase 4 cutover. |
+| `removed-out-of-product-scope` | Removed by Product / lo-user decision. The field may remain in old schema for compatibility, but no formal data is expected. |
+
+## Formal-Live Source Version Policy
+
+R1/R6 lock nanoka as the source for all source-backed cleaned data, including
+Deadly Assault. R4 locks patch history as snapshot-derived numeric diff data.
+
+Release artifacts must therefore resolve source versions through nanoka's
+manifest:
+
+- `liveVersionRef = "manifest.zzz.live"`;
+- current audited live version: `2.8`;
+- current latest/research snapshot: `3.0.2+15625449`;
+- `approvedLiveVersions[]` starts with `["2.8"]`;
+- `manifest.zzz.latest` may be read for research or drift audit, but cannot
+  enter cleaned output unless lo-user explicitly approves it.
+
+Time-windowed rows such as Deadly Assault periods also require a row-level gate:
+`begin_time <= configuredLiveSnapshotDate`. Future rows must be rejected into
+machine-readable `forbiddenRows` / `missingFields` output rather than silently
+published.
 
 ## Compatibility Rules
 
@@ -42,21 +63,24 @@ Every cleaned field in the inventory must be assigned one class:
 5. A field can be promoted only when the inventory row has a source endpoint,
    raw path, sample evidence, and transform rule.
 6. Missing source evidence must be represented as structured
-   `missingFields` / `deferredRows`; adapters must not silently fall back to
-   Excel, default values, or inferred values.
+   `missingFields` / `deferredRows` / `forbiddenRows`; adapters must not
+   silently fall back to Excel, default values, or inferred values.
 7. `implementation-owned` is not an escape hatch. A rule can use that class only
    when it is truly a fairy formula/runtime contract. If the value is a game data
    row, guide value, or sourced constant, it must be researched against nanoka or
    escalated to lo-user.
+8. D-17 Mihoyo and D-12 buhflipexplode Deadly Assault artifacts remain archived
+   audit baselines until Phase 4 cutover. They are not an exception to the
+   R1/R6 nanoka source policy.
 
 ## Canonical Top-Level Inventory
 
 | Path | Class | Owner | Notes |
 |---|---|---|---|
 | `GameData.schemaVersion` | required | implementation-owned | Version of the cleaned schema contract. |
-| `GameData.gameVersion` | required | derived | Must match the approved nanoka live version or retained DA source version. |
+| `GameData.gameVersion` | required | derived | Must match the approved nanoka live version for release artifacts. |
 | `GameData.dataVersion` | required | implementation-owned | Package data build version. |
-| `GameData.sourceVersion` | required | derived | Source registry summary version. |
+| `GameData.sourceVersion` | required | derived | Source registry summary version; default source-backed release data resolves through `manifest.zzz.live`. |
 | `GameData.generatedAt` | required | implementation-owned | Build timestamp. |
 | `GameData.sources[]` | required | derived | Derived from source registry; each source must include parser and license/risk metadata. |
 | `GameData.agents` | required | nanoka-candidate | Character identity, stats, skills, passives, potential, and source aliases. |
@@ -66,7 +90,7 @@ Every cleaned field in the inventory must be assigned one class:
 | `GameData.wEngines` | optional | nanoka-candidate | W-Engine stats and passive modifiers. |
 | `GameData.driveDiscs` | optional | nanoka-candidate | Drive Disc set modifiers; text alone is not promotable. |
 | `GameData.enemies` | required | nanoka-candidate | Enemy variants, stats, resistances, anomaly thresholds, and daze recovery. |
-| `GameData.resonium` | deferred | deferred | Lost Void scope is deferred unless Product reopens it. |
+| `GameData.resonium` | removed-out-of-product-scope | removed-out-of-product-scope | Lost Void / Resonium formal data is removed from the V0.1.0 product scope by R4. Existing schema presence is compatibility-only until a breaking schema cleanup. |
 | `GameData.modifiers` | required | implementation-owned | Deterministic typed modifier templates with source refs. |
 | `GameData.rules` | required | mixed | Each rule must be inventoried separately as `source-backed`, `derived`, or `implementation-owned`; this field is not a blanket exemption from source research. |
 | `GameData.aliases` | required | implementation-owned | D-11 naming and source-term compatibility table. |

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,14 +1,31 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 0 draft
+Status: Phase 0 R1-R6 locked update
 Owner: @TechLead
 Reviewers: @Product, @QA
-Related: D-20 data-source migration, task #121, task #122
+Related: D-20 data-source migration, task #121, task #122, task #125, task #127
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
 It replaces the discussion-only A-J checklist as the working baseline for Phase
 0/1.
+
+## Formal-Live Source Version Policy
+
+R1/R6 now lock nanoka as the source for all source-backed cleaned data,
+including Deadly Assault. R4 locks patch history as snapshot-derived numeric
+diff data, and removes Lost Void / Resonium from the current product scope.
+
+The release source version is no longer the provisional
+`3.0.2+15625449` sample version from PR #52. Cleaned output must resolve through
+`manifest.zzz.live`:
+
+- `liveVersionRef`: `manifest.zzz.live`;
+- current audited live version: `2.8`;
+- current latest/research snapshot: `3.0.2+15625449`;
+- `approvedLiveVersions[]`: `["2.8"]`;
+- `manifest.zzz.latest` is allowed for research / drift only until lo-user
+  explicitly approves it for cleaned output.
 
 ## Status Values
 
@@ -17,7 +34,7 @@ It replaces the discussion-only A-J checklist as the working baseline for Phase
 | `verified-from-nanoka` | Sampled nanoka endpoint and raw path exist. The field is promotable only when `promotable=true`. |
 | `needs-tl-research` | Evidence is incomplete, semantic mapping is unresolved, or transform rules are not yet proven. |
 | `needs-owner-research` | TL exhausted nanoka research and the item must be escalated to lo-user. No current rows use this status yet. |
-| `deferred` | Explicitly out of the current migration scope or retained outside nanoka. |
+| `deferred` | Explicitly not promotable in the current implementation step, or implementation-owned rather than a nanoka gameplay row. |
 
 The machine-readable version is
 `data/cleaned/audit/nanoka-coverage-matrix.json`, mirrored to
@@ -34,6 +51,14 @@ The machine-readable version is
 | Enemy / Dullahan sample | `https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json` | `monster_info.*.stats`, `curves`, `element`, `element_abnormal`. Variant mapping is still unresolved. |
 | W-Engine / Yixuan signature sample | `https://static.nanoka.cc/zzz/3.0.2+15625449/zh/weapon/14137.json` | `base_property`, `rand_property`, `level`, `stars`, `talents`; typed passive mapping is still unresolved. |
 | Drive Disc / Woodpecker Electro sample | `https://static.nanoka.cc/zzz/3.0.2+15625449/zh/equipment/31000.json` | `desc2` / `desc4` text exists, but typed modifiers are not promotable until deterministic parsing/templates exist. |
+| Manifest / live gate | `https://static.nanoka.cc/manifest.json` | `zzz.live = 2.8`, `zzz.latest = 3.0.2+15625449`, `zzz.available[]` supports approved-live version allowlists and snapshot-derived patch diff history. |
+| Live Sentinel sample / Nekomata | `https://static.nanoka.cc/zzz/2.8/zh/character/1021.json` | `stats.rp_max`, `stats.rp_recover`, and skill `fever_recovery` / `rp_recovery` raw paths exist in the live version. |
+| Live Deadly Assault index | `https://static.nanoka.cc/zzz/2.8/boss.json` | 38 live DA entries; all sampled `zh/boss/{id}.json` details returned 200 in PR #54. |
+| Live Deadly Assault period / 69036 | `https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json` | Current live period window, zones, layer/selectable buffs, room monster lists, weakness data, and `boss_adjust`. |
+
+The `3.0.2+15625449` samples are retained as phase-0 research evidence, not as
+release-ready source evidence. Phase 2 promotion must either re-sample the live
+version or receive explicit owner approval for a newer version.
 
 ## Corrections To The Discussion Checklist
 
@@ -50,27 +75,32 @@ The machine-readable version is
 - `GameData.modifiers`, `GameData.rules`, `GameData.aliases`, and
   `GameData.sources` are top-level schema contract rows and must appear in the
   inventory even when they are not nanoka gameplay rows.
-- Deadly Assault remains `retained-non-nanoka` unless lo-user explicitly changes
-  the previous Mihoyo + buhflipexplode scope decision.
+- Deadly Assault is now source-backed by nanoka under R1/R6. D-17 Mihoyo and
+  D-12 buhflipexplode artifacts remain archived audit baselines / deprecated
+  candidates until Phase 4 cutover; they are not a runtime source exception.
+- Lost Void / Resonium is removed from the V0.1.0 product scope by R4. It is no
+  longer represented as a deferred migration row.
 - `implementation-owned` is assigned per row only after checking whether the
   value is really a fairy formula/runtime rule. Game data or guide-backed
   constants still need nanoka research or lo-user escalation.
 
 ## Human-Readable Summary
 
-Machine summary after task #122 batch 1: 41 rows total, 25
-`verified-from-nanoka`, 8 `needs-tl-research`, 0 `needs-owner-research`, 8
-`deferred`, and 9 `promotableNow`.
+Machine summary after task #127: 45 rows total, 31 `verified-from-nanoka`, 8
+`needs-tl-research`, 0 `needs-owner-research`, 6 `deferred`, and 9
+`promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
 |---|---|---:|---|
-| Source metadata / registry | needs-tl-research | no | D-20 source registry and stable-version gate still need implementation. |
+| Source metadata / registry | needs-tl-research | no | `liveVersionRef`, `approvedLiveVersions[]`, source hashes, and stable-version CI still need implementation. |
+| Snapshot-derived patch history | verified-from-nanoka | no | R4.a locks snapshot-derived numeric diff; diff tool and approved-live allowlist are still required. |
 | Agent identity / labels / enums | verified-from-nanoka | yes | Enum mapping table must be recorded. |
 | Agent base panel stats | verified-from-nanoka | yes | Formula proven for `baseStatsByLevel`: `stats[key] + level[promotionPhase][key] + stats[key_growth] * (level - 1) / 10000`. Promotion extra stats remain separate. |
 | Agent promotion extra stats | needs-tl-research | no | `extra_level` raw fields exist, but final snapshot composition semantics are not locked. |
 | Agent skill numeric params | verified-from-nanoka | yes | Full level derivation needs transform tests, but sampled base/growth paths exist. |
 | Agent passive / talent / potential | verified-from-nanoka | no | Raw text/objects exist; typed modifier and potential semantics are unresolved. |
 | Rupture and adrenaline candidate fields | verified-from-nanoka | no | Raw fields exist; semantic mapping must be validated. |
+| Sentinel / decibel fields | verified-from-nanoka | no | Live raw fields exist; canonical naming and unit normalization are unresolved. |
 | Bangboo skill numeric params | verified-from-nanoka | yes | G26 sampled values are promotable. |
 | Bangboo panel stats | verified-from-nanoka | yes | Formula proven for G26 Plugboo: `stats[key] + level[promotionPhase][key] + stats[key_upgrade] * (level - 1) / 10000`. |
 | Enemy stats/resistance/thresholds | verified-from-nanoka | no | Raw fields exist; variant mapping and formula mapping are unresolved. |
@@ -78,8 +108,8 @@ Machine summary after task #122 batch 1: 41 rows total, 25
 | W-Engine passive | verified-from-nanoka | no | Raw text/objects exist; typed modifier template is unresolved. |
 | Drive Disc set effects | verified-from-nanoka | no | Raw text exists; typed modifier template is unresolved. |
 | Drive Disc slot/main/sub stats | needs-tl-research | no | Not found in sampled equipment detail endpoint. |
-| Resonium / Lost Void | deferred | no | Out of current V1 migration scope. |
-| Deadly Assault periods/buffs | deferred | no | Retained Mihoyo + buhflipexplode scope. |
+| Resonium / Lost Void | removed | no | Removed from V0.1.0 product scope by R4; no formal data expected. |
+| Deadly Assault periods/buffs | verified-from-nanoka | no | Live raw data exists; `boss_adjust`, score/HP semantics, and period filtering block runtime cutover. |
 | Formula rule tables | mixed | no | Must be split per rule: defense/rounding may be implementation-owned, while anomaly thresholds, daze recovery, disorder, and attribute mappings need row-level owner/source decisions. |
 
 ## Remaining TL Research Rows
@@ -99,10 +129,28 @@ Task #122 batch 1 leaves 8 rows in `needs-tl-research`:
 - `rules.disorderDazeLevelZone` — source or implementation owner still
   unresolved.
 
+## Current Scope Rows Added By R1/R4/R6
+
+- `metadata.snapshotDiffHistory` — R4.a snapshot-derived numeric patch history,
+  derived from `manifest.zzz.available` and approved live snapshot hashes.
+- `sentinel.rpMax` / `sentinel.rpRecover` / `sentinel.skillFeverRecovery` /
+  `sentinel.skillRpRecovery` — raw Sentinel / decibel fields verified from the
+  live Nekomata sample; typed promotion waits on canonical naming and unit
+  normalization.
+- `deadlyAssault.periodsBossesBuffs` — nanoka live DA raw source row; runtime
+  promotion waits on `boss_adjust`, score/HP semantics, and period filtering.
+
+## Removed Product Scope
+
+- `resonium.lostVoid` has been removed from the matrix. `GameData.resonium`
+  remains in the current TypeScript schema only as compatibility surface until a
+  future breaking schema cleanup; V0.1.0 does not expect formal Resonium data.
+
 ## Phase 3 Drift Audit Boundary
 
 The Phase 3 parallel period is not runtime multi-source fallback. It is a drift
 audit that compares nanoka-generated output against archived Excel/V0.0.4 golden
-evidence. Runtime adapters must not silently fall back to archived Excel; any
-missing or changed field must be represented in `missingFields` / `deferredRows`
-or a drift report requiring a ruling.
+evidence plus archived D-17/D-12 Deadly Assault evidence. Runtime adapters must
+not silently fall back to archived Excel, Mihoyo, or buhflipexplode; any missing,
+future, forbidden, or changed field must be represented in `missingFields` /
+`deferredRows` / `forbiddenRows` or a drift report requiring a ruling.

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T00:21:07+08:00",
-  "status": "phase-0-draft",
-  "sourceVersion": "3.0.2+15625449",
+  "generatedAt": "2026-05-15T02:55:00+08:00",
+  "status": "phase-0-r1-r6-locked",
+  "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
     "packages/core/src/schema/battle-snapshot.ts",
@@ -19,8 +19,9 @@
     "nanoka",
     "derived-from-source-registry",
     "implementation-owned",
-    "retained-non-nanoka",
-    "out-of-scope"
+    "archived-audit-baseline",
+    "out-of-scope",
+    "removed-out-of-product-scope"
   ],
   "sampleSources": [
     {
@@ -29,10 +30,12 @@
       "entityId": "1371",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1371.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "6cb0a652f92d9daf0e6cd382d757c7755d543f9013defb61799b747aaf2b8868",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-character-nekomata-1021",
@@ -40,10 +43,12 @@
       "entityId": "1021",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1021.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "85186a7568c11ff9f56e2085bf561485f0548ff29fc70e686c8aa3dca2b0f961",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-character-soldier11-1041",
@@ -51,10 +56,12 @@
       "entityId": "1041",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/character/1041.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "8acde3e5c3849a371c5a2fefe32bd38e2b96397067a73e27cd5a69296550fcc1",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-bangboo-plugboo-54008",
@@ -62,10 +69,12 @@
       "entityId": "54008",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/bangboo/54008.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "2afc34c8b72b3a7dc6e18d945e83c12784a742817e4ce760ee8c4c17aa3b0261",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-monster-dullahan-30000",
@@ -73,10 +82,12 @@
       "entityId": "30000",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "46eebea2270e748a6057d152a05a3296f2601efaccf299667318025f44bf492a",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-weapon-yixuan-signature-14137",
@@ -84,10 +95,12 @@
       "entityId": "14137",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/weapon/14137.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "a0d7dfe24f24a5cfc623e750c33bbea7aead9952283d670861b9a67e814a667d",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
     },
     {
       "id": "nanoka-equipment-woodpecker-31000",
@@ -95,10 +108,64 @@
       "entityId": "31000",
       "url": "https://static.nanoka.cc/zzz/3.0.2+15625449/zh/equipment/31000.json",
       "version": "3.0.2+15625449",
-      "releaseChannel": "stable",
+      "releaseChannel": "research",
       "fetchedAt": "2026-05-15T00:21:07+08:00",
       "contentSha256": "6af7dcce6a1863b1d801e54621056b2f92baab2c31672a4ed6c2cb1ff3fcf508",
-      "server": "live"
+      "server": "latest-snapshot",
+      "approvedForCleanedOutput": false,
+      "evidenceUse": "research-only-until-owner-approval"
+    },
+    {
+      "id": "nanoka-manifest",
+      "entityType": "sourceManifest",
+      "entityId": "zzz",
+      "url": "https://static.nanoka.cc/manifest.json",
+      "version": "manifest",
+      "releaseChannel": "source-registry",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "6213ac3b71f5827e850691c2f8547ec6657b7d8ab7e546c50b80252387e613b8",
+      "server": "source-registry",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "live-version-gate"
+    },
+    {
+      "id": "nanoka-character-nekomata-live-1021",
+      "entityType": "agent",
+      "entityId": "1021",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1021.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:32:00+08:00",
+      "contentSha256": "85186a7568c11ff9f56e2085bf561485f0548ff29fc70e686c8aa3dca2b0f961",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-boss-live-index-2.8",
+      "entityType": "deadlyAssaultIndex",
+      "entityId": "boss",
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "3379eba07fe6c77e821dc403fc31a9f304148666ee5f5a51706ac5e203393ec0",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-boss-live-69036",
+      "entityType": "deadlyAssaultPeriod",
+      "entityId": "69036",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json",
+      "version": "2.8",
+      "releaseChannel": "stable",
+      "fetchedAt": "2026-05-15T02:21:00+08:00",
+      "contentSha256": "8f31e1f15918797e8e28c8a350fba6934077b73a35855778d8c0a660815d276b",
+      "server": "live",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "release-gate-evidence"
     }
   ],
   "rows": [
@@ -108,15 +175,20 @@
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
       "status": "needs-tl-research",
-      "nanokaEndpoint": "https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
-      "rawFieldPaths": [],
-      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, and stable-version allowlist",
-      "sampleEntity": "nanoka-character-yixuan-1371",
+      "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
+      "rawFieldPaths": [
+        "/zzz/live",
+        "/zzz/latest",
+        "/zzz/available"
+      ],
+      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, liveVersionRef=manifest.zzz.live, approvedLiveVersions[], and stable-version allowlist",
+      "sampleEntity": "nanoka-manifest",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
         "source-registry-contract-required",
-        "content-hash-capture-required"
+        "content-hash-capture-required",
+        "live-version-policy-ci-required"
       ]
     },
     {
@@ -127,13 +199,36 @@
       "status": "needs-tl-research",
       "nanokaEndpoint": "all promoted nanoka rows",
       "rawFieldPaths": [],
-      "transformRule": "attach endpoint URL, JSON pointer, and sourceVersion to every promoted field",
+      "transformRule": "attach endpoint URL, JSON pointer, content hash, approved sourceVersion, and liveVersionRef to every promoted field",
       "sampleEntity": "nanoka-bangboo-plugboo-54008",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
-        "adapter-source-ref-emission-required"
+        "adapter-source-ref-emission-required",
+        "json-pointer-convention-required"
       ]
+    },
+    {
+      "fieldId": "metadata.snapshotDiffHistory",
+      "canonicalPath": "planned GameData.sources[].snapshotDiffHistory / package audit metadata",
+      "fieldClass": "derived",
+      "sourcePolicy": "derived-from-source-registry",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and approved versioned nanoka snapshots",
+      "rawFieldPaths": [
+        "/zzz/available",
+        "/zzz/live",
+        "/zzz/latest"
+      ],
+      "transformRule": "R4.a: derive numeric patch history by diffing approved-live snapshot hashes and raw JSON paths; latest/pre-release snapshots are research-only unless lo-user approves them",
+      "sampleEntity": "nanoka-manifest",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "snapshot-diff-tool-required",
+        "approved-live-version-allowlist-required"
+      ],
+      "notes": "No dedicated patch-note/changelog prose endpoint was found in PR #54. This row represents snapshot-derived numeric diff history only."
     },
     {
       "fieldId": "metadata.aliases",
@@ -362,6 +457,86 @@
       "promotable": false,
       "blockedBy": [
         "typed-modifier-template-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.rpMax",
+      "canonicalPath": "planned V0.1.0 GameData.agents.*.sentinel.rpMax / AgentSnapshot.panel",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/stats/rp_max"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.rpRecover",
+      "canonicalPath": "planned V0.1.0 GameData.agents.*.sentinel.rpRecover / AgentSnapshot.panel",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/stats/rp_recover"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.skillFeverRecovery",
+      "canonicalPath": "planned V0.1.0 GameData.skills.*.sentinel.feverRecovery",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/skill/*/description/*/param/*/param/*/fever_recovery",
+        "/skill/*/description/*/param/*/param/*/fever_recovery_growth"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming, level-growth handling, and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required",
+        "field:skill-level-growth-transform-required"
+      ]
+    },
+    {
+      "fieldId": "sentinel.skillRpRecovery",
+      "canonicalPath": "planned V0.1.0 GameData.skills.*.sentinel.rpRecovery",
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/{locale}/character/{id}.json",
+      "rawFieldPaths": [
+        "/skill/*/description/*/param/*/param/*/rp_recovery",
+        "/skill/*/description/*/param/*/param/*/rp_recovery_growth"
+      ],
+      "transformRule": "live sample proves raw availability; lock canonical naming, level-growth handling, and unit normalization before typed promotion",
+      "sampleEntity": "nanoka-character-nekomata-live-1021",
+      "rawAvailable": true,
+      "promotable": false,
+      "blockedBy": [
+        "field:sentinel-naming-required",
+        "field:sentinel-unit-normalization-required",
+        "field:skill-level-growth-transform-required"
       ]
     },
     {
@@ -733,36 +908,38 @@
       ]
     },
     {
-      "fieldId": "resonium.lostVoid",
-      "canonicalPath": "GameData.resonium",
-      "fieldClass": "deferred",
-      "sourcePolicy": "out-of-scope",
-      "status": "deferred",
-      "nanokaEndpoint": null,
-      "rawFieldPaths": [],
-      "transformRule": "Lost Void / Resonium is deferred unless Product reopens V1.x scope",
-      "sampleEntity": null,
-      "rawAvailable": false,
-      "promotable": false,
-      "blockedBy": [
-        "scope:deferred-v1x"
-      ]
-    },
-    {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
       "canonicalPath": "BattleContext gameMode=hollowZeroAssault / DA source artifacts",
-      "fieldClass": "retained-non-nanoka",
-      "sourcePolicy": "retained-non-nanoka",
-      "status": "deferred",
-      "nanokaEndpoint": null,
-      "rawFieldPaths": [],
-      "transformRule": "retain existing Mihoyo D-17 and buhflipexplode D-12 scope unless lo-user changes the decision",
-      "sampleEntity": null,
-      "rawAvailable": false,
+      "fieldClass": "required",
+      "sourcePolicy": "nanoka",
+      "status": "verified-from-nanoka",
+      "nanokaEndpoint": "/boss.json and /{locale}/boss/{id}.json",
+      "rawFieldPaths": [
+        "/begin_time",
+        "/end_time",
+        "/zone/*/name",
+        "/zone/*/monster_level",
+        "/zone/*/layer_buff/*/title",
+        "/zone/*/layer_buff/*/desc",
+        "/zone/*/selectable_buff/*/title",
+        "/zone/*/selectable_buff/*/desc",
+        "/zone/*/layer_room/*/monster_list",
+        "/zone/*/layer_room/*/monster_weakness",
+        "/boss_adjust/*"
+      ],
+      "transformRule": "derive Deadly Assault period, zone, buff, monster, weakness, and boss-adjust raw records from the approved nanoka live version; reject period rows with begin_time after configuredLiveSnapshotDate; runtime promotion requires boss_adjust and score/HP semantic mapping",
+      "sampleEntity": "nanoka-boss-live-69036",
+      "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
-        "scope:explicit-da-exception-required"
-      ]
+        "field:boss-adjust-semantics-required",
+        "field:score-hp-semantics-required",
+        "field:period-live-filter-required"
+      ],
+      "supportingSamples": [
+        "nanoka-boss-live-index-2.8"
+      ],
+      "notes": "R1/R6 lock DA to nanoka. D-17/D-12 remain archived audit baselines and the runtime path is retained until Phase 4 cutover; this row does not authorize adapter/runtime removal."
     },
     {
       "fieldId": "modifiers.formalTemplateContract",
@@ -906,28 +1083,48 @@
     }
   ],
   "summary": {
-    "totalRows": 41,
-    "verifiedFromNanoka": 25,
+    "totalRows": 45,
+    "verifiedFromNanoka": 31,
     "needsTlResearch": 8,
     "needsOwnerResearch": 0,
-    "deferred": 8,
+    "deferred": 6,
     "promotableNow": 9,
-    "notPromotableYet": 32
+    "notPromotableYet": 36
   },
   "openResearchItems": [
-    "source registry contract and content hash capture",
+    "source registry contract, liveVersionRef policy, approvedLiveVersions[], and content hash capture",
     "adapter source-ref emission and JSON pointer convention",
     "agent promotion extra stats / final snapshot panel semantics",
     "agent stat unit mapping for crit/pen/anomaly/impact/adrenaline",
     "rupture rbl semantic mapping",
     "skill tag/damageType/hitCount mapping",
     "mindscape/potential semantic mapping",
-    "typed modifier templates for passives, W-Engines, Drive Discs, and enemy rules",
+    "typed modifier templates for passives, W-Engines, Drive Discs, enemy rules, DA buffs, and Sentinel rows",
     "Bangboo element/attribute source field",
     "enemy monster_info variant mapping for cleaned/golden rows",
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics",
     "W-Engine stat/refine mapping",
     "Drive Disc slot main stat and substat table source",
+    "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
+    "Sentinel canonical naming and unit normalization",
+    "snapshot-derived patch history diff tool and approved-live-version allowlist",
     "disorder formula and disorder daze-level source/config endpoint"
-  ]
+  ],
+  "liveVersionRef": "manifest.zzz.live",
+  "sourceVersionResolved": "2.8",
+  "latestResearchVersion": "3.0.2+15625449",
+  "approvedLiveVersions": [
+    "2.8"
+  ],
+  "sourceVersionPolicy": {
+    "liveVersionRef": "manifest.zzz.live",
+    "defaultReleaseSourceVersion": "2.8",
+    "approvedLiveVersions": [
+      "2.8"
+    ],
+    "latestResearchVersion": "3.0.2+15625449",
+    "latestUsage": "research-and-drift-only",
+    "cleanedOutputRule": "cleaned output must use manifest.zzz.live or an explicitly owner-approved version",
+    "timeWindowRule": "time-windowed rows such as Deadly Assault periods must satisfy begin_time <= configuredLiveSnapshotDate"
+  }
 }


### PR DESCRIPTION
## Summary

- Updates the nanoka coverage matrix after lo-user locked R1/R4/R6.
- Changes source policy from provisional `3.0.2+15625449` to `manifest.zzz.live`, with `approvedLiveVersions: ["2.8"]` and latest marked research-only.
- Moves Deadly Assault to nanoka source-backed evidence, with explicit `boss_adjust` / score-HP / period-filter blockers and D-17/D-12 retained only as archived audit baselines until Phase 4 cutover.
- Adds Sentinel rows and R4.a snapshot-derived patch history row.
- Removes the Resonium/Lost Void row from the matrix and documents the schema deprecation boundary.
- Keeps root/package matrix mirrors byte-identical.

## Scope

Docs + machine-readable matrix only. No adapter, runtime cutover, generated cleaned data, or D-17/D-12 removal.

## Verification

- matrix JSON parse + mirror parity + duplicate fieldId + summary count check
- `git diff --check`
- Markdown fence balance check
- `pnpm check`
- `pnpm --filter @randomplay/data test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data pack --dry-run --json`
