### PR TITLE
feat(data): promote nanoka source metadata gates

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T13:40:00+08:00",
-  "status": "phase-2-enemy-variant-mapping-gate",
+  "generatedAt": "2026-05-15T13:55:00+08:00",
+  "status": "phase-2-source-metadata-contract-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -317,39 +317,39 @@
       "canonicalPath": "GameData.sources[]",
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
-      "status": "needs-tl-research",
+      "status": "verified-from-nanoka",
       "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
       "rawFieldPaths": [
         "/zzz/live",
         "/zzz/latest",
         "/zzz/available"
       ],
-      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, liveVersionRef=manifest.zzz.live, approvedLiveVersions[], and stable-version allowlist",
+      "transformRule": "derive SourceDocument rows from source registry entries: sourceVersion=configuredLiveVersion and fetchedAt from registry; contentHash, liveVersionRef, approvedLiveVersions[], and URL allowlist remain in data/source-registry.json and are verified by CI",
       "sampleEntity": "nanoka-manifest",
       "rawAvailable": true,
-      "promotable": false,
-      "blockedBy": [
-        "source-registry-contract-required",
-        "content-hash-capture-required",
-        "live-version-policy-ci-required"
-      ]
+      "promotable": true,
+      "blockedBy": [],
+      "notes": "Task #148 closes the source-registry contract: data/source-registry.json and package mirror are byte-identical, contentHash is sha256-prefixed, configuredLiveVersion is approved, and verify:source-registry gates the live-version policy."
     },
     {
       "fieldId": "metadata.sourceRefs",
       "canonicalPath": "SourceRef.sourceId/sourceAnchor/sourceVersion/dataPath",
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
-      "status": "needs-tl-research",
+      "status": "verified-from-nanoka",
       "nanokaEndpoint": "all promoted nanoka rows",
-      "rawFieldPaths": [],
-      "transformRule": "attach endpoint URL, JSON pointer, content hash, approved sourceVersion, and liveVersionRef to every promoted field",
-      "sampleEntity": "nanoka-bangboo-plugboo-54008",
+      "rawFieldPaths": [
+        "/assets/*/url",
+        "/assets/*/localPath",
+        "/assets/*/sourceVersion",
+        "/assets/*/sha256"
+      ],
+      "transformRule": "derive SourceRef anchors from parsed adapter metadata records: sourceId/sourceVersion from ParsedSourceBatch, sourceAnchor=asset.url, dataPath=retained raw fixture path; content hashes and liveVersionRef resolve through source-registry/source-manifest by sourceId and retained path",
+      "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
-      "promotable": false,
-      "blockedBy": [
-        "adapter-source-ref-emission-required",
-        "json-pointer-convention-required"
-      ]
+      "promotable": true,
+      "blockedBy": [],
+      "notes": "Task #148 adds buildSourceRefsForParsedBatch() and fail-loud tests requiring sourceAnchor and dataPath for every retained nanoka metadata record. This promotes the metadata contract only; runtime cleaned-data cutover remains blocked by row-specific gates."
     },
     {
       "fieldId": "metadata.snapshotDiffHistory",
@@ -1279,16 +1279,14 @@
   ],
   "summary": {
     "totalRows": 45,
-    "verifiedFromNanoka": 32,
-    "needsTlResearch": 7,
+    "verifiedFromNanoka": 34,
+    "needsTlResearch": 5,
     "needsOwnerResearch": 0,
     "deferred": 6,
-    "promotableNow": 16,
-    "notPromotableYet": 29
+    "promotableNow": 18,
+    "notPromotableYet": 27
   },
   "openResearchItems": [
-    "source registry contract, liveVersionRef policy, approvedLiveVersions[], and content hash capture",
-    "adapter source-ref emission and JSON pointer convention",
     "agent promotion extra stats / final snapshot panel semantics",
     "agent stat unit mapping for crit/pen/anomaly/impact/adrenaline",
     "rupture rbl semantic mapping",

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,10 +1,10 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 2 enemy variant mapping gate
+Status: Phase 2 source metadata contract gate
 Owner: @TechLead
 Reviewers: @Product, @QA
 Related: D-20 data-source migration, task #121, task #122, task #125, task #127,
-task #138, task #140, task #142, task #144, task #146
+task #138, task #140, task #142, task #144, task #146, task #148
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
@@ -95,13 +95,13 @@ or receive explicit owner approval for a newer version.
 
 ## Human-Readable Summary
 
-Machine summary after task #146: 45 rows total, 32 `verified-from-nanoka`, 7
-`needs-tl-research`, 0 `needs-owner-research`, 6 `deferred`, and 16
+Machine summary after task #148: 45 rows total, 34 `verified-from-nanoka`, 5
+`needs-tl-research`, 0 `needs-owner-research`, 6 `deferred`, and 18
 `promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
 |---|---|---:|---|
-| Source metadata / registry | needs-tl-research | no | `liveVersionRef`, `approvedLiveVersions[]`, source hashes, and stable-version CI still need implementation. |
+| Source metadata / registry | verified-from-nanoka | yes | Task #148 gates source registry mirror parity, `liveVersionRef`, `approvedLiveVersions[]`, source hashes, stable-version CI, and SourceRef emission from parsed adapter records. |
 | Snapshot-derived patch history | verified-from-nanoka | yes | R4.a snapshot-derived numeric diff tool exists and is gated by `approvedLiveVersions[]`; current artifact has one approved live snapshot (`2.8`) and therefore no compared pairs until another live version is approved. |
 | Agent identity / labels / enums | verified-from-nanoka | yes | Current promotable rows point to approved live Nekomata evidence; enum mapping table must be recorded. |
 | Agent base panel stats | verified-from-nanoka | yes | Formula proven for `baseStatsByLevel`: `stats[key] + level[promotionPhase][key] + stats[key_growth] * (level - 1) / 10000`, with retained live Nekomata panel tests. Promotion extra stats remain separate. |
@@ -124,10 +124,8 @@ Machine summary after task #146: 45 rows total, 32 `verified-from-nanoka`, 7
 
 ## Remaining TL Research Rows
 
-After task #144, 7 rows remain in `needs-tl-research`:
+After task #148, 5 rows remain in `needs-tl-research`:
 
-- `metadata.sources` — source registry contract and content-hash capture.
-- `metadata.sourceRefs` — adapter source-ref emission contract.
 - `agents.promotionExtraStats` — `extra_level` final snapshot composition
   semantics.
 - `bangboos.element` — Plugboo sampled detail did not verify Bangboo element.
@@ -139,6 +137,9 @@ After task #144, 7 rows remain in `needs-tl-research`:
 
 ## Current Scope Rows Added By R1/R4/R6
 
+- `metadata.sources` / `metadata.sourceRefs` — source-registry-backed metadata
+  contract rows; task #148 promotes them after executable registry mirror,
+  content-hash, live-version, and parsed-record SourceRef emission gates.
 - `metadata.snapshotDiffHistory` — R4.a snapshot-derived numeric patch history;
   task #146 emits `data/cleaned/audit/nanoka-snapshot-diff-history.json` from
   approved live snapshot hashes and marks official patch-note prose as

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T13:40:00+08:00",
-  "status": "phase-2-enemy-variant-mapping-gate",
+  "generatedAt": "2026-05-15T13:55:00+08:00",
+  "status": "phase-2-source-metadata-contract-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -317,39 +317,39 @@
       "canonicalPath": "GameData.sources[]",
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
-      "status": "needs-tl-research",
+      "status": "verified-from-nanoka",
       "nanokaEndpoint": "https://static.nanoka.cc/manifest.json and https://static.nanoka.cc/zzz/{sourceVersion}/{locale}/{entityType}/{id}.json",
       "rawFieldPaths": [
         "/zzz/live",
         "/zzz/latest",
         "/zzz/available"
       ],
-      "transformRule": "derive SourceDocument rows from source registry, parser version, source hash, liveVersionRef=manifest.zzz.live, approvedLiveVersions[], and stable-version allowlist",
+      "transformRule": "derive SourceDocument rows from source registry entries: sourceVersion=configuredLiveVersion and fetchedAt from registry; contentHash, liveVersionRef, approvedLiveVersions[], and URL allowlist remain in data/source-registry.json and are verified by CI",
       "sampleEntity": "nanoka-manifest",
       "rawAvailable": true,
-      "promotable": false,
-      "blockedBy": [
-        "source-registry-contract-required",
-        "content-hash-capture-required",
-        "live-version-policy-ci-required"
-      ]
+      "promotable": true,
+      "blockedBy": [],
+      "notes": "Task #148 closes the source-registry contract: data/source-registry.json and package mirror are byte-identical, contentHash is sha256-prefixed, configuredLiveVersion is approved, and verify:source-registry gates the live-version policy."
     },
     {
       "fieldId": "metadata.sourceRefs",
       "canonicalPath": "SourceRef.sourceId/sourceAnchor/sourceVersion/dataPath",
       "fieldClass": "required",
       "sourcePolicy": "derived-from-source-registry",
-      "status": "needs-tl-research",
+      "status": "verified-from-nanoka",
       "nanokaEndpoint": "all promoted nanoka rows",
-      "rawFieldPaths": [],
-      "transformRule": "attach endpoint URL, JSON pointer, content hash, approved sourceVersion, and liveVersionRef to every promoted field",
-      "sampleEntity": "nanoka-bangboo-plugboo-54008",
+      "rawFieldPaths": [
+        "/assets/*/url",
+        "/assets/*/localPath",
+        "/assets/*/sourceVersion",
+        "/assets/*/sha256"
+      ],
+      "transformRule": "derive SourceRef anchors from parsed adapter metadata records: sourceId/sourceVersion from ParsedSourceBatch, sourceAnchor=asset.url, dataPath=retained raw fixture path; content hashes and liveVersionRef resolve through source-registry/source-manifest by sourceId and retained path",
+      "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
-      "promotable": false,
-      "blockedBy": [
-        "adapter-source-ref-emission-required",
-        "json-pointer-convention-required"
-      ]
+      "promotable": true,
+      "blockedBy": [],
+      "notes": "Task #148 adds buildSourceRefsForParsedBatch() and fail-loud tests requiring sourceAnchor and dataPath for every retained nanoka metadata record. This promotes the metadata contract only; runtime cleaned-data cutover remains blocked by row-specific gates."
     },
     {
       "fieldId": "metadata.snapshotDiffHistory",
@@ -1279,16 +1279,14 @@
   ],
   "summary": {
     "totalRows": 45,
-    "verifiedFromNanoka": 32,
-    "needsTlResearch": 7,
+    "verifiedFromNanoka": 34,
+    "needsTlResearch": 5,
     "needsOwnerResearch": 0,
     "deferred": 6,
-    "promotableNow": 16,
-    "notPromotableYet": 29
+    "promotableNow": 18,
+    "notPromotableYet": 27
   },
   "openResearchItems": [
-    "source registry contract, liveVersionRef policy, approvedLiveVersions[], and content hash capture",
-    "adapter source-ref emission and JSON pointer convention",
     "agent promotion extra stats / final snapshot panel semantics",
     "agent stat unit mapping for crit/pen/anomaly/impact/adrenaline",
     "rupture rbl semantic mapping",

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -92,6 +92,7 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   const nanoka = sourceById(registry, "nanoka-zzz")
   validateNanokaRegistry(nanoka)
 
+  assert(matrix.status === "phase-2-source-metadata-contract-gate", "matrix status must match the latest source metadata contract gate")
   assert(matrix.sourceVersionPolicy?.liveVersionRef === nanoka.liveVersionRef, "matrix liveVersionRef must match nanoka registry")
   assert(matrix.sourceVersionPolicy?.defaultReleaseSourceVersion === nanoka.configuredLiveVersion, "matrix default release version must match configuredLiveVersion")
   assert(matrix.sourceVersionResolved === nanoka.configuredLiveVersion, "matrix resolved sourceVersion must match configuredLiveVersion")
@@ -128,6 +129,28 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   }
 
   const resourceRows = new Map((matrix.rows ?? []).map(row => [row.fieldId, row]))
+  const metadataSourcesRow = resourceRows.get("metadata.sources")
+  assert(metadataSourcesRow !== undefined, "metadata.sources: missing source registry metadata row")
+  assert(metadataSourcesRow.status === "verified-from-nanoka", "metadata.sources: source registry row must be verified after executable source-registry gate")
+  assert(metadataSourcesRow.promotable === true, "metadata.sources: source registry metadata must be promotable after contract gate")
+  assert(metadataSourcesRow.sampleEntity === "nanoka-manifest", "metadata.sources: row must use nanoka manifest evidence")
+  assert(metadataSourcesRow.sourcePolicy === "derived-from-source-registry", "metadata.sources: row must derive from source registry")
+  assert((metadataSourcesRow.blockedBy ?? []).length === 0, "metadata.sources: resolved source registry blockers must be removed")
+  for (const rawPath of ["/zzz/live", "/zzz/latest", "/zzz/available"]) {
+    assert(metadataSourcesRow.rawFieldPaths?.includes(rawPath), `metadata.sources: missing raw path ${rawPath}`)
+  }
+
+  const metadataSourceRefsRow = resourceRows.get("metadata.sourceRefs")
+  assert(metadataSourceRefsRow !== undefined, "metadata.sourceRefs: missing SourceRef metadata row")
+  assert(metadataSourceRefsRow.status === "verified-from-nanoka", "metadata.sourceRefs: SourceRef row must be verified after adapter emission gate")
+  assert(metadataSourceRefsRow.promotable === true, "metadata.sourceRefs: SourceRef metadata must be promotable after emission gate")
+  assert(metadataSourceRefsRow.sampleEntity === "nanoka-bangboo-plugboo-live-54008", "metadata.sourceRefs: row must use approved live Plugboo metadata evidence")
+  assert(metadataSourceRefsRow.sourcePolicy === "derived-from-source-registry", "metadata.sourceRefs: row must derive from source registry")
+  assert((metadataSourceRefsRow.blockedBy ?? []).length === 0, "metadata.sourceRefs: resolved SourceRef blockers must be removed")
+  for (const rawPath of ["/assets/*/url", "/assets/*/localPath", "/assets/*/sourceVersion"]) {
+    assert(metadataSourceRefsRow.rawFieldPaths?.includes(rawPath), `metadata.sourceRefs: missing raw path ${rawPath}`)
+  }
+
   for (const fieldId of [
     "adrenaline.maxAdrenaline",
     "adrenaline.automaticAdrenalineAccumulation",

--- a/packages/data/src/metadata.ts
+++ b/packages/data/src/metadata.ts
@@ -4,6 +4,7 @@ import {
   type SourceDocument,
   type SourceRef,
 } from "@randomplay/core"
+import type { ParsedSourceBatch, ParsedSourceRecord } from "./adapters"
 import type { DataSourceDescriptor } from "./sources"
 
 export const DATA_SOURCE_SKELETON_PARSER_VERSION =
@@ -23,6 +24,15 @@ export interface BuildSourceRefOptions {
   sourceVersion?: string
   sourceAnchor?: string
   dataPath?: string
+}
+
+export interface SourceRegistryEntryForDocument {
+  sourceId: string
+  configuredLiveVersion: string
+  fetchedAt?: string
+  contentHash: string
+  liveVersionRef?: string
+  approvedLiveVersions?: readonly string[]
 }
 
 export function buildSourceDocument(
@@ -52,6 +62,35 @@ export function buildSourceDocument(
   return sourceDocumentSchema.parse(candidate)
 }
 
+export function buildSourceDocumentFromRegistryEntry(
+  descriptor: DataSourceDescriptor,
+  registryEntry: SourceRegistryEntryForDocument,
+  options: Omit<BuildSourceDocumentOptions, "fetchedAt" | "sourceVersion">,
+): SourceDocument {
+  if (registryEntry.sourceId !== descriptor.id)
+    throw new Error(`source registry entry ${registryEntry.sourceId} does not match descriptor ${descriptor.id}`)
+  if (!registryEntry.contentHash.startsWith("sha256:"))
+    throw new Error(`${registryEntry.sourceId}: source registry contentHash must be sha256-prefixed`)
+  if (
+    registryEntry.liveVersionRef === "manifest.zzz.live"
+    && !registryEntry.approvedLiveVersions?.includes(registryEntry.configuredLiveVersion)
+  ) {
+    throw new Error(`${registryEntry.sourceId}: approvedLiveVersions must include configuredLiveVersion`)
+  }
+
+  const sourceDocumentOptions: BuildSourceDocumentOptions = {
+    ...options,
+    sourceVersion: registryEntry.configuredLiveVersion,
+  }
+
+  if (registryEntry.fetchedAt !== undefined)
+    sourceDocumentOptions.fetchedAt = registryEntry.fetchedAt
+  if (descriptor.fileNameHint !== undefined)
+    sourceDocumentOptions.fileName = descriptor.fileNameHint
+
+  return buildSourceDocument(descriptor, sourceDocumentOptions)
+}
+
 export function buildSourceRef(
   descriptor: Pick<DataSourceDescriptor, "id">,
   options: BuildSourceRefOptions = {},
@@ -68,4 +107,27 @@ export function buildSourceRef(
     candidate.dataPath = options.dataPath
 
   return sourceRefSchema.parse(candidate)
+}
+
+export function buildSourceRefForParsedRecord(
+  batch: Pick<ParsedSourceBatch, "sourceId" | "sourceVersion">,
+  record: Pick<ParsedSourceRecord, "id" | "sourceAnchor" | "dataPath">,
+): SourceRef {
+  if (record.sourceAnchor === undefined || record.sourceAnchor.length === 0)
+    throw new Error(`${record.id}: sourceAnchor is required for SourceRef emission`)
+  if (record.dataPath === undefined || record.dataPath.length === 0)
+    throw new Error(`${record.id}: dataPath is required for SourceRef emission`)
+
+  return sourceRefSchema.parse({
+    sourceId: batch.sourceId,
+    sourceVersion: batch.sourceVersion,
+    sourceAnchor: record.sourceAnchor,
+    dataPath: record.dataPath,
+  })
+}
+
+export function buildSourceRefsForParsedBatch(
+  batch: Pick<ParsedSourceBatch, "sourceId" | "sourceVersion" | "records">,
+): SourceRef[] {
+  return batch.records.map(record => buildSourceRefForParsedRecord(batch, record))
 }

--- a/packages/data/src/missing-fields-failloud.test.ts
+++ b/packages/data/src/missing-fields-failloud.test.ts
@@ -50,11 +50,15 @@ describe("missing-fields fail-loud gate", () => {
     expect(unresolved.every(row => Array.isArray(row.blockedBy) && row.blockedBy.length > 0)).toBe(true)
     expect(unresolved.map(row => row.fieldId)).toEqual(
       expect.arrayContaining([
-        "metadata.sources",
-        "metadata.sourceRefs",
+        "agents.promotionExtraStats",
+        "bangboos.element",
         "driveDiscs.slotAndSubstatTables",
       ]),
     )
+    expect(unresolved.map(row => row.fieldId)).not.toEqual(expect.arrayContaining([
+      "metadata.sources",
+      "metadata.sourceRefs",
+    ]))
   })
 
   it("fails loudly when missing, deferred, or forbidden rows are present in a release report", () => {

--- a/packages/data/src/nanoka-adapter.test.ts
+++ b/packages/data/src/nanoka-adapter.test.ts
@@ -6,10 +6,13 @@ import { describe, expect, it } from "vitest"
 import {
   assertNanokaSnapshotManifest,
   buildSourceDocument,
+  buildSourceDocumentFromRegistryEntry,
+  buildSourceRefsForParsedBatch,
   createNanokaSnapshotAdapter,
   getDataSourceDescriptor,
   nanokaSnapshotRecords,
   type NanokaRawSnapshotManifest,
+  type ParsedSourceRecord,
   type SourceManifest,
 } from "./index"
 
@@ -93,6 +96,67 @@ describe("nanoka raw snapshot adapter skeleton", () => {
     })
   })
 
+  it("derives SourceDocument metadata from the source-registry contract", () => {
+    const registry = readJson<{
+      sources: Array<{
+        sourceId: string
+        configuredLiveVersion: string
+        fetchedAt?: string
+        contentHash: string
+        liveVersionRef?: string
+        approvedLiveVersions?: string[]
+      }>
+    }>("data/source-registry.json")
+    const registryEntry = registry.sources.find(source => source.sourceId === "nanoka-zzz")
+
+    expect(registryEntry, "missing nanoka source registry entry").toBeDefined()
+
+    const sourceDocument = buildSourceDocumentFromRegistryEntry(
+      getDataSourceDescriptor("nanoka-zzz"),
+      registryEntry!,
+      {
+        parsedAt: "2026-05-15T13:50:00+08:00",
+        parserVersion: "nanoka-source-v0.1.0",
+        gameVersion: "ZZZ-live",
+      },
+    )
+
+    expect(sourceDocument).toMatchObject({
+      id: "nanoka-zzz",
+      kind: "thirdPartySite",
+      url: "https://static.nanoka.cc/manifest.json",
+      sourceVersion: "2.8",
+      fetchedAt: registryEntry?.fetchedAt,
+    })
+    expect(registryEntry?.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(registryEntry?.liveVersionRef).toBe("manifest.zzz.live")
+    expect(registryEntry?.approvedLiveVersions).toContain(sourceDocument.sourceVersion)
+  })
+
+  it("fails loud when source-registry metadata cannot back SourceDocument derivation", () => {
+    const descriptor = getDataSourceDescriptor("nanoka-zzz")
+
+    expect(() =>
+      buildSourceDocumentFromRegistryEntry(descriptor, {
+        sourceId: "other-source",
+        configuredLiveVersion: "2.8",
+        contentHash: "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d",
+      }, {
+        parsedAt: "2026-05-15T13:50:00+08:00",
+      }),
+    ).toThrow("does not match descriptor")
+
+    expect(() =>
+      buildSourceDocumentFromRegistryEntry(descriptor, {
+        sourceId: "nanoka-zzz",
+        configuredLiveVersion: "2.8",
+        contentHash: "not-a-sha",
+      }, {
+        parsedAt: "2026-05-15T13:50:00+08:00",
+      }),
+    ).toThrow("contentHash must be sha256-prefixed")
+  })
+
   it("parses retained snapshot assets as metadata records without formal data promotion", async () => {
     const manifest = readJson<NanokaRawSnapshotManifest>(snapshotManifestPath)
     const adapter = createNanokaSnapshotAdapter({ manifest })
@@ -109,6 +173,57 @@ describe("nanoka raw snapshot adapter skeleton", () => {
       expect.arrayContaining(["manifest", "boss-index", "character-nekomata-1021", "character-yixuan-1371", "boss-69036"]),
     )
     expect(parsed.notes.join("\n")).toContain("source-gate only")
+  })
+
+  it("emits SourceRef anchors for every retained nanoka metadata record", async () => {
+    const manifest = readJson<NanokaRawSnapshotManifest>(snapshotManifestPath)
+    const adapter = createNanokaSnapshotAdapter({ manifest })
+    const raw = await adapter.fetch({ now: "2026-05-15T11:40:00+08:00" })
+    const parsed = await adapter.parse(raw, { now: "2026-05-15T11:40:00+08:00" })
+    const sourceRefs = buildSourceRefsForParsedBatch(parsed)
+
+    expect(sourceRefs).toHaveLength(parsed.records.length)
+    expect(sourceRefs).toEqual(expect.arrayContaining([
+      {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+        sourceAnchor: "https://static.nanoka.cc/manifest.json",
+        dataPath: "data/source/raw/nanoka/zzz/2.8/manifest.json",
+      },
+      {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+        sourceAnchor: "https://static.nanoka.cc/zzz/2.8/boss.json",
+        dataPath: "data/source/raw/nanoka/zzz/2.8/boss.json",
+      },
+      {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+        sourceAnchor: "https://static.nanoka.cc/zzz/2.8/zh/character/1021.json",
+        dataPath: "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+      },
+    ]))
+  })
+
+  it("fails loud when a parsed metadata record cannot emit a SourceRef", async () => {
+    const manifest = readJson<NanokaRawSnapshotManifest>(snapshotManifestPath)
+    const adapter = createNanokaSnapshotAdapter({ manifest })
+    const raw = await adapter.fetch({ now: "2026-05-15T11:40:00+08:00" })
+    const parsed = await adapter.parse(raw, { now: "2026-05-15T11:40:00+08:00" })
+
+    expect(() =>
+      buildSourceRefsForParsedBatch({
+        ...parsed,
+        records: [withoutSourceAnchor(parsed.records[0]!)],
+      }),
+    ).toThrow("sourceAnchor is required")
+
+    expect(() =>
+      buildSourceRefsForParsedBatch({
+        ...parsed,
+        records: [withoutDataPath(parsed.records[0]!)],
+      }),
+    ).toThrow("dataPath is required")
   })
 
   it("fails loud when raw adapter metadata does not match the payload snapshot", async () => {
@@ -171,3 +286,13 @@ describe("nanoka raw snapshot adapter skeleton", () => {
     expect(() => assertNanokaSnapshotManifest(unapprovedIndex)).toThrow("not allowed by nanoka urlPolicy")
   })
 })
+
+function withoutSourceAnchor(record: ParsedSourceRecord): ParsedSourceRecord {
+  const { sourceAnchor: _sourceAnchor, ...rest } = record
+  return rest
+}
+
+function withoutDataPath(record: ParsedSourceRecord): ParsedSourceRecord {
+  const { dataPath: _dataPath, ...rest } = record
+  return rest
+}

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -15,6 +15,7 @@ type SourceRegistry = {
 }
 
 type CoverageMatrix = {
+  status: string
   rows: Array<{
     fieldId: string
     status: string
@@ -22,6 +23,8 @@ type CoverageMatrix = {
     sampleEntity?: string
     supportingSampleEntities?: string[]
     blockedBy?: string[]
+    sourcePolicy?: string
+    rawFieldPaths?: string[]
   }>
 }
 
@@ -100,6 +103,38 @@ describe("nanoka source gate", () => {
         sampleEntity: "nanoka-character-yixuan-live-1371",
       })
     }
+  })
+
+  it("promotes metadata source registry and SourceRef rows only after executable gates exist", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
+
+    expect(matrix.status).toBe("phase-2-source-metadata-contract-gate")
+    expect(rows.get("metadata.sources")).toMatchObject({
+      status: "verified-from-nanoka",
+      promotable: true,
+      sampleEntity: "nanoka-manifest",
+      sourcePolicy: "derived-from-source-registry",
+    })
+    expect(rows.get("metadata.sources")?.blockedBy ?? []).toEqual([])
+    expect(rows.get("metadata.sources")?.rawFieldPaths).toEqual(expect.arrayContaining([
+      "/zzz/live",
+      "/zzz/latest",
+      "/zzz/available",
+    ]))
+
+    expect(rows.get("metadata.sourceRefs")).toMatchObject({
+      status: "verified-from-nanoka",
+      promotable: true,
+      sampleEntity: "nanoka-bangboo-plugboo-live-54008",
+      sourcePolicy: "derived-from-source-registry",
+    })
+    expect(rows.get("metadata.sourceRefs")?.blockedBy ?? []).toEqual([])
+    expect(rows.get("metadata.sourceRefs")?.rawFieldPaths).toEqual(expect.arrayContaining([
+      "/assets/*/url",
+      "/assets/*/localPath",
+      "/assets/*/sourceVersion",
+    ]))
   })
 
   it("locks enemy variant mapping to approved live monster detail samples", () => {


### PR DESCRIPTION
## Summary
- promotes metadata.sources and metadata.sourceRefs from needs-tl-research to verified/promotable in the mirrored nanoka coverage matrix
- adds source-registry-derived SourceDocument helper and parsed-record SourceRef emission helper with fail-loud tests
- extends verify:source-registry and source-gate tests to lock metadata row evidence, live sample usage, and mirror counts

## Verification
- pnpm --filter @randomplay/data verify:source-registry
- pnpm --filter @randomplay/data verify:nanoka
- pnpm --filter @randomplay/data test
- pnpm check
- pnpm build
- pnpm test
- pnpm --filter @randomplay/data verify:golden-v1
- pnpm --filter @randomplay/data pack --dry-run --json + package raw-source exclusion check
- git diff --check