### PR TITLE
feat(data): add nanoka drive disc slot audit

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T14:40:00+08:00",
-  "status": "phase-2-bangboo-element-gate",
+  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "status": "phase-2-drive-disc-slot-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1094,16 +1094,25 @@
       "canonicalPath": "DriveDiscSnapshot.slot/setId and future GameData drive disc stat tables",
       "fieldClass": "optional",
       "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "/{locale}/equipment/{id}.json or other nanoka config endpoint",
-      "rawFieldPaths": [],
-      "transformRule": "find source tables for slot main stats and substat increments if the cleaned schema keeps those generated defaults",
-      "sampleEntity": "nanoka-equipment-woodpecker-31000",
+      "status": "needs-owner-research",
+      "nanokaEndpoint": "/equipment.json, /{locale}/equipment/{id}.json, and checked candidate stat-table endpoints",
+      "rawFieldPaths": [
+        "/equipment.json/{id}/{locale}/desc2",
+        "/equipment.json/{id}/{locale}/desc4",
+        "/id",
+        "/name",
+        "/desc2",
+        "/desc4"
+      ],
+      "transformRule": "nanoka live equipment index/detail only expose Drive Disc set identity and set-effect text; checked candidate slot/main/substat table endpoints are absent, so do not synthesize slot, main-stat, substat, level, or stat-roll tables. Escalate per R3 for owner decision: remove from V0.1.0 formal-data scope or approve research of a non-nanoka source.",
+      "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:drive-disc-stat-tables-not-found-in-sampled-detail"
-      ]
+        "owner:drive-disc-slot-stat-source-required"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
+      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. The row stays non-promotable and owner-research gated to preserve the no-fabrication/no-silent-fallback rule."
     },
     {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
@@ -1288,8 +1297,8 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 3,
-    "needsOwnerResearch": 0,
+    "needsTlResearch": 2,
+    "needsOwnerResearch": 1,
     "deferred": 6,
     "promotableNow": 20,
     "notPromotableYet": 25
@@ -1302,10 +1311,10 @@
     "typed modifier templates for passives, W-Engines, Drive Discs, enemy rules, DA buffs, and Sentinel rows",
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics after variant mapping",
     "W-Engine stat/refine mapping",
-    "Drive Disc slot main stat and substat table source",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "disorder formula and disorder daze-level source/config endpoint"
+    "disorder formula and disorder daze-level source/config endpoint",
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
+++ b/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "nanoka-drive-disc-slot-stat-audit/v0.1",
+  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "driveDiscs.slotAndSubstatTables",
+  "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 9,
+    "foundSlotMainSubstatTable": false,
+    "ownerResearchRequired": true
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment.json",
+      "status": 200,
+      "finding": "Drive Disc set-effect index only. Entries contain icon plus localized name/desc2/desc4; no slot, main-stat, substat, level, or stat-roll table fields."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/equipment/31000.json",
+      "contentSha256": "4190f6084521aead931a28ada9a44e6d9cd26a7fdb2401ffd0ab4e00a257f1ec",
+      "presentRawFieldPaths": [
+        "/id",
+        "/name",
+        "/desc2",
+        "/desc4"
+      ],
+      "missingRawFieldPaths": [
+        "/slot",
+        "/part",
+        "/main_property",
+        "/rand_property",
+        "/level",
+        "/stats"
+      ],
+      "finding": "Localized equipment detail only exposes set identity and set-effect text for Woodpecker Electro."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_stat.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_config.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_level.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_main_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_rand_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/item/33921.json",
+      "status": 404,
+      "finding": "Candidate per-disc item detail from manifest item-style ids not present."
+    }
+  ],
+  "decision": {
+    "matrixStatus": "needs-owner-research",
+    "blockedBy": [
+      "owner:drive-disc-slot-stat-source-required"
+    ],
+    "recommendedEscalation": "lo-user/Product should decide whether Drive Disc slot/main/substat tables are out of V0.1.0 formal-data scope or whether a non-nanoka source must be researched."
+  }
+}

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,11 +1,11 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 2 Bangboo element gate
+Status: Phase 2 Drive Disc slot/stat audit gate
 Owner: @TechLead
 Reviewers: @Product, @QA
 Related: D-20 data-source migration, task #121, task #122, task #125, task #127,
 task #138, task #140, task #142, task #144, task #146, task #148, task #150,
-task #152
+task #152, task #154
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
@@ -35,7 +35,7 @@ The release source version is no longer the provisional
 |---|---|
 | `verified-from-nanoka` | Sampled nanoka endpoint and raw path exist. The field is promotable only when `promotable=true`. |
 | `needs-tl-research` | Evidence is incomplete, semantic mapping is unresolved, or transform rules are not yet proven. |
-| `needs-owner-research` | TL exhausted nanoka research and the item must be escalated to lo-user. No current rows use this status yet. |
+| `needs-owner-research` | TL exhausted nanoka research and the item must be escalated to lo-user before promotion or scope removal. |
 | `deferred` | Explicitly not promotable in the current implementation step, or implementation-owned rather than a nanoka gameplay row. |
 
 The machine-readable version is
@@ -55,7 +55,8 @@ The machine-readable version is
 | Enemy / Dullahan research sample | `https://static.nanoka.cc/zzz/3.0.2+15625449/zh/monster/30000.json` | Research-only `monster_info.*.stats`, `curves`, `element`, `element_abnormal`; not approved for cleaned output. |
 | Live enemy variant mapping samples | `https://static.nanoka.cc/zzz/2.8/zh/monster/{id}.json` | Approved live samples for Dullahan `30000`, Greta `30004`, Ruthless Fiend `200141`, Notorious Hati `200014`, Notorious Armored Hati `200034`, Miasma Priest `30033`, and Notorious Pompey `300211`. Task #144 proves `detail.monster_id -> monster_info[monster_id]` for G13/G18/G19/G20 source artifacts. |
 | Live W-Engine / Yixuan signature sample | `https://static.nanoka.cc/zzz/2.8/zh/weapon/14137.json` | Approved live sample for W-Engine identity; `base_property`, `rand_property`, `level`, `stars`, and `talents` remain blocked for stat/passive promotion until mapping/templates are proven. |
-| Live Drive Disc / Woodpecker Electro sample | `https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json` | Approved live sample for Drive Disc identity; `desc2` / `desc4` text exists, but typed modifiers are not promotable until deterministic parsing/templates exist. |
+| Live Drive Disc / Woodpecker Electro sample | `https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json` | Approved live sample for Drive Disc identity; `desc2` / `desc4` text exists, but typed modifiers are not promotable until deterministic parsing/templates exist. Task #154 confirms this detail does not expose slot/main/substat tables. |
+| Live Drive Disc / equipment index audit | `https://static.nanoka.cc/zzz/2.8/equipment.json` | Failed-evidence audit only: live equipment index exposes set name/`desc2`/`desc4` text, not slot/main/substat tables. Candidate stat-table endpoints checked in `data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json` returned 404. |
 | Manifest / live gate | `https://static.nanoka.cc/manifest.json` | `zzz.live = 2.8`, `zzz.latest = 3.0.2+15625449`, `zzz.available[]` supports approved-live version allowlists and snapshot-derived patch diff history. |
 | Live Adrenaline / Resonance sample / Yixuan | `https://static.nanoka.cc/zzz/2.8/zh/character/1371.json` | `stats.rp_max = 120`, `stats.rp_recover = 200`, `fever_recovery`, and `rp_recovery` raw paths exist in the configured live version. |
 | Live Deadly Assault index | `https://static.nanoka.cc/zzz/2.8/boss.json` | 38 live DA entries; all sampled `zh/boss/{id}.json` details returned 200 in PR #54. |
@@ -102,8 +103,8 @@ until Phase 3/4 drift/cutover.
 
 ## Human-Readable Summary
 
-Machine summary after task #152: 45 rows total, 36 `verified-from-nanoka`, 3
-`needs-tl-research`, 0 `needs-owner-research`, 6 `deferred`, and 20
+Machine summary after task #154: 45 rows total, 36 `verified-from-nanoka`, 2
+`needs-tl-research`, 1 `needs-owner-research`, 6 `deferred`, and 20
 `promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
@@ -125,20 +126,27 @@ Machine summary after task #152: 45 rows total, 36 `verified-from-nanoka`, 3
 | W-Engine stats | verified-from-nanoka | no | Detail endpoint exists; ID mapping and stat normalization are unresolved. |
 | W-Engine passive | verified-from-nanoka | no | Raw text/objects exist; typed modifier template is unresolved. |
 | Drive Disc set effects | verified-from-nanoka | no | Raw text exists; typed modifier template is unresolved. |
-| Drive Disc slot/main/sub stats | needs-tl-research | no | Not found in sampled equipment detail endpoint. |
+| Drive Disc slot/main/sub stats | needs-owner-research | no | Task #154 exhausted live nanoka equipment detail/index and candidate stat-table endpoints; no slot/main/substat table source was found, so lo-user/Product must decide out-of-scope vs approved non-nanoka source research. |
 | Resonium / Lost Void | removed | no | Removed from V0.1.0 product scope by R4; no formal data expected. |
 | Deadly Assault periods/buffs | verified-from-nanoka | yes | Structured source artifact mapping exists for period, zones, buffs, monsters, weakness, rank goals, and `boss_adjust`; runtime cutover still waits for Phase 3 drift audit. |
 | Formula rule tables | mixed | no | Must be split per rule: defense/rounding may be implementation-owned, while anomaly thresholds, daze recovery, disorder, and attribute mappings need row-level owner/source decisions. |
 
 ## Remaining TL Research Rows
 
-After task #152, 3 rows remain in `needs-tl-research`:
+After task #154, 2 rows remain in `needs-tl-research`:
 
-- `driveDiscs.slotAndSubstatTables` — sampled equipment detail did not expose
-  slot/main/sub-stat tables.
 - `rules.disorderFormula` — source or implementation owner still unresolved.
 - `rules.disorderDazeLevelZone` — source or implementation owner still
   unresolved.
+
+## Owner Research / Decision Rows
+
+After task #154, 1 row is escalated to `needs-owner-research`:
+
+- `driveDiscs.slotAndSubstatTables` — approved live nanoka equipment detail and
+  index expose only Drive Disc set identity/effect text; checked candidate
+  stat-table endpoints are absent. Owner decision required: remove this from
+  V0.1.0 formal-data scope or approve non-nanoka source research.
 
 ## Current Scope Rows Added By R1/R4/R6
 

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T14:40:00+08:00",
-  "status": "phase-2-bangboo-element-gate",
+  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "status": "phase-2-drive-disc-slot-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1094,16 +1094,25 @@
       "canonicalPath": "DriveDiscSnapshot.slot/setId and future GameData drive disc stat tables",
       "fieldClass": "optional",
       "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "/{locale}/equipment/{id}.json or other nanoka config endpoint",
-      "rawFieldPaths": [],
-      "transformRule": "find source tables for slot main stats and substat increments if the cleaned schema keeps those generated defaults",
-      "sampleEntity": "nanoka-equipment-woodpecker-31000",
+      "status": "needs-owner-research",
+      "nanokaEndpoint": "/equipment.json, /{locale}/equipment/{id}.json, and checked candidate stat-table endpoints",
+      "rawFieldPaths": [
+        "/equipment.json/{id}/{locale}/desc2",
+        "/equipment.json/{id}/{locale}/desc4",
+        "/id",
+        "/name",
+        "/desc2",
+        "/desc4"
+      ],
+      "transformRule": "nanoka live equipment index/detail only expose Drive Disc set identity and set-effect text; checked candidate slot/main/substat table endpoints are absent, so do not synthesize slot, main-stat, substat, level, or stat-roll tables. Escalate per R3 for owner decision: remove from V0.1.0 formal-data scope or approve research of a non-nanoka source.",
+      "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:drive-disc-stat-tables-not-found-in-sampled-detail"
-      ]
+        "owner:drive-disc-slot-stat-source-required"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
+      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. The row stays non-promotable and owner-research gated to preserve the no-fabrication/no-silent-fallback rule."
     },
     {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
@@ -1288,8 +1297,8 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 3,
-    "needsOwnerResearch": 0,
+    "needsTlResearch": 2,
+    "needsOwnerResearch": 1,
     "deferred": 6,
     "promotableNow": 20,
     "notPromotableYet": 25
@@ -1302,10 +1311,10 @@
     "typed modifier templates for passives, W-Engines, Drive Discs, enemy rules, DA buffs, and Sentinel rows",
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics after variant mapping",
     "W-Engine stat/refine mapping",
-    "Drive Disc slot main stat and substat table source",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "disorder formula and disorder daze-level source/config endpoint"
+    "disorder formula and disorder daze-level source/config endpoint",
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
+++ b/packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "nanoka-drive-disc-slot-stat-audit/v0.1",
+  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "driveDiscs.slotAndSubstatTables",
+  "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 9,
+    "foundSlotMainSubstatTable": false,
+    "ownerResearchRequired": true
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment.json",
+      "status": 200,
+      "finding": "Drive Disc set-effect index only. Entries contain icon plus localized name/desc2/desc4; no slot, main-stat, substat, level, or stat-roll table fields."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/equipment/31000.json",
+      "contentSha256": "4190f6084521aead931a28ada9a44e6d9cd26a7fdb2401ffd0ab4e00a257f1ec",
+      "presentRawFieldPaths": [
+        "/id",
+        "/name",
+        "/desc2",
+        "/desc4"
+      ],
+      "missingRawFieldPaths": [
+        "/slot",
+        "/part",
+        "/main_property",
+        "/rand_property",
+        "/level",
+        "/stats"
+      ],
+      "finding": "Localized equipment detail only exposes set identity and set-effect text for Woodpecker Electro."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_stat.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_config.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_level.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_main_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/equipment_rand_property.json",
+      "status": 404,
+      "finding": "Candidate slot/stat-table index not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/item/33921.json",
+      "status": 404,
+      "finding": "Candidate per-disc item detail from manifest item-style ids not present."
+    }
+  ],
+  "decision": {
+    "matrixStatus": "needs-owner-research",
+    "blockedBy": [
+      "owner:drive-disc-slot-stat-source-required"
+    ],
+    "recommendedEscalation": "lo-user/Product should decide whether Drive Disc slot/main/substat tables are out of V0.1.0 formal-data scope or whether a non-nanoka source must be researched."
+  }
+}

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -10,6 +10,8 @@ const packageRegistryPath = join(packageDir, "source-registry.json")
 const matrixPath = join(repoRoot, "data/cleaned/audit/nanoka-coverage-matrix.json")
 const rootSnapshotDiffHistoryPath = join(repoRoot, "data/cleaned/audit/nanoka-snapshot-diff-history.json")
 const packageSnapshotDiffHistoryPath = join(packageDir, "cleaned/audit/nanoka-snapshot-diff-history.json")
+const rootDriveDiscSlotStatAuditPath = join(repoRoot, "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
+const packageDriveDiscSlotStatAuditPath = join(packageDir, "cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
 
 const redistributionRisks = new Set([
   "accepted-by-owner",
@@ -118,7 +120,7 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   const nanoka = sourceById(registry, "nanoka-zzz")
   validateNanokaRegistry(nanoka)
 
-  assert(matrix.status === "phase-2-bangboo-element-gate", "matrix status must match the latest Bangboo element gate")
+  assert(matrix.status === "phase-2-drive-disc-slot-audit-gate", "matrix status must match the latest Drive Disc slot/stat audit gate")
   assert(matrix.sourceVersionPolicy?.liveVersionRef === nanoka.liveVersionRef, "matrix liveVersionRef must match nanoka registry")
   assert(matrix.sourceVersionPolicy?.defaultReleaseSourceVersion === nanoka.configuredLiveVersion, "matrix default release version must match configuredLiveVersion")
   assert(matrix.sourceVersionResolved === nanoka.configuredLiveVersion, "matrix resolved sourceVersion must match configuredLiveVersion")
@@ -187,6 +189,18 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   assert(bangbooElementRow.transformRule?.includes("source /id to match the requested Bangboo id"), "bangboos.element: transform must bind source /id to requested Bangboo id")
   for (const rawPath of ["/id", "/skill/*/level/*/desc"]) {
     assert(bangbooElementRow.rawFieldPaths?.includes(rawPath), `bangboos.element: missing raw path ${rawPath}`)
+  }
+
+  const driveDiscSlotRow = resourceRows.get("driveDiscs.slotAndSubstatTables")
+  assert(driveDiscSlotRow !== undefined, "driveDiscs.slotAndSubstatTables: missing Drive Disc slot/stat row")
+  assert(driveDiscSlotRow.status === "needs-owner-research", "driveDiscs.slotAndSubstatTables: row must escalate after failed nanoka audit")
+  assert(driveDiscSlotRow.promotable === false, "driveDiscs.slotAndSubstatTables: failed-evidence row must not be promotable")
+  assert(driveDiscSlotRow.sampleEntity === "nanoka-equipment-woodpecker-live-31000", "driveDiscs.slotAndSubstatTables: row must use approved live Woodpecker sample evidence")
+  assert(driveDiscSlotRow.blockedBy?.includes("owner:drive-disc-slot-stat-source-required"), "driveDiscs.slotAndSubstatTables: row must carry owner escalation blocker")
+  assert(driveDiscSlotRow.auditArtifact === "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json", "driveDiscs.slotAndSubstatTables: row must point to failed-evidence audit artifact")
+  assert(driveDiscSlotRow.transformRule?.includes("do not synthesize"), "driveDiscs.slotAndSubstatTables: transform must preserve no-fabrication boundary")
+  for (const rawPath of ["/id", "/name", "/desc2", "/desc4"]) {
+    assert(driveDiscSlotRow.rawFieldPaths?.includes(rawPath), `driveDiscs.slotAndSubstatTables: missing observed raw path ${rawPath}`)
   }
 
   const promotionExtraRow = resourceRows.get("agents.promotionExtraStats")
@@ -309,6 +323,42 @@ function validateSnapshotDiffHistory(registry) {
   }
 }
 
+function validateDriveDiscSlotStatAudit(registry) {
+  const { rootText } = readMirroredText(
+    rootDriveDiscSlotStatAuditPath,
+    packageDriveDiscSlotStatAuditPath,
+    "packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
+  )
+
+  const nanoka = sourceById(registry, "nanoka-zzz")
+  const audit = JSON.parse(rootText)
+  assert(audit.schemaVersion === "nanoka-drive-disc-slot-stat-audit/v0.1", "Drive Disc slot/stat audit schemaVersion drifted")
+  assert(audit.sourceId === "nanoka-zzz", "Drive Disc slot/stat audit sourceId drifted")
+  assert(audit.sourceVersion === nanoka.configuredLiveVersion, "Drive Disc slot/stat audit must use configured live version")
+  assert(audit.status === "not-found", "Drive Disc slot/stat audit must remain failed-evidence until a source is proven")
+  assert(audit.fieldId === "driveDiscs.slotAndSubstatTables", "Drive Disc slot/stat audit fieldId drifted")
+  assert(audit.sampleEntity === "nanoka-equipment-woodpecker-live-31000", "Drive Disc slot/stat audit sampleEntity drifted")
+  assert(audit.runtimeCutoverReady === false, "Drive Disc slot/stat audit must not imply runtime cutover")
+  assert(audit.summary?.foundSlotMainSubstatTable === false, "Drive Disc slot/stat audit must not claim slot/stat table found")
+  assert(audit.summary?.ownerResearchRequired === true, "Drive Disc slot/stat audit must require owner research")
+
+  const endpoints = audit.checkedEndpoints ?? []
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/equipment.json" && endpoint.status === 200), "Drive Disc slot/stat audit must record live equipment index check")
+  const detail = endpoints.find(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json")
+  assert(detail?.status === 200, "Drive Disc slot/stat audit must record live Woodpecker detail check")
+  assert(detail.contentSha256 === "4190f6084521aead931a28ada9a44e6d9cd26a7fdb2401ffd0ab4e00a257f1ec", "Drive Disc slot/stat audit detail hash drifted")
+  for (const rawPath of ["/id", "/name", "/desc2", "/desc4"]) {
+    assert(detail.presentRawFieldPaths?.includes(rawPath), `Drive Disc slot/stat audit detail missing present raw path ${rawPath}`)
+  }
+  for (const rawPath of ["/slot", "/part", "/main_property", "/rand_property", "/level", "/stats"]) {
+    assert(detail.missingRawFieldPaths?.includes(rawPath), `Drive Disc slot/stat audit detail missing absent raw path ${rawPath}`)
+  }
+  assert(endpoints.some(endpoint => endpoint.status === 404 && endpoint.url.endsWith("/equipment_main_property.json")), "Drive Disc slot/stat audit must record missing main-property candidate endpoint")
+  assert(endpoints.some(endpoint => endpoint.status === 404 && endpoint.url.endsWith("/equipment_rand_property.json")), "Drive Disc slot/stat audit must record missing substat candidate endpoint")
+  assert(audit.decision?.matrixStatus === "needs-owner-research", "Drive Disc slot/stat audit decision must match owner-research matrix status")
+  assert(audit.decision?.blockedBy?.includes("owner:drive-disc-slot-stat-source-required"), "Drive Disc slot/stat audit decision must carry owner blocker")
+}
+
 function validateCoveredSourceRefs(registry) {
   const sourceIds = new Set(registry.sources.map(source => source.sourceId))
   const files = [
@@ -336,6 +386,7 @@ function main() {
   validateRegistryShape(registry)
   validateMatrixAgainstRegistry(matrix, registry)
   validateSnapshotDiffHistory(registry)
+  validateDriveDiscSlotStatAudit(registry)
   validateCoveredSourceRefs(registry)
 
   console.log("source registry verification passed")

--- a/packages/data/src/missing-fields-failloud.test.ts
+++ b/packages/data/src/missing-fields-failloud.test.ts
@@ -10,6 +10,7 @@ type CoverageRow = {
   status: string
   promotable: boolean
   blockedBy?: string[]
+  auditArtifact?: string
 }
 
 type CoverageMatrix = {
@@ -50,17 +51,28 @@ describe("missing-fields fail-loud gate", () => {
     expect(unresolved.every(row => Array.isArray(row.blockedBy) && row.blockedBy.length > 0)).toBe(true)
     expect(unresolved.map(row => row.fieldId)).toEqual(
       expect.arrayContaining([
-        "driveDiscs.slotAndSubstatTables",
         "rules.disorderFormula",
         "rules.disorderDazeLevelZone",
       ]),
     )
+    expect(unresolved.map(row => row.fieldId)).not.toContain("driveDiscs.slotAndSubstatTables")
     expect(unresolved.map(row => row.fieldId)).not.toEqual(expect.arrayContaining([
       "metadata.sources",
       "metadata.sourceRefs",
       "agents.promotionExtraStats",
       "bangboos.element",
     ]))
+  })
+
+  it("keeps owner-escalated rows machine-readable and non-promotable", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const ownerRows = matrix.rows.filter(row => row.status === "needs-owner-research")
+    const driveDiscRow = ownerRows.find(row => row.fieldId === "driveDiscs.slotAndSubstatTables")
+
+    expect(driveDiscRow).toBeDefined()
+    expect(driveDiscRow?.promotable).toBe(false)
+    expect(driveDiscRow?.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(driveDiscRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
   })
 
   it("fails loudly when missing, deferred, or forbidden rows are present in a release report", () => {

--- a/packages/data/src/nanoka-drive-disc-slot-audit.test.ts
+++ b/packages/data/src/nanoka-drive-disc-slot-audit.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+
+type DriveDiscSlotStatAudit = {
+  schemaVersion: string
+  sourceId: string
+  sourceVersion: string
+  status: string
+  fieldId: string
+  sampleEntity: string
+  runtimeCutoverReady: boolean
+  summary: {
+    checkedEndpointCount: number
+    foundSlotMainSubstatTable: boolean
+    ownerResearchRequired: boolean
+  }
+  checkedEndpoints: Array<{
+    url: string
+    status: number
+    contentSha256?: string
+    presentRawFieldPaths?: string[]
+    missingRawFieldPaths?: string[]
+  }>
+  decision: {
+    matrixStatus: string
+    blockedBy: string[]
+  }
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8")) as T
+}
+
+describe("nanoka Drive Disc slot/stat failed-evidence audit", () => {
+  it("keeps the package audit artifact mirror byte-identical", () => {
+    expect(readFileSync(join(repoRoot, "packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json"), "utf8")).toBe(
+      readFileSync(join(repoRoot, "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json"), "utf8"),
+    )
+  })
+
+  it("records failed nanoka evidence without promoting or fabricating stat tables", () => {
+    const audit = readJson<DriveDiscSlotStatAudit>("data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
+
+    expect(audit).toMatchObject({
+      schemaVersion: "nanoka-drive-disc-slot-stat-audit/v0.1",
+      sourceId: "nanoka-zzz",
+      sourceVersion: "2.8",
+      status: "not-found",
+      fieldId: "driveDiscs.slotAndSubstatTables",
+      sampleEntity: "nanoka-equipment-woodpecker-live-31000",
+      runtimeCutoverReady: false,
+      summary: {
+        foundSlotMainSubstatTable: false,
+        ownerResearchRequired: true,
+      },
+      decision: {
+        matrixStatus: "needs-owner-research",
+      },
+    })
+    expect(audit.decision.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(audit.checkedEndpoints).toHaveLength(audit.summary.checkedEndpointCount)
+    expect(audit.checkedEndpoints).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/equipment.json",
+        status: 200,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/equipment_main_property.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/equipment_rand_property.json",
+        status: 404,
+      }),
+    ]))
+  })
+
+  it("locks the observed live equipment detail shape", () => {
+    const audit = readJson<DriveDiscSlotStatAudit>("data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
+    const detail = audit.checkedEndpoints.find(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json")
+
+    expect(detail).toBeDefined()
+    expect(detail).toMatchObject({
+      status: 200,
+      contentSha256: "4190f6084521aead931a28ada9a44e6d9cd26a7fdb2401ffd0ab4e00a257f1ec",
+    })
+    expect(detail?.presentRawFieldPaths).toEqual(expect.arrayContaining([
+      "/id",
+      "/name",
+      "/desc2",
+      "/desc4",
+    ]))
+    expect(detail?.missingRawFieldPaths).toEqual(expect.arrayContaining([
+      "/slot",
+      "/part",
+      "/main_property",
+      "/rand_property",
+      "/level",
+      "/stats",
+    ]))
+  })
+})

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -26,6 +26,7 @@ type CoverageMatrix = {
     sourcePolicy?: string
     rawFieldPaths?: string[]
     transformRule?: string
+    auditArtifact?: string
   }>
 }
 
@@ -110,7 +111,7 @@ describe("nanoka source gate", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
 
-    expect(matrix.status).toBe("phase-2-bangboo-element-gate")
+    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
     expect(rows.get("metadata.sources")).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -143,7 +144,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("agents.promotionExtraStats")
 
-    expect(matrix.status).toBe("phase-2-bangboo-element-gate")
+    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -170,7 +171,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("bangboos.element")
 
-    expect(matrix.status).toBe("phase-2-bangboo-element-gate")
+    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -207,5 +208,26 @@ describe("nanoka source gate", () => {
     ]))
     for (const row of matrix.rows)
       expect(row.blockedBy ?? []).not.toContain("field:variant-mapping-required")
+  })
+
+  it("escalates Drive Disc slot/stat tables with failed nanoka evidence", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
+    const row = rows.get("driveDiscs.slotAndSubstatTables")
+
+    expect(row).toMatchObject({
+      status: "needs-owner-research",
+      promotable: false,
+      sampleEntity: "nanoka-equipment-woodpecker-live-31000",
+      auditArtifact: "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
+    })
+    expect(row?.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(row?.rawFieldPaths).toEqual(expect.arrayContaining([
+      "/id",
+      "/name",
+      "/desc2",
+      "/desc4",
+    ]))
+    expect(row?.transformRule).toContain("do not synthesize")
   })
 })


### PR DESCRIPTION
## Summary
- adds mirrored failed-evidence audit artifacts for Drive Disc slot/main/substat table coverage
- moves `driveDiscs.slotAndSubstatTables` from `needs-tl-research` to `needs-owner-research` after approved live nanoka evidence did not expose slot/stat tables
- locks verifier/source-gate/missing-fields tests so the row remains non-promotable and no synthetic tables enter cleaned output

## Verification
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data test -- nanoka-drive-disc-slot-audit.test.ts nanoka-source-gate.test.ts missing-fields-failloud.test.ts`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data pack --dry-run --json > /tmp/fairy-data-pack-154.json`
- custom matrix/pack mirror/raw-source-exclusion check
- `git diff --check` / `git diff --cached --check`

No runtime cleaned-data cutover.