### PR TITLE
feat(data): add nanoka disorder formula audit

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:05:00+08:00",
-  "status": "phase-2-drive-disc-slot-audit-gate",
+  "generatedAt": "2026-05-15T15:20:00+08:00",
+  "status": "phase-2-disorder-formula-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1225,18 +1225,20 @@
     {
       "fieldId": "rules.disorderFormula",
       "canonicalPath": "GameData.rules.disorder / getDisorderFormula",
-      "fieldClass": "required",
-      "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "unknown nanoka config endpoint",
+      "fieldClass": "implementation-owned",
+      "sourcePolicy": "implementation-owned",
+      "status": "deferred",
+      "nanokaEndpoint": null,
       "rawFieldPaths": [],
-      "transformRule": "find source-backed disorder constants/formula ids or classify per-row as implementation-owned with decision evidence",
+      "transformRule": "Fairy owns the runtime Disorder formula contract in core and verifies it through guide-anchored golden replay G15; approved live nanoka formula/rule/disorder endpoints are absent and entity indexes/details do not expose a Disorder formula table. Do not synthesize source-backed formula rows from entity text.",
       "sampleEntity": null,
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:disorder-rule-source-required"
-      ]
+        "implementation-owned-runtime-formula"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+      "notes": "Task #156 classifies this as implementation-owned after nanoka failed-evidence audit. Existing trace sourceAnchor remains guide-3.4.1 and executable replay remains G15."
     },
     {
       "fieldId": "rules.disorderDazeLevelZone",
@@ -1297,9 +1299,9 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 2,
+    "needsTlResearch": 1,
     "needsOwnerResearch": 1,
-    "deferred": 6,
+    "deferred": 7,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1313,8 +1315,8 @@
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "disorder formula and disorder daze-level source/config endpoint",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research",
+    "disorder daze-level source/config endpoint"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/data/cleaned/audit/nanoka-disorder-formula-audit.json
+++ b/data/cleaned/audit/nanoka-disorder-formula-audit.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "nanoka-disorder-formula-audit/v0.1",
+  "generatedAt": "2026-05-15T15:20:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "rules.disorderFormula",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 12,
+    "foundDisorderFormulaTable": false,
+    "implementationOwnedRuntimeFormula": true,
+    "ownerResearchRequired": false
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/formula.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/rules.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder.json",
+      "status": 404,
+      "finding": "Candidate Disorder formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/anomaly_disorder.json",
+      "status": 404,
+      "finding": "Candidate anomaly/Disorder formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/battle_formula.json",
+      "status": 404,
+      "finding": "Candidate battle formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_formula.json",
+      "status": 404,
+      "finding": "Candidate damage formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/element_abnormal.json",
+      "status": 404,
+      "finding": "Candidate anomaly-status endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is character metadata/text and does not provide a global Disorder formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is monster metadata and does not provide a global Disorder formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/boss.json",
+      "contentSha256": "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9",
+      "finding": "Deadly Assault index exists, but it does not provide Disorder formula constants."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/monster/30000.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+      "contentSha256": "99b2286a6a5a3847f067cfc06bd5c5c44b4a3eb2b1b5609df7af820eea55e855",
+      "finding": "Monster detail exposes variant stats and anomaly-related resistance/build-up fields, but no Disorder multiplier formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+      "contentSha256": "781cb67799e6fb8c0438ab57ac5536507b85292161342f9870c18f42d890989f",
+      "finding": "Deadly Assault period detail exposes buffs, rooms, weakness data, and boss_adjust, but no Disorder formula constants."
+    }
+  ],
+  "implementationContract": {
+    "sourceAnchors": [
+      "guide-3.4.1",
+      "golden-v1:G15"
+    ],
+    "coreFormulaIds": [
+      "disorder-burn",
+      "disorder-shock",
+      "disorder-corruption",
+      "disorder-frost",
+      "disorder-physical-or-ice",
+      "disorder-polarity"
+    ],
+    "formulaBoundary": "Fairy owns the runtime Disorder formula contract in core and verifies it through golden replay; nanoka is not expected to provide a source-backed formula table for this row."
+  },
+  "decision": {
+    "matrixStatus": "deferred",
+    "sourcePolicy": "implementation-owned",
+    "blockedBy": [
+      "implementation-owned-runtime-formula"
+    ],
+    "recommendedEscalation": "No owner escalation for this row. Keep the formula contract implementation-owned unless Product later requests source-backed formula-table extraction."
+  }
+}

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,11 +1,11 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 2 Drive Disc slot/stat audit gate
+Status: Phase 2 Disorder formula audit gate
 Owner: @TechLead
 Reviewers: @Product, @QA
 Related: D-20 data-source migration, task #121, task #122, task #125, task #127,
 task #138, task #140, task #142, task #144, task #146, task #148, task #150,
-task #152, task #154
+task #152, task #154, task #156
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
@@ -61,6 +61,7 @@ The machine-readable version is
 | Live Adrenaline / Resonance sample / Yixuan | `https://static.nanoka.cc/zzz/2.8/zh/character/1371.json` | `stats.rp_max = 120`, `stats.rp_recover = 200`, `fever_recovery`, and `rp_recovery` raw paths exist in the configured live version. |
 | Live Deadly Assault index | `https://static.nanoka.cc/zzz/2.8/boss.json` | 38 live DA entries; all sampled `zh/boss/{id}.json` details returned 200 in PR #54. |
 | Live Deadly Assault period / 69036 | `https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json` | Current live period window, zones, layer/selectable buffs, room monster lists, weakness data, and `boss_adjust`. |
+| Live rules / formula candidate audit | `https://static.nanoka.cc/zzz/2.8/{formula,rules,disorder,anomaly_disorder,battle_formula,damage_formula,element_abnormal}.json` | Failed-evidence audit only: dedicated live formula/rule/disorder endpoints are absent. Existing entity indexes/details do not expose a global Disorder formula table, so task #156 classifies `rules.disorderFormula` as implementation-owned runtime formula evidence. |
 
 The `3.0.2+15625449` samples are retained as phase-0 research evidence, not as
 release-ready source evidence. Phase 2 slice 3 re-sampled existing
@@ -103,8 +104,8 @@ until Phase 3/4 drift/cutover.
 
 ## Human-Readable Summary
 
-Machine summary after task #154: 45 rows total, 36 `verified-from-nanoka`, 2
-`needs-tl-research`, 1 `needs-owner-research`, 6 `deferred`, and 20
+Machine summary after task #156: 45 rows total, 36 `verified-from-nanoka`, 1
+`needs-tl-research`, 1 `needs-owner-research`, 7 `deferred`, and 20
 `promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
@@ -129,13 +130,12 @@ Machine summary after task #154: 45 rows total, 36 `verified-from-nanoka`, 2
 | Drive Disc slot/main/sub stats | needs-owner-research | no | Task #154 exhausted live nanoka equipment detail/index and candidate stat-table endpoints; no slot/main/substat table source was found, so lo-user/Product must decide out-of-scope vs approved non-nanoka source research. |
 | Resonium / Lost Void | removed | no | Removed from V0.1.0 product scope by R4; no formal data expected. |
 | Deadly Assault periods/buffs | verified-from-nanoka | yes | Structured source artifact mapping exists for period, zones, buffs, monsters, weakness, rank goals, and `boss_adjust`; runtime cutover still waits for Phase 3 drift audit. |
-| Formula rule tables | mixed | no | Must be split per rule: defense/rounding may be implementation-owned, while anomaly thresholds, daze recovery, disorder, and attribute mappings need row-level owner/source decisions. |
+| Formula rule tables | mixed | no | Base damage, rounding, and Disorder formula are implementation-owned runtime contracts; anomaly thresholds, daze recovery, disorder daze-level, and attribute mappings still need row-level source/owner decisions. |
 
 ## Remaining TL Research Rows
 
-After task #154, 2 rows remain in `needs-tl-research`:
+After task #156, 1 row remains in `needs-tl-research`:
 
-- `rules.disorderFormula` — source or implementation owner still unresolved.
 - `rules.disorderDazeLevelZone` — source or implementation owner still
   unresolved.
 
@@ -147,6 +147,15 @@ After task #154, 1 row is escalated to `needs-owner-research`:
   index expose only Drive Disc set identity/effect text; checked candidate
   stat-table endpoints are absent. Owner decision required: remove this from
   V0.1.0 formal-data scope or approve non-nanoka source research.
+
+## Implementation-Owned Rule Rows
+
+- `rules.disorderFormula` — task #156 found no approved live nanoka formula,
+  rules, Disorder, anomaly-Disorder, battle-formula, damage-formula, or
+  anomaly-status endpoint. Existing nanoka entity indexes/details do not expose
+  a global Disorder formula table. The row is therefore `deferred` /
+  `implementation-owned`, backed by core trace source anchor `guide-3.4.1` and
+  executable golden replay G15 rather than nanoka formal data.
 
 ## Current Scope Rows Added By R1/R4/R6
 

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:05:00+08:00",
-  "status": "phase-2-drive-disc-slot-audit-gate",
+  "generatedAt": "2026-05-15T15:20:00+08:00",
+  "status": "phase-2-disorder-formula-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1225,18 +1225,20 @@
     {
       "fieldId": "rules.disorderFormula",
       "canonicalPath": "GameData.rules.disorder / getDisorderFormula",
-      "fieldClass": "required",
-      "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "unknown nanoka config endpoint",
+      "fieldClass": "implementation-owned",
+      "sourcePolicy": "implementation-owned",
+      "status": "deferred",
+      "nanokaEndpoint": null,
       "rawFieldPaths": [],
-      "transformRule": "find source-backed disorder constants/formula ids or classify per-row as implementation-owned with decision evidence",
+      "transformRule": "Fairy owns the runtime Disorder formula contract in core and verifies it through guide-anchored golden replay G15; approved live nanoka formula/rule/disorder endpoints are absent and entity indexes/details do not expose a Disorder formula table. Do not synthesize source-backed formula rows from entity text.",
       "sampleEntity": null,
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:disorder-rule-source-required"
-      ]
+        "implementation-owned-runtime-formula"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+      "notes": "Task #156 classifies this as implementation-owned after nanoka failed-evidence audit. Existing trace sourceAnchor remains guide-3.4.1 and executable replay remains G15."
     },
     {
       "fieldId": "rules.disorderDazeLevelZone",
@@ -1297,9 +1299,9 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 2,
+    "needsTlResearch": 1,
     "needsOwnerResearch": 1,
-    "deferred": 6,
+    "deferred": 7,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1313,8 +1315,8 @@
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "disorder formula and disorder daze-level source/config endpoint",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research",
+    "disorder daze-level source/config endpoint"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/packages/data/cleaned/audit/nanoka-disorder-formula-audit.json
+++ b/packages/data/cleaned/audit/nanoka-disorder-formula-audit.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "nanoka-disorder-formula-audit/v0.1",
+  "generatedAt": "2026-05-15T15:20:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "rules.disorderFormula",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 12,
+    "foundDisorderFormulaTable": false,
+    "implementationOwnedRuntimeFormula": true,
+    "ownerResearchRequired": false
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/formula.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/rules.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder.json",
+      "status": 404,
+      "finding": "Candidate Disorder formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/anomaly_disorder.json",
+      "status": 404,
+      "finding": "Candidate anomaly/Disorder formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/battle_formula.json",
+      "status": 404,
+      "finding": "Candidate battle formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_formula.json",
+      "status": 404,
+      "finding": "Candidate damage formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/element_abnormal.json",
+      "status": 404,
+      "finding": "Candidate anomaly-status endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is character metadata/text and does not provide a global Disorder formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is monster metadata and does not provide a global Disorder formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/boss.json",
+      "contentSha256": "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9",
+      "finding": "Deadly Assault index exists, but it does not provide Disorder formula constants."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/monster/30000.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+      "contentSha256": "99b2286a6a5a3847f067cfc06bd5c5c44b4a3eb2b1b5609df7af820eea55e855",
+      "finding": "Monster detail exposes variant stats and anomaly-related resistance/build-up fields, but no Disorder multiplier formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+      "contentSha256": "781cb67799e6fb8c0438ab57ac5536507b85292161342f9870c18f42d890989f",
+      "finding": "Deadly Assault period detail exposes buffs, rooms, weakness data, and boss_adjust, but no Disorder formula constants."
+    }
+  ],
+  "implementationContract": {
+    "sourceAnchors": [
+      "guide-3.4.1",
+      "golden-v1:G15"
+    ],
+    "coreFormulaIds": [
+      "disorder-burn",
+      "disorder-shock",
+      "disorder-corruption",
+      "disorder-frost",
+      "disorder-physical-or-ice",
+      "disorder-polarity"
+    ],
+    "formulaBoundary": "Fairy owns the runtime Disorder formula contract in core and verifies it through golden replay; nanoka is not expected to provide a source-backed formula table for this row."
+  },
+  "decision": {
+    "matrixStatus": "deferred",
+    "sourcePolicy": "implementation-owned",
+    "blockedBy": [
+      "implementation-owned-runtime-formula"
+    ],
+    "recommendedEscalation": "No owner escalation for this row. Keep the formula contract implementation-owned unless Product later requests source-backed formula-table extraction."
+  }
+}

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -12,6 +12,8 @@ const rootSnapshotDiffHistoryPath = join(repoRoot, "data/cleaned/audit/nanoka-sn
 const packageSnapshotDiffHistoryPath = join(packageDir, "cleaned/audit/nanoka-snapshot-diff-history.json")
 const rootDriveDiscSlotStatAuditPath = join(repoRoot, "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
 const packageDriveDiscSlotStatAuditPath = join(packageDir, "cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
+const rootDisorderFormulaAuditPath = join(repoRoot, "data/cleaned/audit/nanoka-disorder-formula-audit.json")
+const packageDisorderFormulaAuditPath = join(packageDir, "cleaned/audit/nanoka-disorder-formula-audit.json")
 
 const redistributionRisks = new Set([
   "accepted-by-owner",
@@ -120,7 +122,7 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   const nanoka = sourceById(registry, "nanoka-zzz")
   validateNanokaRegistry(nanoka)
 
-  assert(matrix.status === "phase-2-drive-disc-slot-audit-gate", "matrix status must match the latest Drive Disc slot/stat audit gate")
+  assert(matrix.status === "phase-2-disorder-formula-audit-gate", "matrix status must match the latest Disorder formula audit gate")
   assert(matrix.sourceVersionPolicy?.liveVersionRef === nanoka.liveVersionRef, "matrix liveVersionRef must match nanoka registry")
   assert(matrix.sourceVersionPolicy?.defaultReleaseSourceVersion === nanoka.configuredLiveVersion, "matrix default release version must match configuredLiveVersion")
   assert(matrix.sourceVersionResolved === nanoka.configuredLiveVersion, "matrix resolved sourceVersion must match configuredLiveVersion")
@@ -202,6 +204,18 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   for (const rawPath of ["/id", "/name", "/desc2", "/desc4"]) {
     assert(driveDiscSlotRow.rawFieldPaths?.includes(rawPath), `driveDiscs.slotAndSubstatTables: missing observed raw path ${rawPath}`)
   }
+
+  const disorderFormulaRow = resourceRows.get("rules.disorderFormula")
+  assert(disorderFormulaRow !== undefined, "rules.disorderFormula: missing Disorder formula row")
+  assert(disorderFormulaRow.status === "deferred", "rules.disorderFormula: row must be deferred after implementation-owned classification")
+  assert(disorderFormulaRow.sourcePolicy === "implementation-owned", "rules.disorderFormula: row must be implementation-owned after failed nanoka audit")
+  assert(disorderFormulaRow.fieldClass === "implementation-owned", "rules.disorderFormula: fieldClass must be implementation-owned")
+  assert(disorderFormulaRow.promotable === false, "rules.disorderFormula: implementation-owned formula row must not be nanoka-promotable")
+  assert(disorderFormulaRow.sampleEntity === null, "rules.disorderFormula: implementation-owned row must not point to a nanoka sample entity")
+  assert(disorderFormulaRow.blockedBy?.includes("implementation-owned-runtime-formula"), "rules.disorderFormula: row must carry implementation-owned runtime blocker")
+  assert(disorderFormulaRow.auditArtifact === "data/cleaned/audit/nanoka-disorder-formula-audit.json", "rules.disorderFormula: row must point to failed-evidence audit artifact")
+  assert(disorderFormulaRow.transformRule?.includes("guide-anchored golden replay G15"), "rules.disorderFormula: transform must document guide/golden ownership")
+  assert(disorderFormulaRow.transformRule?.includes("Do not synthesize"), "rules.disorderFormula: transform must preserve no-fabrication boundary")
 
   const promotionExtraRow = resourceRows.get("agents.promotionExtraStats")
   assert(promotionExtraRow !== undefined, "agents.promotionExtraStats: missing promotion extra row")
@@ -359,6 +373,49 @@ function validateDriveDiscSlotStatAudit(registry) {
   assert(audit.decision?.blockedBy?.includes("owner:drive-disc-slot-stat-source-required"), "Drive Disc slot/stat audit decision must carry owner blocker")
 }
 
+function validateDisorderFormulaAudit(registry) {
+  const { rootText } = readMirroredText(
+    rootDisorderFormulaAuditPath,
+    packageDisorderFormulaAuditPath,
+    "packages/data/cleaned/audit/nanoka-disorder-formula-audit.json",
+  )
+
+  const nanoka = sourceById(registry, "nanoka-zzz")
+  const audit = JSON.parse(rootText)
+  assert(audit.schemaVersion === "nanoka-disorder-formula-audit/v0.1", "Disorder formula audit schemaVersion drifted")
+  assert(audit.sourceId === "nanoka-zzz", "Disorder formula audit sourceId drifted")
+  assert(audit.sourceVersion === nanoka.configuredLiveVersion, "Disorder formula audit must use configured live version")
+  assert(audit.status === "not-found", "Disorder formula audit must remain failed-evidence unless a nanoka source is proven")
+  assert(audit.fieldId === "rules.disorderFormula", "Disorder formula audit fieldId drifted")
+  assert(audit.runtimeCutoverReady === false, "Disorder formula audit must not imply runtime cutover")
+  assert(audit.summary?.foundDisorderFormulaTable === false, "Disorder formula audit must not claim a formula table was found")
+  assert(audit.summary?.implementationOwnedRuntimeFormula === true, "Disorder formula audit must classify the row as implementation-owned")
+  assert(audit.summary?.ownerResearchRequired === false, "Disorder formula audit must not require owner research")
+
+  const endpoints = audit.checkedEndpoints ?? []
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/formula.json" && endpoint.status === 404), "Disorder formula audit must record missing formula endpoint")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/disorder.json" && endpoint.status === 404), "Disorder formula audit must record missing Disorder endpoint")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/anomaly_disorder.json" && endpoint.status === 404), "Disorder formula audit must record missing anomaly/Disorder endpoint")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/character.json" && endpoint.status === 200), "Disorder formula audit must record character index check")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/monster.json" && endpoint.status === 200), "Disorder formula audit must record monster index check")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/zh/monster/30000.json" && endpoint.status === 200), "Disorder formula audit must record retained monster detail check")
+  assert(audit.implementationContract?.sourceAnchors?.includes("guide-3.4.1"), "Disorder formula audit must keep guide source anchor")
+  assert(audit.implementationContract?.sourceAnchors?.includes("golden-v1:G15"), "Disorder formula audit must keep golden replay anchor")
+  for (const formulaId of [
+    "disorder-burn",
+    "disorder-shock",
+    "disorder-corruption",
+    "disorder-frost",
+    "disorder-physical-or-ice",
+    "disorder-polarity",
+  ]) {
+    assert(audit.implementationContract?.coreFormulaIds?.includes(formulaId), `Disorder formula audit missing core formula id ${formulaId}`)
+  }
+  assert(audit.decision?.matrixStatus === "deferred", "Disorder formula audit decision must match deferred matrix status")
+  assert(audit.decision?.sourcePolicy === "implementation-owned", "Disorder formula audit decision must classify source policy as implementation-owned")
+  assert(audit.decision?.blockedBy?.includes("implementation-owned-runtime-formula"), "Disorder formula audit decision must carry implementation-owned blocker")
+}
+
 function validateCoveredSourceRefs(registry) {
   const sourceIds = new Set(registry.sources.map(source => source.sourceId))
   const files = [
@@ -387,6 +444,7 @@ function main() {
   validateMatrixAgainstRegistry(matrix, registry)
   validateSnapshotDiffHistory(registry)
   validateDriveDiscSlotStatAudit(registry)
+  validateDisorderFormulaAudit(registry)
   validateCoveredSourceRefs(registry)
 
   console.log("source registry verification passed")

--- a/packages/data/src/missing-fields-failloud.test.ts
+++ b/packages/data/src/missing-fields-failloud.test.ts
@@ -51,11 +51,11 @@ describe("missing-fields fail-loud gate", () => {
     expect(unresolved.every(row => Array.isArray(row.blockedBy) && row.blockedBy.length > 0)).toBe(true)
     expect(unresolved.map(row => row.fieldId)).toEqual(
       expect.arrayContaining([
-        "rules.disorderFormula",
         "rules.disorderDazeLevelZone",
       ]),
     )
     expect(unresolved.map(row => row.fieldId)).not.toContain("driveDiscs.slotAndSubstatTables")
+    expect(unresolved.map(row => row.fieldId)).not.toContain("rules.disorderFormula")
     expect(unresolved.map(row => row.fieldId)).not.toEqual(expect.arrayContaining([
       "metadata.sources",
       "metadata.sourceRefs",
@@ -73,6 +73,16 @@ describe("missing-fields fail-loud gate", () => {
     expect(driveDiscRow?.promotable).toBe(false)
     expect(driveDiscRow?.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
     expect(driveDiscRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
+  })
+
+  it("keeps implementation-owned formulas out of TL research rows", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const disorderFormulaRow = matrix.rows.find(row => row.fieldId === "rules.disorderFormula")
+
+    expect(disorderFormulaRow).toBeDefined()
+    expect(disorderFormulaRow?.status).toBe("deferred")
+    expect(disorderFormulaRow?.blockedBy).toContain("implementation-owned-runtime-formula")
+    expect(disorderFormulaRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-disorder-formula-audit.json")
   })
 
   it("fails loudly when missing, deferred, or forbidden rows are present in a release report", () => {

--- a/packages/data/src/nanoka-disorder-formula-audit.test.ts
+++ b/packages/data/src/nanoka-disorder-formula-audit.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+
+type DisorderFormulaAudit = {
+  schemaVersion: string
+  sourceId: string
+  sourceVersion: string
+  status: string
+  fieldId: string
+  runtimeCutoverReady: boolean
+  summary: {
+    checkedEndpointCount: number
+    foundDisorderFormulaTable: boolean
+    implementationOwnedRuntimeFormula: boolean
+    ownerResearchRequired: boolean
+  }
+  checkedEndpoints: Array<{
+    url: string
+    status: number
+  }>
+  implementationContract: {
+    sourceAnchors: string[]
+    coreFormulaIds: string[]
+  }
+  decision: {
+    matrixStatus: string
+    sourcePolicy: string
+    blockedBy: string[]
+  }
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8")) as T
+}
+
+describe("nanoka Disorder formula failed-evidence audit", () => {
+  it("keeps the package audit artifact mirror byte-identical", () => {
+    expect(readFileSync(join(repoRoot, "packages/data/cleaned/audit/nanoka-disorder-formula-audit.json"), "utf8")).toBe(
+      readFileSync(join(repoRoot, "data/cleaned/audit/nanoka-disorder-formula-audit.json"), "utf8"),
+    )
+  })
+
+  it("records missing formula endpoints and implementation-owned classification", () => {
+    const audit = readJson<DisorderFormulaAudit>("data/cleaned/audit/nanoka-disorder-formula-audit.json")
+
+    expect(audit).toMatchObject({
+      schemaVersion: "nanoka-disorder-formula-audit/v0.1",
+      sourceId: "nanoka-zzz",
+      sourceVersion: "2.8",
+      status: "not-found",
+      fieldId: "rules.disorderFormula",
+      runtimeCutoverReady: false,
+      summary: {
+        foundDisorderFormulaTable: false,
+        implementationOwnedRuntimeFormula: true,
+        ownerResearchRequired: false,
+      },
+      decision: {
+        matrixStatus: "deferred",
+        sourcePolicy: "implementation-owned",
+      },
+    })
+    expect(audit.checkedEndpoints).toHaveLength(audit.summary.checkedEndpointCount)
+    expect(audit.checkedEndpoints).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/formula.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/disorder.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/anomaly_disorder.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/character.json",
+        status: 200,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/monster.json",
+        status: 200,
+      }),
+    ]))
+    expect(audit.decision.blockedBy).toContain("implementation-owned-runtime-formula")
+  })
+
+  it("locks the guide/golden-backed core formula ids", () => {
+    const audit = readJson<DisorderFormulaAudit>("data/cleaned/audit/nanoka-disorder-formula-audit.json")
+
+    expect(audit.implementationContract.sourceAnchors).toEqual(expect.arrayContaining([
+      "guide-3.4.1",
+      "golden-v1:G15",
+    ]))
+    expect(audit.implementationContract.coreFormulaIds).toEqual(expect.arrayContaining([
+      "disorder-burn",
+      "disorder-shock",
+      "disorder-corruption",
+      "disorder-frost",
+      "disorder-physical-or-ice",
+      "disorder-polarity",
+    ]))
+  })
+})

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -18,6 +18,7 @@ type CoverageMatrix = {
   status: string
   rows: Array<{
     fieldId: string
+    fieldClass?: string
     status: string
     promotable: boolean
     sampleEntity?: string
@@ -111,7 +112,7 @@ describe("nanoka source gate", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
 
-    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
     expect(rows.get("metadata.sources")).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -144,7 +145,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("agents.promotionExtraStats")
 
-    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -171,7 +172,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("bangboos.element")
 
-    expect(matrix.status).toBe("phase-2-drive-disc-slot-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -229,5 +230,23 @@ describe("nanoka source gate", () => {
       "/desc4",
     ]))
     expect(row?.transformRule).toContain("do not synthesize")
+  })
+
+  it("classifies the Disorder formula as implementation-owned after failed nanoka evidence", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
+    const row = rows.get("rules.disorderFormula")
+
+    expect(row).toMatchObject({
+      fieldClass: "implementation-owned",
+      sourcePolicy: "implementation-owned",
+      status: "deferred",
+      promotable: false,
+      auditArtifact: "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+    })
+    expect(row?.sampleEntity).toBeNull()
+    expect(row?.blockedBy).toContain("implementation-owned-runtime-formula")
+    expect(row?.transformRule).toContain("guide-anchored golden replay G15")
+    expect(row?.transformRule).toContain("Do not synthesize")
   })
 })


### PR DESCRIPTION
## Summary
- adds mirrored failed-evidence audit artifacts for nanoka Disorder formula coverage
- classifies `rules.disorderFormula` as `implementation-owned` / `deferred` after live formula/rule/disorder endpoints were absent
- locks verifier/source-gate/missing-fields tests so the row remains guide/core-owned via `guide-3.4.1` + G15 instead of fabricated nanoka data

## Verification
- `pnpm --filter @randomplay/data test -- nanoka-disorder-formula-audit.test.ts nanoka-source-gate.test.ts missing-fields-failloud.test.ts`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data pack --dry-run --json > /tmp/fairy-data-pack-156.json`
- custom matrix/pack mirror/raw-source-exclusion check
- `git diff --check` / `git diff --cached --check`

No runtime cleaned-data cutover.