### PR TITLE
feat(data): add nanoka disorder daze-level audit

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:20:00+08:00",
-  "status": "phase-2-disorder-formula-audit-gate",
+  "generatedAt": "2026-05-15T15:35:00+08:00",
+  "status": "phase-2-disorder-daze-level-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1243,18 +1243,20 @@
     {
       "fieldId": "rules.disorderDazeLevelZone",
       "canonicalPath": "GameData.rules.dazeLevelZone / getDisorderDazeLevelMultiplier",
-      "fieldClass": "required",
-      "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "unknown nanoka config endpoint",
+      "fieldClass": "implementation-owned",
+      "sourcePolicy": "implementation-owned",
+      "status": "deferred",
+      "nanokaEndpoint": null,
       "rawFieldPaths": [],
-      "transformRule": "find source-backed daze level zone constants or classify per-row as implementation-owned with decision evidence",
+      "transformRule": "Fairy owns the runtime Disorder daze-level zone formula contract in core and verifies it through guide-anchored golden replay G16; approved live nanoka daze-level/level-zone/formula endpoints are absent and entity indexes/details do not expose a Disorder daze-level formula table. Do not synthesize source-backed daze-level rows from entity text.",
       "sampleEntity": null,
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:daze-level-zone-source-required"
-      ]
+        "implementation-owned-runtime-formula"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+      "notes": "Task #158 classifies this as implementation-owned after nanoka failed-evidence audit. Existing trace sourceAnchor remains guide-3.4.2 and executable replay remains G16."
     },
     {
       "fieldId": "rules.attributeMapping",
@@ -1299,9 +1301,9 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 1,
+    "needsTlResearch": 0,
     "needsOwnerResearch": 1,
-    "deferred": 7,
+    "deferred": 8,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1315,8 +1317,7 @@
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research",
-    "disorder daze-level source/config endpoint"
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/data/cleaned/audit/nanoka-disorder-daze-level-audit.json
+++ b/data/cleaned/audit/nanoka-disorder-daze-level-audit.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": "nanoka-disorder-daze-level-audit/v0.1",
+  "generatedAt": "2026-05-15T15:35:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "rules.disorderDazeLevelZone",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 19,
+    "foundDisorderDazeLevelTable": false,
+    "implementationOwnedRuntimeFormula": true,
+    "ownerResearchRequired": false
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/daze_level.json",
+      "status": 404,
+      "finding": "Candidate daze-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/daze_level_zone.json",
+      "status": 404,
+      "finding": "Candidate daze-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze_level.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze_level_zone.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_zone.json",
+      "status": 404,
+      "finding": "Candidate level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_correction.json",
+      "status": 404,
+      "finding": "Candidate level-correction endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_suppression.json",
+      "status": 404,
+      "finding": "Candidate level-suppression endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_level.json",
+      "status": 404,
+      "finding": "Candidate damage-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_level_zone.json",
+      "status": 404,
+      "finding": "Candidate damage-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/formula.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/rules.json",
+      "status": 404,
+      "finding": "Candidate rules/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder.json",
+      "status": 404,
+      "finding": "Candidate Disorder endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/battle_formula.json",
+      "status": 404,
+      "finding": "Candidate battle formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_formula.json",
+      "status": 404,
+      "finding": "Candidate damage formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/element_abnormal.json",
+      "status": 404,
+      "finding": "Candidate anomaly-status endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is character metadata/text and does not provide a global Disorder daze-level formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is monster metadata and does not provide a global Disorder daze-level formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/boss.json",
+      "contentSha256": "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9",
+      "finding": "Deadly Assault index exists, but it does not provide Disorder daze-level constants."
+    }
+  ],
+  "implementationContract": {
+    "sourceAnchors": [
+      "guide-3.4.2",
+      "golden-v1:G16"
+    ],
+    "coreFormula": "disorderDazeLevelZone = 1 + 0.0075 * level",
+    "sampleExpectation": {
+      "level": 60,
+      "multiplier": 1.45
+    },
+    "formulaBoundary": "Fairy owns the runtime Disorder daze-level zone formula contract in core and verifies it through golden replay; nanoka is not expected to provide a source-backed formula table for this row."
+  },
+  "decision": {
+    "matrixStatus": "deferred",
+    "sourcePolicy": "implementation-owned",
+    "blockedBy": [
+      "implementation-owned-runtime-formula"
+    ],
+    "recommendedEscalation": "No owner escalation for this row. Keep the formula contract implementation-owned unless Product later requests source-backed formula-table extraction."
+  }
+}

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,11 +1,11 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 2 Disorder formula audit gate
+Status: Phase 2 Disorder daze-level audit gate
 Owner: @TechLead
 Reviewers: @Product, @QA
 Related: D-20 data-source migration, task #121, task #122, task #125, task #127,
 task #138, task #140, task #142, task #144, task #146, task #148, task #150,
-task #152, task #154, task #156
+task #152, task #154, task #156, task #158
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
@@ -62,6 +62,7 @@ The machine-readable version is
 | Live Deadly Assault index | `https://static.nanoka.cc/zzz/2.8/boss.json` | 38 live DA entries; all sampled `zh/boss/{id}.json` details returned 200 in PR #54. |
 | Live Deadly Assault period / 69036 | `https://static.nanoka.cc/zzz/2.8/zh/boss/69036.json` | Current live period window, zones, layer/selectable buffs, room monster lists, weakness data, and `boss_adjust`. |
 | Live rules / formula candidate audit | `https://static.nanoka.cc/zzz/2.8/{formula,rules,disorder,anomaly_disorder,battle_formula,damage_formula,element_abnormal}.json` | Failed-evidence audit only: dedicated live formula/rule/disorder endpoints are absent. Existing entity indexes/details do not expose a global Disorder formula table, so task #156 classifies `rules.disorderFormula` as implementation-owned runtime formula evidence. |
+| Live daze-level / level-zone candidate audit | `https://static.nanoka.cc/zzz/2.8/{daze_level,daze_level_zone,disorder_daze_level,disorder_daze,disorder_daze_level_zone,level_zone,level_correction,level_suppression,damage_level,damage_level_zone}.json` | Failed-evidence audit only: dedicated live daze-level / level-zone endpoints are absent. Entity indexes do not expose Disorder daze-level constants, so task #158 classifies `rules.disorderDazeLevelZone` as implementation-owned runtime formula evidence. |
 
 The `3.0.2+15625449` samples are retained as phase-0 research evidence, not as
 release-ready source evidence. Phase 2 slice 3 re-sampled existing
@@ -104,8 +105,8 @@ until Phase 3/4 drift/cutover.
 
 ## Human-Readable Summary
 
-Machine summary after task #156: 45 rows total, 36 `verified-from-nanoka`, 1
-`needs-tl-research`, 1 `needs-owner-research`, 7 `deferred`, and 20
+Machine summary after task #158: 45 rows total, 36 `verified-from-nanoka`, 0
+`needs-tl-research`, 1 `needs-owner-research`, 8 `deferred`, and 20
 `promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
@@ -130,14 +131,11 @@ Machine summary after task #156: 45 rows total, 36 `verified-from-nanoka`, 1
 | Drive Disc slot/main/sub stats | needs-owner-research | no | Task #154 exhausted live nanoka equipment detail/index and candidate stat-table endpoints; no slot/main/substat table source was found, so lo-user/Product must decide out-of-scope vs approved non-nanoka source research. |
 | Resonium / Lost Void | removed | no | Removed from V0.1.0 product scope by R4; no formal data expected. |
 | Deadly Assault periods/buffs | verified-from-nanoka | yes | Structured source artifact mapping exists for period, zones, buffs, monsters, weakness, rank goals, and `boss_adjust`; runtime cutover still waits for Phase 3 drift audit. |
-| Formula rule tables | mixed | no | Base damage, rounding, and Disorder formula are implementation-owned runtime contracts; anomaly thresholds, daze recovery, disorder daze-level, and attribute mappings still need row-level source/owner decisions. |
+| Formula rule tables | mixed | no | Base damage, rounding, Disorder formula, and Disorder daze-level are implementation-owned runtime contracts; anomaly thresholds, daze recovery, and attribute mappings still need row-level source/owner decisions. |
 
 ## Remaining TL Research Rows
 
-After task #156, 1 row remains in `needs-tl-research`:
-
-- `rules.disorderDazeLevelZone` — source or implementation owner still
-  unresolved.
+After task #158, no rows remain in `needs-tl-research`.
 
 ## Owner Research / Decision Rows
 
@@ -156,6 +154,12 @@ After task #154, 1 row is escalated to `needs-owner-research`:
   a global Disorder formula table. The row is therefore `deferred` /
   `implementation-owned`, backed by core trace source anchor `guide-3.4.1` and
   executable golden replay G15 rather than nanoka formal data.
+- `rules.disorderDazeLevelZone` — task #158 found no approved live nanoka
+  daze-level, level-zone, Disorder-daze-level, level-correction, or damage-level
+  endpoint. Existing nanoka entity indexes do not expose Disorder daze-level
+  constants. The row is therefore `deferred` / `implementation-owned`, backed by
+  core trace source anchor `guide-3.4.2` and executable golden replay G16 rather
+  than nanoka formal data.
 
 ## Current Scope Rows Added By R1/R4/R6
 

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:20:00+08:00",
-  "status": "phase-2-disorder-formula-audit-gate",
+  "generatedAt": "2026-05-15T15:35:00+08:00",
+  "status": "phase-2-disorder-daze-level-audit-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1243,18 +1243,20 @@
     {
       "fieldId": "rules.disorderDazeLevelZone",
       "canonicalPath": "GameData.rules.dazeLevelZone / getDisorderDazeLevelMultiplier",
-      "fieldClass": "required",
-      "sourcePolicy": "nanoka",
-      "status": "needs-tl-research",
-      "nanokaEndpoint": "unknown nanoka config endpoint",
+      "fieldClass": "implementation-owned",
+      "sourcePolicy": "implementation-owned",
+      "status": "deferred",
+      "nanokaEndpoint": null,
       "rawFieldPaths": [],
-      "transformRule": "find source-backed daze level zone constants or classify per-row as implementation-owned with decision evidence",
+      "transformRule": "Fairy owns the runtime Disorder daze-level zone formula contract in core and verifies it through guide-anchored golden replay G16; approved live nanoka daze-level/level-zone/formula endpoints are absent and entity indexes/details do not expose a Disorder daze-level formula table. Do not synthesize source-backed daze-level rows from entity text.",
       "sampleEntity": null,
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "field:daze-level-zone-source-required"
-      ]
+        "implementation-owned-runtime-formula"
+      ],
+      "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+      "notes": "Task #158 classifies this as implementation-owned after nanoka failed-evidence audit. Existing trace sourceAnchor remains guide-3.4.2 and executable replay remains G16."
     },
     {
       "fieldId": "rules.attributeMapping",
@@ -1299,9 +1301,9 @@
   "summary": {
     "totalRows": 45,
     "verifiedFromNanoka": 36,
-    "needsTlResearch": 1,
+    "needsTlResearch": 0,
     "needsOwnerResearch": 1,
-    "deferred": 7,
+    "deferred": 8,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1315,8 +1317,7 @@
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
     "Sentinel canonical naming and unit normalization",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research",
-    "disorder daze-level source/config endpoint"
+    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/packages/data/cleaned/audit/nanoka-disorder-daze-level-audit.json
+++ b/packages/data/cleaned/audit/nanoka-disorder-daze-level-audit.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": "nanoka-disorder-daze-level-audit/v0.1",
+  "generatedAt": "2026-05-15T15:35:00+08:00",
+  "sourceId": "nanoka-zzz",
+  "sourceVersion": "2.8",
+  "status": "not-found",
+  "fieldId": "rules.disorderDazeLevelZone",
+  "runtimeCutoverReady": false,
+  "summary": {
+    "checkedEndpointCount": 19,
+    "foundDisorderDazeLevelTable": false,
+    "implementationOwnedRuntimeFormula": true,
+    "ownerResearchRequired": false
+  },
+  "checkedEndpoints": [
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/daze_level.json",
+      "status": 404,
+      "finding": "Candidate daze-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/daze_level_zone.json",
+      "status": 404,
+      "finding": "Candidate daze-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze_level.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder_daze_level_zone.json",
+      "status": 404,
+      "finding": "Candidate Disorder daze-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_zone.json",
+      "status": 404,
+      "finding": "Candidate level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_correction.json",
+      "status": 404,
+      "finding": "Candidate level-correction endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/level_suppression.json",
+      "status": 404,
+      "finding": "Candidate level-suppression endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_level.json",
+      "status": 404,
+      "finding": "Candidate damage-level endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_level_zone.json",
+      "status": 404,
+      "finding": "Candidate damage-level-zone endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/formula.json",
+      "status": 404,
+      "finding": "Candidate formula/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/rules.json",
+      "status": 404,
+      "finding": "Candidate rules/config endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/disorder.json",
+      "status": 404,
+      "finding": "Candidate Disorder endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/battle_formula.json",
+      "status": 404,
+      "finding": "Candidate battle formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/damage_formula.json",
+      "status": 404,
+      "finding": "Candidate damage formula endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/element_abnormal.json",
+      "status": 404,
+      "finding": "Candidate anomaly-status endpoint not present."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is character metadata/text and does not provide a global Disorder daze-level formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "status": 200,
+      "finding": "Entity index exists, but it is monster metadata and does not provide a global Disorder daze-level formula table."
+    },
+    {
+      "url": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "status": 200,
+      "localPath": "data/source/raw/nanoka/zzz/2.8/boss.json",
+      "contentSha256": "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9",
+      "finding": "Deadly Assault index exists, but it does not provide Disorder daze-level constants."
+    }
+  ],
+  "implementationContract": {
+    "sourceAnchors": [
+      "guide-3.4.2",
+      "golden-v1:G16"
+    ],
+    "coreFormula": "disorderDazeLevelZone = 1 + 0.0075 * level",
+    "sampleExpectation": {
+      "level": 60,
+      "multiplier": 1.45
+    },
+    "formulaBoundary": "Fairy owns the runtime Disorder daze-level zone formula contract in core and verifies it through golden replay; nanoka is not expected to provide a source-backed formula table for this row."
+  },
+  "decision": {
+    "matrixStatus": "deferred",
+    "sourcePolicy": "implementation-owned",
+    "blockedBy": [
+      "implementation-owned-runtime-formula"
+    ],
+    "recommendedEscalation": "No owner escalation for this row. Keep the formula contract implementation-owned unless Product later requests source-backed formula-table extraction."
+  }
+}

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -14,6 +14,8 @@ const rootDriveDiscSlotStatAuditPath = join(repoRoot, "data/cleaned/audit/nanoka
 const packageDriveDiscSlotStatAuditPath = join(packageDir, "cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
 const rootDisorderFormulaAuditPath = join(repoRoot, "data/cleaned/audit/nanoka-disorder-formula-audit.json")
 const packageDisorderFormulaAuditPath = join(packageDir, "cleaned/audit/nanoka-disorder-formula-audit.json")
+const rootDisorderDazeLevelAuditPath = join(repoRoot, "data/cleaned/audit/nanoka-disorder-daze-level-audit.json")
+const packageDisorderDazeLevelAuditPath = join(packageDir, "cleaned/audit/nanoka-disorder-daze-level-audit.json")
 
 const redistributionRisks = new Set([
   "accepted-by-owner",
@@ -122,7 +124,7 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   const nanoka = sourceById(registry, "nanoka-zzz")
   validateNanokaRegistry(nanoka)
 
-  assert(matrix.status === "phase-2-disorder-formula-audit-gate", "matrix status must match the latest Disorder formula audit gate")
+  assert(matrix.status === "phase-2-disorder-daze-level-audit-gate", "matrix status must match the latest Disorder daze-level audit gate")
   assert(matrix.sourceVersionPolicy?.liveVersionRef === nanoka.liveVersionRef, "matrix liveVersionRef must match nanoka registry")
   assert(matrix.sourceVersionPolicy?.defaultReleaseSourceVersion === nanoka.configuredLiveVersion, "matrix default release version must match configuredLiveVersion")
   assert(matrix.sourceVersionResolved === nanoka.configuredLiveVersion, "matrix resolved sourceVersion must match configuredLiveVersion")
@@ -216,6 +218,18 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   assert(disorderFormulaRow.auditArtifact === "data/cleaned/audit/nanoka-disorder-formula-audit.json", "rules.disorderFormula: row must point to failed-evidence audit artifact")
   assert(disorderFormulaRow.transformRule?.includes("guide-anchored golden replay G15"), "rules.disorderFormula: transform must document guide/golden ownership")
   assert(disorderFormulaRow.transformRule?.includes("Do not synthesize"), "rules.disorderFormula: transform must preserve no-fabrication boundary")
+
+  const disorderDazeLevelRow = resourceRows.get("rules.disorderDazeLevelZone")
+  assert(disorderDazeLevelRow !== undefined, "rules.disorderDazeLevelZone: missing Disorder daze-level row")
+  assert(disorderDazeLevelRow.status === "deferred", "rules.disorderDazeLevelZone: row must be deferred after implementation-owned classification")
+  assert(disorderDazeLevelRow.sourcePolicy === "implementation-owned", "rules.disorderDazeLevelZone: row must be implementation-owned after failed nanoka audit")
+  assert(disorderDazeLevelRow.fieldClass === "implementation-owned", "rules.disorderDazeLevelZone: fieldClass must be implementation-owned")
+  assert(disorderDazeLevelRow.promotable === false, "rules.disorderDazeLevelZone: implementation-owned formula row must not be nanoka-promotable")
+  assert(disorderDazeLevelRow.sampleEntity === null, "rules.disorderDazeLevelZone: implementation-owned row must not point to a nanoka sample entity")
+  assert(disorderDazeLevelRow.blockedBy?.includes("implementation-owned-runtime-formula"), "rules.disorderDazeLevelZone: row must carry implementation-owned runtime blocker")
+  assert(disorderDazeLevelRow.auditArtifact === "data/cleaned/audit/nanoka-disorder-daze-level-audit.json", "rules.disorderDazeLevelZone: row must point to failed-evidence audit artifact")
+  assert(disorderDazeLevelRow.transformRule?.includes("guide-anchored golden replay G16"), "rules.disorderDazeLevelZone: transform must document guide/golden ownership")
+  assert(disorderDazeLevelRow.transformRule?.includes("Do not synthesize"), "rules.disorderDazeLevelZone: transform must preserve no-fabrication boundary")
 
   const promotionExtraRow = resourceRows.get("agents.promotionExtraStats")
   assert(promotionExtraRow !== undefined, "agents.promotionExtraStats: missing promotion extra row")
@@ -416,6 +430,54 @@ function validateDisorderFormulaAudit(registry) {
   assert(audit.decision?.blockedBy?.includes("implementation-owned-runtime-formula"), "Disorder formula audit decision must carry implementation-owned blocker")
 }
 
+function validateDisorderDazeLevelAudit(registry) {
+  const { rootText } = readMirroredText(
+    rootDisorderDazeLevelAuditPath,
+    packageDisorderDazeLevelAuditPath,
+    "packages/data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+  )
+
+  const nanoka = sourceById(registry, "nanoka-zzz")
+  const audit = JSON.parse(rootText)
+  assert(audit.schemaVersion === "nanoka-disorder-daze-level-audit/v0.1", "Disorder daze-level audit schemaVersion drifted")
+  assert(audit.sourceId === "nanoka-zzz", "Disorder daze-level audit sourceId drifted")
+  assert(audit.sourceVersion === nanoka.configuredLiveVersion, "Disorder daze-level audit must use configured live version")
+  assert(audit.status === "not-found", "Disorder daze-level audit must remain failed-evidence unless a nanoka source is proven")
+  assert(audit.fieldId === "rules.disorderDazeLevelZone", "Disorder daze-level audit fieldId drifted")
+  assert(audit.runtimeCutoverReady === false, "Disorder daze-level audit must not imply runtime cutover")
+  assert(audit.summary?.foundDisorderDazeLevelTable === false, "Disorder daze-level audit must not claim a daze-level formula table was found")
+  assert(audit.summary?.implementationOwnedRuntimeFormula === true, "Disorder daze-level audit must classify the row as implementation-owned")
+  assert(audit.summary?.ownerResearchRequired === false, "Disorder daze-level audit must not require owner research")
+
+  const endpoints = audit.checkedEndpoints ?? []
+  for (const endpointName of [
+    "daze_level.json",
+    "disorder_daze_level.json",
+    "disorder_daze_level_zone.json",
+    "level_zone.json",
+    "formula.json",
+    "rules.json",
+  ]) {
+    assert(
+      endpoints.some(endpoint => endpoint.url === `https://static.nanoka.cc/zzz/2.8/${endpointName}` && endpoint.status === 404),
+      `Disorder daze-level audit must record missing ${endpointName}`,
+    )
+  }
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/character.json" && endpoint.status === 200), "Disorder daze-level audit must record character index check")
+  assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/monster.json" && endpoint.status === 200), "Disorder daze-level audit must record monster index check")
+  const bossIndex = endpoints.find(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/boss.json")
+  assert(bossIndex?.status === 200, "Disorder daze-level audit must record boss index check")
+  assert(bossIndex.contentSha256 === "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9", "Disorder daze-level boss index hash drifted")
+  assert(audit.implementationContract?.sourceAnchors?.includes("guide-3.4.2"), "Disorder daze-level audit must keep guide source anchor")
+  assert(audit.implementationContract?.sourceAnchors?.includes("golden-v1:G16"), "Disorder daze-level audit must keep golden replay anchor")
+  assert(audit.implementationContract?.coreFormula === "disorderDazeLevelZone = 1 + 0.0075 * level", "Disorder daze-level audit core formula drifted")
+  assert(audit.implementationContract?.sampleExpectation?.level === 60, "Disorder daze-level audit sample level drifted")
+  assert(audit.implementationContract?.sampleExpectation?.multiplier === 1.45, "Disorder daze-level audit sample multiplier drifted")
+  assert(audit.decision?.matrixStatus === "deferred", "Disorder daze-level audit decision must match deferred matrix status")
+  assert(audit.decision?.sourcePolicy === "implementation-owned", "Disorder daze-level audit decision must classify source policy as implementation-owned")
+  assert(audit.decision?.blockedBy?.includes("implementation-owned-runtime-formula"), "Disorder daze-level audit decision must carry implementation-owned blocker")
+}
+
 function validateCoveredSourceRefs(registry) {
   const sourceIds = new Set(registry.sources.map(source => source.sourceId))
   const files = [
@@ -445,6 +507,7 @@ function main() {
   validateSnapshotDiffHistory(registry)
   validateDriveDiscSlotStatAudit(registry)
   validateDisorderFormulaAudit(registry)
+  validateDisorderDazeLevelAudit(registry)
   validateCoveredSourceRefs(registry)
 
   console.log("source registry verification passed")

--- a/packages/data/src/missing-fields-failloud.test.ts
+++ b/packages/data/src/missing-fields-failloud.test.ts
@@ -43,25 +43,11 @@ function assertReleaseGate(report: GateReport) {
 }
 
 describe("missing-fields fail-loud gate", () => {
-  it("keeps unresolved source-backed rows machine-readable with blockers", () => {
+  it("has resolved all TL research rows into verified, deferred, or owner-owned gates", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const unresolved = matrix.rows.filter(row => row.status === "needs-tl-research")
 
-    expect(unresolved).not.toHaveLength(0)
-    expect(unresolved.every(row => Array.isArray(row.blockedBy) && row.blockedBy.length > 0)).toBe(true)
-    expect(unresolved.map(row => row.fieldId)).toEqual(
-      expect.arrayContaining([
-        "rules.disorderDazeLevelZone",
-      ]),
-    )
-    expect(unresolved.map(row => row.fieldId)).not.toContain("driveDiscs.slotAndSubstatTables")
-    expect(unresolved.map(row => row.fieldId)).not.toContain("rules.disorderFormula")
-    expect(unresolved.map(row => row.fieldId)).not.toEqual(expect.arrayContaining([
-      "metadata.sources",
-      "metadata.sourceRefs",
-      "agents.promotionExtraStats",
-      "bangboos.element",
-    ]))
+    expect(unresolved).toEqual([])
   })
 
   it("keeps owner-escalated rows machine-readable and non-promotable", () => {
@@ -78,11 +64,17 @@ describe("missing-fields fail-loud gate", () => {
   it("keeps implementation-owned formulas out of TL research rows", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const disorderFormulaRow = matrix.rows.find(row => row.fieldId === "rules.disorderFormula")
+    const disorderDazeLevelRow = matrix.rows.find(row => row.fieldId === "rules.disorderDazeLevelZone")
 
     expect(disorderFormulaRow).toBeDefined()
     expect(disorderFormulaRow?.status).toBe("deferred")
     expect(disorderFormulaRow?.blockedBy).toContain("implementation-owned-runtime-formula")
     expect(disorderFormulaRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-disorder-formula-audit.json")
+
+    expect(disorderDazeLevelRow).toBeDefined()
+    expect(disorderDazeLevelRow?.status).toBe("deferred")
+    expect(disorderDazeLevelRow?.blockedBy).toContain("implementation-owned-runtime-formula")
+    expect(disorderDazeLevelRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-disorder-daze-level-audit.json")
   })
 
   it("fails loudly when missing, deferred, or forbidden rows are present in a release report", () => {

--- a/packages/data/src/nanoka-disorder-daze-level-audit.test.ts
+++ b/packages/data/src/nanoka-disorder-daze-level-audit.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+
+type DisorderDazeLevelAudit = {
+  schemaVersion: string
+  sourceId: string
+  sourceVersion: string
+  status: string
+  fieldId: string
+  runtimeCutoverReady: boolean
+  summary: {
+    checkedEndpointCount: number
+    foundDisorderDazeLevelTable: boolean
+    implementationOwnedRuntimeFormula: boolean
+    ownerResearchRequired: boolean
+  }
+  checkedEndpoints: Array<{
+    url: string
+    status: number
+    contentSha256?: string
+  }>
+  implementationContract: {
+    sourceAnchors: string[]
+    coreFormula: string
+    sampleExpectation: {
+      level: number
+      multiplier: number
+    }
+  }
+  decision: {
+    matrixStatus: string
+    sourcePolicy: string
+    blockedBy: string[]
+  }
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8")) as T
+}
+
+describe("nanoka Disorder daze-level failed-evidence audit", () => {
+  it("keeps the package audit artifact mirror byte-identical", () => {
+    expect(readFileSync(join(repoRoot, "packages/data/cleaned/audit/nanoka-disorder-daze-level-audit.json"), "utf8")).toBe(
+      readFileSync(join(repoRoot, "data/cleaned/audit/nanoka-disorder-daze-level-audit.json"), "utf8"),
+    )
+  })
+
+  it("records missing daze-level endpoints and implementation-owned classification", () => {
+    const audit = readJson<DisorderDazeLevelAudit>("data/cleaned/audit/nanoka-disorder-daze-level-audit.json")
+
+    expect(audit).toMatchObject({
+      schemaVersion: "nanoka-disorder-daze-level-audit/v0.1",
+      sourceId: "nanoka-zzz",
+      sourceVersion: "2.8",
+      status: "not-found",
+      fieldId: "rules.disorderDazeLevelZone",
+      runtimeCutoverReady: false,
+      summary: {
+        foundDisorderDazeLevelTable: false,
+        implementationOwnedRuntimeFormula: true,
+        ownerResearchRequired: false,
+      },
+      decision: {
+        matrixStatus: "deferred",
+        sourcePolicy: "implementation-owned",
+      },
+    })
+    expect(audit.checkedEndpoints).toHaveLength(audit.summary.checkedEndpointCount)
+    expect(audit.checkedEndpoints).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/daze_level.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/disorder_daze_level.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/disorder_daze_level_zone.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/level_zone.json",
+        status: 404,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/character.json",
+        status: 200,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/monster.json",
+        status: 200,
+      }),
+      expect.objectContaining({
+        url: "https://static.nanoka.cc/zzz/2.8/boss.json",
+        status: 200,
+        contentSha256: "d9519738c6100082760f59bb92fd17fdba93afb853c845b1c90d0718788a79f9",
+      }),
+    ]))
+    expect(audit.decision.blockedBy).toContain("implementation-owned-runtime-formula")
+  })
+
+  it("locks the guide/golden-backed daze-level formula contract", () => {
+    const audit = readJson<DisorderDazeLevelAudit>("data/cleaned/audit/nanoka-disorder-daze-level-audit.json")
+
+    expect(audit.implementationContract.sourceAnchors).toEqual(expect.arrayContaining([
+      "guide-3.4.2",
+      "golden-v1:G16",
+    ]))
+    expect(audit.implementationContract.coreFormula).toBe("disorderDazeLevelZone = 1 + 0.0075 * level")
+    expect(audit.implementationContract.sampleExpectation).toEqual({
+      level: 60,
+      multiplier: 1.45,
+    })
+  })
+})

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -112,7 +112,7 @@ describe("nanoka source gate", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
 
-    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
     expect(rows.get("metadata.sources")).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -145,7 +145,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("agents.promotionExtraStats")
 
-    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -172,7 +172,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("bangboos.element")
 
-    expect(matrix.status).toBe("phase-2-disorder-formula-audit-gate")
+    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -247,6 +247,24 @@ describe("nanoka source gate", () => {
     expect(row?.sampleEntity).toBeNull()
     expect(row?.blockedBy).toContain("implementation-owned-runtime-formula")
     expect(row?.transformRule).toContain("guide-anchored golden replay G15")
+    expect(row?.transformRule).toContain("Do not synthesize")
+  })
+
+  it("classifies the Disorder daze-level formula as implementation-owned after failed nanoka evidence", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
+    const row = rows.get("rules.disorderDazeLevelZone")
+
+    expect(row).toMatchObject({
+      fieldClass: "implementation-owned",
+      sourcePolicy: "implementation-owned",
+      status: "deferred",
+      promotable: false,
+      auditArtifact: "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+    })
+    expect(row?.sampleEntity).toBeNull()
+    expect(row?.blockedBy).toContain("implementation-owned-runtime-formula")
+    expect(row?.transformRule).toContain("guide-anchored golden replay G16")
     expect(row?.transformRule).toContain("Do not synthesize")
   })
 })


### PR DESCRIPTION
## Summary
- classify `rules.disorderDazeLevelZone` as `implementation-owned` / `deferred` after approved-live nanoka failed-evidence audit
- add mirrored `nanoka-disorder-daze-level-audit.json` artifacts with missing daze-level / level-zone endpoint evidence and the G16 formula contract
- update matrix/docs/verifier/tests so zero `needs-tl-research` rows remain and the no-fabrication boundary is executable

## Verification
- `pnpm --filter @randomplay/data test -- nanoka-disorder-daze-level-audit.test.ts nanoka-source-gate.test.ts missing-fields-failloud.test.ts`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data pack --dry-run --json > /tmp/fairy-data-pack-158.json`
- custom matrix/pack mirror + raw-source exclusion + audit inclusion checks
- `git diff --check`
- `git diff --cached --check`

## Scope
No runtime cleaned-data cutover. This only closes the final TL-research row as implementation-owned and keeps Phase 3/4 cutover gates intact.
