### PR TITLE
feat(data): add Phase 3 drift foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       - run: pnpm --filter @randomplay/data verify:excel
       - run: pnpm --filter @randomplay/data verify:nanoka
       - run: pnpm --filter @randomplay/data verify:source-registry
+      - run: pnpm --filter @randomplay/data verify:source-migration
       - run: pnpm --silent fairy:s1 | jq empty
       - run: pnpm --silent fairy:s2 | jq empty
       - run: pnpm --silent fairy:s3 | jq empty

--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:35:00+08:00",
-  "status": "phase-2-disorder-daze-level-audit-gate",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "status": "phase-3-drift-foundation-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1092,10 +1092,10 @@
     {
       "fieldId": "driveDiscs.slotAndSubstatTables",
       "canonicalPath": "DriveDiscSnapshot.slot/setId and future GameData drive disc stat tables",
-      "fieldClass": "optional",
-      "sourcePolicy": "nanoka",
-      "status": "needs-owner-research",
-      "nanokaEndpoint": "/equipment.json, /{locale}/equipment/{id}.json, and checked candidate stat-table endpoints",
+      "fieldClass": "removed-out-of-product-scope",
+      "sourcePolicy": "out-of-scope",
+      "status": "deferred",
+      "nanokaEndpoint": "/equipment.json and /{locale}/equipment/{id}.json for set identity/effect text; slot/main/substat tables are out of V0.1.0 formal-data scope",
       "rawFieldPaths": [
         "/equipment.json/{id}/{locale}/desc2",
         "/equipment.json/{id}/{locale}/desc4",
@@ -1104,15 +1104,15 @@
         "/desc2",
         "/desc4"
       ],
-      "transformRule": "nanoka live equipment index/detail only expose Drive Disc set identity and set-effect text; checked candidate slot/main/substat table endpoints are absent, so do not synthesize slot, main-stat, substat, level, or stat-roll tables. Escalate per R3 for owner decision: remove from V0.1.0 formal-data scope or approve research of a non-nanoka source.",
+      "transformRule": "Owner decision (2026-05-15) removes Drive Disc slot/main/substat tables from V0.1.0 formal-data scope because user snapshot input supplies the final Agent panel after main/substats. Fairy consumes Drive Disc set identity and set-effect text from nanoka; do not synthesize slot, main-stat, substat, level, or stat-roll tables, and do not reverse-engineer user panel values in runtime.",
       "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "owner:drive-disc-slot-stat-source-required"
+        "scope:user-provided-snapshot-boundary"
       ],
       "auditArtifact": "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
-      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. The row stays non-promotable and owner-research gated to preserve the no-fabrication/no-silent-fallback rule."
+      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. Lo-user decision on 2026-05-15 locks option (a): V0.1.0 only needs final user-provided panel plus Drive Disc set effects, so this row is excluded from Phase 3 blocking drift and deferred to V1.x validation/recommendation scope."
     },
     {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
@@ -1302,8 +1302,8 @@
     "totalRows": 45,
     "verifiedFromNanoka": 36,
     "needsTlResearch": 0,
-    "needsOwnerResearch": 1,
-    "deferred": 8,
+    "needsOwnerResearch": 0,
+    "deferred": 9,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1316,8 +1316,7 @@
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics after variant mapping",
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
-    "Sentinel canonical naming and unit normalization",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
+    "Sentinel canonical naming and unit normalization"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-000-foundation",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 0,
+    "new": 0,
+    "semantic-mismatch": 0
+  },
+  "rows": [],
+  "unresolvedCount": 0,
+  "notes": [
+    "Phase 3 foundation fixture only: this artifact locks the drift-report contract, mirror, verifier, and package inclusion before full field comparison lands.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
+++ b/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "nanoka-drive-disc-slot-stat-audit/v0.1",
-  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
   "sourceId": "nanoka-zzz",
   "sourceVersion": "2.8",
   "status": "not-found",
@@ -10,7 +10,7 @@
   "summary": {
     "checkedEndpointCount": 9,
     "foundSlotMainSubstatTable": false,
-    "ownerResearchRequired": true
+    "ownerResearchRequired": false
   },
   "checkedEndpoints": [
     {
@@ -76,10 +76,11 @@
     }
   ],
   "decision": {
-    "matrixStatus": "needs-owner-research",
+    "matrixStatus": "deferred",
+    "sourcePolicy": "out-of-scope",
     "blockedBy": [
-      "owner:drive-disc-slot-stat-source-required"
+      "scope:user-provided-snapshot-boundary"
     ],
-    "recommendedEscalation": "lo-user/Product should decide whether Drive Disc slot/main/substat tables are out of V0.1.0 formal-data scope or whether a non-nanoka source must be researched."
+    "ownerDecision": "2026-05-15 lo-user locks option (a): remove Drive Disc slot/main/substat tables from V0.1.0 formal-data scope. Runtime consumes user-provided final Agent panel plus nanoka-backed Drive Disc set effects; slot/main/substat tables are V1.x validation/recommendation scope."
   }
 }

--- a/docs/data-contract/cleaned-schema-contract.md
+++ b/docs/data-contract/cleaned-schema-contract.md
@@ -88,7 +88,7 @@ published.
 | `GameData.bangboos` | required | nanoka-candidate | Bangboo identity and panel data. |
 | `GameData.bangbooSkills` | required | nanoka-candidate | Bangboo segment numbers and source refs. |
 | `GameData.wEngines` | optional | nanoka-candidate | W-Engine stats and passive modifiers. |
-| `GameData.driveDiscs` | optional | nanoka-candidate | Drive Disc set modifiers; text alone is not promotable. |
+| `GameData.driveDiscs` | optional | nanoka-candidate | Drive Disc identity and 2/4-piece set modifiers; slot/main/substat tables are out of V0.1.0 formal-data scope because snapshots provide the final agent panel. |
 | `GameData.enemies` | required | nanoka-candidate | Enemy variants, stats, resistances, anomaly thresholds, and daze recovery. |
 | `GameData.resonium` | removed-out-of-product-scope | removed-out-of-product-scope | Lost Void / Resonium formal data is removed from the V0.1.0 product scope by R4. Existing schema presence is compatibility-only until a breaking schema cleanup. |
 | `GameData.modifiers` | required | implementation-owned | Deterministic typed modifier templates with source refs. |
@@ -103,9 +103,16 @@ source data. Inventory rows that affect snapshots must therefore declare whether
 they populate:
 
 - `AgentSnapshot.panel`
+- `DriveDiscSnapshot` / final Drive Disc panel contribution
 - `BangbooSnapshot.panel`
 - `EnemySnapshot`
 - `AttackSegment`
 - `TypedModifier`
 - `ManualEvent`
 - `fieldProvenance` / `overrides`
+
+For V0.1.0, Drive Disc main-stat and substat values are not recomputed from
+slot/stat tables. Users provide the final `AgentSnapshot.panel` after equipped
+Drive Discs, while formal data only needs nanoka-backed Drive Disc identity and
+set-effect text for future typed modifier promotion. Slot/main/substat tables
+remain V1.x validation/recommendation scope.

--- a/docs/data-source/drift-reports/phase3-sync-000-foundation.md
+++ b/docs/data-source/drift-reports/phase3-sync-000-foundation.md
@@ -1,0 +1,43 @@
+# Nanoka Drift Report: phase3-sync-000-foundation
+
+Status: Phase 3 drift audit foundation fixture
+Generated: 2026-05-15T16:20:00+08:00
+
+This report is a schema/verifier fixture. It intentionally contains no field
+comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.
+
+## Candidate
+
+| Source | Version | Content Hash |
+|---|---|---|
+| `nanoka-zzz` | `2.8` | `sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d` |
+
+## Baselines
+
+| Source | Version | Archived |
+|---|---|---|
+| `lo-user-excel` | `2.6.0_R14028417` | yes |
+| `mihoyo-zzz-critical-assault` | `2026-05-05T0850Z` | yes |
+| `buhflipexplode-zzz-da` | `2026-05-05T0445Z` | yes |
+
+## Counts
+
+| Status | Count |
+|---|---:|
+| `same` | 0 |
+| `changed` | 0 |
+| `missing` | 0 |
+| `new` | 0 |
+| `semantic-mismatch` | 0 |
+
+Unresolved blocking drift rows: **0**
+
+Runtime cutover ready: **false**
+
+## Boundary
+
+- This artifact does not compare production fields yet.
+- Archived Excel / D-17 / D-12 sources remain audit baselines, not runtime
+  fallback.
+- Any future `changed`, `missing`, `new`, or `semantic-mismatch` row must
+  carry source refs and a ruling before Phase 3 exit.

--- a/docs/data-source/nanoka-coverage-matrix.md
+++ b/docs/data-source/nanoka-coverage-matrix.md
@@ -1,11 +1,11 @@
 # Nanoka Coverage Matrix
 
-Status: Phase 2 Disorder daze-level audit gate
+Status: Phase 3 drift foundation gate
 Owner: @TechLead
 Reviewers: @Product, @QA
 Related: D-20 data-source migration, task #121, task #122, task #125, task #127,
 task #138, task #140, task #142, task #144, task #146, task #148, task #150,
-task #152, task #154, task #156, task #158
+task #152, task #154, task #156, task #158, task #161
 
 This matrix is schema-first. It is derived from the canonical `GameData` and
 `BattleSnapshot` schemas, then checked against sampled nanoka detail endpoints.
@@ -56,7 +56,7 @@ The machine-readable version is
 | Live enemy variant mapping samples | `https://static.nanoka.cc/zzz/2.8/zh/monster/{id}.json` | Approved live samples for Dullahan `30000`, Greta `30004`, Ruthless Fiend `200141`, Notorious Hati `200014`, Notorious Armored Hati `200034`, Miasma Priest `30033`, and Notorious Pompey `300211`. Task #144 proves `detail.monster_id -> monster_info[monster_id]` for G13/G18/G19/G20 source artifacts. |
 | Live W-Engine / Yixuan signature sample | `https://static.nanoka.cc/zzz/2.8/zh/weapon/14137.json` | Approved live sample for W-Engine identity; `base_property`, `rand_property`, `level`, `stars`, and `talents` remain blocked for stat/passive promotion until mapping/templates are proven. |
 | Live Drive Disc / Woodpecker Electro sample | `https://static.nanoka.cc/zzz/2.8/zh/equipment/31000.json` | Approved live sample for Drive Disc identity; `desc2` / `desc4` text exists, but typed modifiers are not promotable until deterministic parsing/templates exist. Task #154 confirms this detail does not expose slot/main/substat tables. |
-| Live Drive Disc / equipment index audit | `https://static.nanoka.cc/zzz/2.8/equipment.json` | Failed-evidence audit only: live equipment index exposes set name/`desc2`/`desc4` text, not slot/main/substat tables. Candidate stat-table endpoints checked in `data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json` returned 404. |
+| Live Drive Disc / equipment index audit | `https://static.nanoka.cc/zzz/2.8/equipment.json` | Failed-evidence audit only: live equipment index exposes set name/`desc2`/`desc4` text, not slot/main/substat tables. Candidate stat-table endpoints checked in `data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json` returned 404. Lo-user locks V0.1.0 scope to final user-provided panel + set effects, so slot/main/substat tables are V1.x validation/recommendation scope. |
 | Manifest / live gate | `https://static.nanoka.cc/manifest.json` | `zzz.live = 2.8`, `zzz.latest = 3.0.2+15625449`, `zzz.available[]` supports approved-live version allowlists and snapshot-derived patch diff history. |
 | Live Adrenaline / Resonance sample / Yixuan | `https://static.nanoka.cc/zzz/2.8/zh/character/1371.json` | `stats.rp_max = 120`, `stats.rp_recover = 200`, `fever_recovery`, and `rp_recovery` raw paths exist in the configured live version. |
 | Live Deadly Assault index | `https://static.nanoka.cc/zzz/2.8/boss.json` | 38 live DA entries; all sampled `zh/boss/{id}.json` details returned 200 in PR #54. |
@@ -105,9 +105,9 @@ until Phase 3/4 drift/cutover.
 
 ## Human-Readable Summary
 
-Machine summary after task #158: 45 rows total, 36 `verified-from-nanoka`, 0
-`needs-tl-research`, 1 `needs-owner-research`, 8 `deferred`, and 20
-`promotableNow`.
+Machine summary after task #161 / Drive Disc owner decision: 45 rows total, 36
+`verified-from-nanoka`, 0 `needs-tl-research`, 0 `needs-owner-research`, 9
+`deferred`, and 20 `promotableNow`.
 
 | Area | Status | Promote Now | Main Blocker |
 |---|---|---:|---|
@@ -128,7 +128,7 @@ Machine summary after task #158: 45 rows total, 36 `verified-from-nanoka`, 0
 | W-Engine stats | verified-from-nanoka | no | Detail endpoint exists; ID mapping and stat normalization are unresolved. |
 | W-Engine passive | verified-from-nanoka | no | Raw text/objects exist; typed modifier template is unresolved. |
 | Drive Disc set effects | verified-from-nanoka | no | Raw text exists; typed modifier template is unresolved. |
-| Drive Disc slot/main/sub stats | needs-owner-research | no | Task #154 exhausted live nanoka equipment detail/index and candidate stat-table endpoints; no slot/main/substat table source was found, so lo-user/Product must decide out-of-scope vs approved non-nanoka source research. |
+| Drive Disc slot/main/sub stats | deferred / out-of-scope | no | Lo-user locks V0.1.0 to user-provided final Agent panel plus Drive Disc set effects; task #154 still records failed nanoka evidence, but this row is excluded from Phase 3 blocking drift and deferred to V1.x validation/recommendation scope. |
 | Resonium / Lost Void | removed | no | Removed from V0.1.0 product scope by R4; no formal data expected. |
 | Deadly Assault periods/buffs | verified-from-nanoka | yes | Structured source artifact mapping exists for period, zones, buffs, monsters, weakness, rank goals, and `boss_adjust`; runtime cutover still waits for Phase 3 drift audit. |
 | Formula rule tables | mixed | no | Base damage, rounding, Disorder formula, and Disorder daze-level are implementation-owned runtime contracts; anomaly thresholds, daze recovery, and attribute mappings still need row-level source/owner decisions. |
@@ -139,12 +139,17 @@ After task #158, no rows remain in `needs-tl-research`.
 
 ## Owner Research / Decision Rows
 
-After task #154, 1 row is escalated to `needs-owner-research`:
+After the 2026-05-15 owner decision, no rows remain in `needs-owner-research`.
+
+## User-Provided Snapshot Boundary Rows
 
 - `driveDiscs.slotAndSubstatTables` — approved live nanoka equipment detail and
   index expose only Drive Disc set identity/effect text; checked candidate
-  stat-table endpoints are absent. Owner decision required: remove this from
-  V0.1.0 formal-data scope or approve non-nanoka source research.
+  stat-table endpoints are absent. Lo-user locks V0.1.0 to user-provided final
+  Agent panel plus Drive Disc set effects, so slot/main/substat tables are
+  `deferred` / `out-of-scope` for V0.1.0 formal data and excluded from Phase 3
+  blocking drift. They may return in V1.x for reverse-engineering, validation,
+  or recommendation features.
 
 ## Implementation-Owned Rule Rows
 

--- a/docs/product/decisions/D-20-data-source-migration.md
+++ b/docs/product/decisions/D-20-data-source-migration.md
@@ -311,7 +311,21 @@ lo-user 已 explicitly 接受以下残余风险（per msg `74b52454`）：
 
 ### Gate 8 — Phase 3 drift audit
 - Phase 3 = nanoka output ↔ archived Excel / D-17 / D-12 evidence drift audit，**不是 runtime fallback**
-- Exit gate：连续 2 sync 无未 ruling drift + G01-G26 golden replay PASS + 新 G27/G28 source-backed anchors PASS
+- Drift report 必须产出 root/package mirrored JSON：
+  `data/cleaned/audit/nanoka-drift-report/<syncId>.json` 与
+  `packages/data/cleaned/audit/nanoka-drift-report/<syncId>.json`
+- 人读报告路径：`docs/data-source/drift-reports/<syncId>.md`
+- Drift status 枚举：`same` / `changed` / `missing` / `new` /
+  `semantic-mismatch`
+- `changed` / `missing` / `new` / `semantic-mismatch` 均进入 ruling queue；
+  `same` 为 `not-required`
+- 可执行命令：
+  - `pnpm --filter @randomplay/data audit:source-migration --sync-id <syncId>`
+  - `pnpm --filter @randomplay/data verify:source-migration --sync-id <syncId>`
+- Exit gate：连续 2 sync `unresolvedCount === 0` + G01-G26 golden replay PASS
+  + 新 G27/G28 source-backed anchors PASS
+- `runtimeCutoverReady` 必须保持 `false` 到 Phase 4；Phase 3 不允许接回
+  Excel/D-17/D-12 runtime fallback
 
 ### Phase 2 test files（5 个）
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -10,6 +10,8 @@ Current state:
   offline verification scripts;
 - D-20 source registry gates live under `source-registry.json` and are verified
   by `verify:source-registry`;
+- Phase 3 nanoka drift reports live under `cleaned/audit/nanoka-drift-report/`
+  and are verified by `verify:source-migration`;
 - V1 golden source candidates, manual acceptance records, and the replay report
   are generated under repo-level `data/cleaned/`;
 - `pnpm --filter @randomplay/data sync-cleaned` mirrors repo-level cleaned JSON into
@@ -28,3 +30,4 @@ Useful source checks:
 - `pnpm --filter @randomplay/data verify:mihoyo-da`
 - `pnpm --filter @randomplay/data verify:nanoka`
 - `pnpm --filter @randomplay/data verify:source-registry`
+- `pnpm --filter @randomplay/data verify:source-migration`

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T15:35:00+08:00",
-  "status": "phase-2-disorder-daze-level-audit-gate",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "status": "phase-3-drift-foundation-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
     "packages/core/src/schema/game-data.ts",
@@ -1092,10 +1092,10 @@
     {
       "fieldId": "driveDiscs.slotAndSubstatTables",
       "canonicalPath": "DriveDiscSnapshot.slot/setId and future GameData drive disc stat tables",
-      "fieldClass": "optional",
-      "sourcePolicy": "nanoka",
-      "status": "needs-owner-research",
-      "nanokaEndpoint": "/equipment.json, /{locale}/equipment/{id}.json, and checked candidate stat-table endpoints",
+      "fieldClass": "removed-out-of-product-scope",
+      "sourcePolicy": "out-of-scope",
+      "status": "deferred",
+      "nanokaEndpoint": "/equipment.json and /{locale}/equipment/{id}.json for set identity/effect text; slot/main/substat tables are out of V0.1.0 formal-data scope",
       "rawFieldPaths": [
         "/equipment.json/{id}/{locale}/desc2",
         "/equipment.json/{id}/{locale}/desc4",
@@ -1104,15 +1104,15 @@
         "/desc2",
         "/desc4"
       ],
-      "transformRule": "nanoka live equipment index/detail only expose Drive Disc set identity and set-effect text; checked candidate slot/main/substat table endpoints are absent, so do not synthesize slot, main-stat, substat, level, or stat-roll tables. Escalate per R3 for owner decision: remove from V0.1.0 formal-data scope or approve research of a non-nanoka source.",
+      "transformRule": "Owner decision (2026-05-15) removes Drive Disc slot/main/substat tables from V0.1.0 formal-data scope because user snapshot input supplies the final Agent panel after main/substats. Fairy consumes Drive Disc set identity and set-effect text from nanoka; do not synthesize slot, main-stat, substat, level, or stat-roll tables, and do not reverse-engineer user panel values in runtime.",
       "sampleEntity": "nanoka-equipment-woodpecker-live-31000",
       "rawAvailable": false,
       "promotable": false,
       "blockedBy": [
-        "owner:drive-disc-slot-stat-source-required"
+        "scope:user-provided-snapshot-boundary"
       ],
       "auditArtifact": "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
-      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. The row stays non-promotable and owner-research gated to preserve the no-fabrication/no-silent-fallback rule."
+      "notes": "Task #154 exhausted approved live nanoka equipment index/detail and candidate slot/stat-table endpoints. Lo-user decision on 2026-05-15 locks option (a): V0.1.0 only needs final user-provided panel plus Drive Disc set effects, so this row is excluded from Phase 3 blocking drift and deferred to V1.x validation/recommendation scope."
     },
     {
       "fieldId": "deadlyAssault.periodsBossesBuffs",
@@ -1302,8 +1302,8 @@
     "totalRows": 45,
     "verifiedFromNanoka": 36,
     "needsTlResearch": 0,
-    "needsOwnerResearch": 1,
-    "deferred": 8,
+    "needsOwnerResearch": 0,
+    "deferred": 9,
     "promotableNow": 20,
     "notPromotableYet": 25
   },
@@ -1316,8 +1316,7 @@
     "enemy level formula, resistance units, anomaly threshold mapping, and daze recovery semantics after variant mapping",
     "W-Engine stat/refine mapping",
     "DA boss_adjust, score/HP, field-rule, and period filter semantic mapping",
-    "Sentinel canonical naming and unit normalization",
-    "Drive Disc slot/main/substat owner decision: out-of-scope formal data or approved non-nanoka source research"
+    "Sentinel canonical naming and unit normalization"
   ],
   "liveVersionRef": "manifest.zzz.live",
   "sourceVersionResolved": "2.8",

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-000-foundation",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 0,
+    "new": 0,
+    "semantic-mismatch": 0
+  },
+  "rows": [],
+  "unresolvedCount": 0,
+  "notes": [
+    "Phase 3 foundation fixture only: this artifact locks the drift-report contract, mirror, verifier, and package inclusion before full field comparison lands.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
+++ b/packages/data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "nanoka-drive-disc-slot-stat-audit/v0.1",
-  "generatedAt": "2026-05-15T15:05:00+08:00",
+  "generatedAt": "2026-05-15T16:20:00+08:00",
   "sourceId": "nanoka-zzz",
   "sourceVersion": "2.8",
   "status": "not-found",
@@ -10,7 +10,7 @@
   "summary": {
     "checkedEndpointCount": 9,
     "foundSlotMainSubstatTable": false,
-    "ownerResearchRequired": true
+    "ownerResearchRequired": false
   },
   "checkedEndpoints": [
     {
@@ -76,10 +76,11 @@
     }
   ],
   "decision": {
-    "matrixStatus": "needs-owner-research",
+    "matrixStatus": "deferred",
+    "sourcePolicy": "out-of-scope",
     "blockedBy": [
-      "owner:drive-disc-slot-stat-source-required"
+      "scope:user-provided-snapshot-boundary"
     ],
-    "recommendedEscalation": "lo-user/Product should decide whether Drive Disc slot/main/substat tables are out of V0.1.0 formal-data scope or whether a non-nanoka source must be researched."
+    "ownerDecision": "2026-05-15 lo-user locks option (a): remove Drive Disc slot/main/substat tables from V0.1.0 formal-data scope. Runtime consumes user-provided final Agent panel plus nanoka-backed Drive Disc set effects; slot/main/substat tables are V1.x validation/recommendation scope."
   }
 }

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "audit:excel": "node scripts/excel-source.mjs audit --generated-at 2026-05-05T17:40:00+08:00",
     "audit:golden-v1": "tsx scripts/golden-v1-replay.ts audit --generated-at 2026-05-05T18:20:00+08:00",
+    "audit:source-migration": "node scripts/source-migration-drift.mjs audit",
     "build": "tsdown src/index.ts src/types.ts --format esm --dts --clean --out-dir dist",
     "check": "tsc -p tsconfig.json --noEmit",
     "fetch:buhflipexplode-da": "node scripts/buhflipexplode-da-source.mjs fetch",
@@ -46,6 +47,7 @@
     "verify:golden-v1": "tsx scripts/golden-v1-replay.ts verify",
     "verify:mihoyo-da": "node scripts/mihoyo-da-source.mjs verify --snapshot 2026-05-05T0850Z",
     "verify:nanoka": "node scripts/nanoka-source.mjs verify --snapshot 2.8",
+    "verify:source-migration": "node scripts/source-migration-drift.mjs verify",
     "verify:source-registry": "node scripts/verify-source-registry.mjs"
   },
   "dependencies": {

--- a/packages/data/scripts/source-migration-drift.mjs
+++ b/packages/data/scripts/source-migration-drift.mjs
@@ -1,0 +1,319 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageDir = fileURLToPath(new URL("..", import.meta.url))
+const repoRoot = join(packageDir, "../..")
+
+const rootRegistryPath = join(repoRoot, "data/source-registry.json")
+const packageRegistryPath = join(packageDir, "source-registry.json")
+const matrixPath = join(repoRoot, "data/cleaned/audit/nanoka-coverage-matrix.json")
+const rootReportDir = join(repoRoot, "data/cleaned/audit/nanoka-drift-report")
+const packageReportDir = join(packageDir, "cleaned/audit/nanoka-drift-report")
+const docsReportDir = join(repoRoot, "docs/data-source/drift-reports")
+
+const schemaVersion = "nanoka-drift-report/v0.1"
+const defaultSyncId = "phase3-sync-000-foundation"
+const defaultGeneratedAt = "2026-05-15T16:20:00+08:00"
+const driftStatuses = ["same", "changed", "missing", "new", "semantic-mismatch"]
+const entityTypes = ["agent", "bangboo", "enemy", "wEngine", "driveDisc", "deadlyAssault", "metadata", "rules"]
+const severities = ["info", "blocking"]
+const rulingStatuses = ["not-required", "pending", "accepted", "fixed", "deferred", "owner-required"]
+const requiredBaselineIds = ["lo-user-excel", "mihoyo-zzz-critical-assault", "buhflipexplode-zzz-da"]
+
+function parseArgs(argv) {
+  const [command = "verify", ...rest] = argv
+  const flags = {}
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index]
+    if (token === "--")
+      continue
+    if (!token.startsWith("--"))
+      throw new Error(`Unexpected positional argument: ${token}`)
+    const key = token.slice(2)
+    const next = rest[index + 1]
+    if (next === undefined || next.startsWith("--")) {
+      flags[key] = true
+    }
+    else {
+      flags[key] = next
+      index += 1
+    }
+  }
+
+  return { command, flags }
+}
+
+function assert(condition, message) {
+  if (!condition)
+    throw new Error(message)
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function writeJson(path, data) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`)
+}
+
+function writeText(path, text) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, text)
+}
+
+function sourceById(registry, sourceId) {
+  const source = registry.sources.find(item => item.sourceId === sourceId)
+  assert(source !== undefined, `Missing source-registry entry for ${sourceId}`)
+  return source
+}
+
+function baselineFromRegistry(registry, sourceId) {
+  const source = sourceById(registry, sourceId)
+  assert(source.redistributionRisk === "archived-audit-baseline", `${sourceId}: drift baselines must be archived audit baselines`)
+  return {
+    sourceId,
+    sourceVersion: source.configuredLiveVersion,
+    archived: true,
+  }
+}
+
+function zeroCounts() {
+  return {
+    same: 0,
+    changed: 0,
+    missing: 0,
+    new: 0,
+    "semantic-mismatch": 0,
+  }
+}
+
+function reportPaths(syncId) {
+  return {
+    rootJson: join(rootReportDir, `${syncId}.json`),
+    packageJson: join(packageReportDir, `${syncId}.json`),
+    markdown: join(docsReportDir, `${syncId}.md`),
+  }
+}
+
+function buildFoundationReport({ syncId, generatedAt }) {
+  const registry = readJson(rootRegistryPath)
+  const matrix = readJson(matrixPath)
+  const nanoka = sourceById(registry, "nanoka-zzz")
+
+  return {
+    schemaVersion,
+    syncId,
+    generatedAt,
+    candidate: {
+      sourceId: "nanoka-zzz",
+      sourceVersion: nanoka.configuredLiveVersion,
+      contentHash: nanoka.contentHash,
+    },
+    baselines: requiredBaselineIds.map(sourceId => baselineFromRegistry(registry, sourceId)),
+    matrixStatus: matrix.status,
+    runtimeCutoverReady: false,
+    counts: zeroCounts(),
+    rows: [],
+    unresolvedCount: 0,
+    notes: [
+      "Phase 3 foundation fixture only: this artifact locks the drift-report contract, mirror, verifier, and package inclusion before full field comparison lands.",
+      "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs.",
+    ],
+  }
+}
+
+function renderMarkdown(report) {
+  const countRows = driftStatuses
+    .map(status => `| \`${status}\` | ${report.counts[status]} |`)
+    .join("\n")
+  const baselines = report.baselines
+    .map(baseline => `| \`${baseline.sourceId}\` | \`${baseline.sourceVersion}\` | ${baseline.archived ? "yes" : "no"} |`)
+    .join("\n")
+
+  return `# Nanoka Drift Report: ${report.syncId}
+
+Status: Phase 3 drift audit foundation fixture
+Generated: ${report.generatedAt}
+
+This report is a schema/verifier fixture. It intentionally contains no field
+comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.
+
+## Candidate
+
+| Source | Version | Content Hash |
+|---|---|---|
+| \`${report.candidate.sourceId}\` | \`${report.candidate.sourceVersion}\` | \`${report.candidate.contentHash}\` |
+
+## Baselines
+
+| Source | Version | Archived |
+|---|---|---|
+${baselines}
+
+## Counts
+
+| Status | Count |
+|---|---:|
+${countRows}
+
+Unresolved blocking drift rows: **${report.unresolvedCount}**
+
+Runtime cutover ready: **${report.runtimeCutoverReady}**
+
+## Boundary
+
+- This artifact does not compare production fields yet.
+- Archived Excel / D-17 / D-12 sources remain audit baselines, not runtime
+  fallback.
+- Any future \`changed\`, \`missing\`, \`new\`, or \`semantic-mismatch\` row must
+  carry source refs and a ruling before Phase 3 exit.
+`
+}
+
+function validateSourceRef(ref, label) {
+  assert(ref !== null && typeof ref === "object", `${label}: SourceRef is required`)
+  for (const key of ["sourceId", "sourceVersion", "sourceAnchor", "dataPath"])
+    assert(typeof ref[key] === "string" && ref[key].length > 0, `${label}: ${key} is required`)
+}
+
+function validateRows(report) {
+  const actualCounts = zeroCounts()
+  let unresolvedCount = 0
+
+  assert(Array.isArray(report.rows), "rows must be an array")
+  for (const [index, row] of report.rows.entries()) {
+    const label = `rows[${index}]`
+    assert(entityTypes.includes(row.entityType), `${label}: invalid entityType ${row.entityType}`)
+    assert(typeof row.entityId === "string" && row.entityId.length > 0, `${label}: entityId is required`)
+    assert(typeof row.fieldId === "string" && row.fieldId.length > 0, `${label}: fieldId is required`)
+    assert(typeof row.canonicalPath === "string" && row.canonicalPath.length > 0, `${label}: canonicalPath is required`)
+    assert(typeof row.fieldPath === "string" && row.fieldPath.length > 0, `${label}: fieldPath is required`)
+    validateSourceRef(row.baselineSourceRef, `${label}.baselineSourceRef`)
+    validateSourceRef(row.candidateSourceRef, `${label}.candidateSourceRef`)
+    assert(driftStatuses.includes(row.status), `${label}: invalid status ${row.status}`)
+    assert(severities.includes(row.severity), `${label}: invalid severity ${row.severity}`)
+    assert(rulingStatuses.includes(row.rulingStatus), `${label}: invalid rulingStatus ${row.rulingStatus}`)
+    assert(Array.isArray(row.blockedBy), `${label}: blockedBy must be an array`)
+    assert(typeof row.notes === "string", `${label}: notes must be a string`)
+
+    actualCounts[row.status] += 1
+
+    if (row.status === "same") {
+      assert(row.severity === "info", `${label}: same rows must be informational`)
+      assert(row.rulingStatus === "not-required", `${label}: same rows must not require a ruling`)
+      assert(row.blockedBy.length === 0, `${label}: same rows must not carry blockers`)
+    }
+    else {
+      assert(row.severity === "blocking", `${label}: non-same drift rows are blocking until ruled`)
+      assert(row.rulingStatus !== "not-required", `${label}: non-same rows require explicit ruling queue status`)
+      if (row.rulingStatus === "pending" || row.rulingStatus === "owner-required") {
+        unresolvedCount += 1
+      }
+      else {
+        assert(typeof row.rulingId === "string" && row.rulingId.length > 0, `${label}: resolved non-same rows require rulingId`)
+      }
+    }
+  }
+
+  assert(JSON.stringify(report.counts) === JSON.stringify(actualCounts), "counts must equal row status totals")
+  assert(report.unresolvedCount === unresolvedCount, "unresolvedCount must equal pending/owner-required blocking rows")
+}
+
+function validateReportShape(report, { registry, matrix, syncId }) {
+  assert(report.schemaVersion === schemaVersion, "Unexpected drift report schemaVersion")
+  assert(report.syncId === syncId, "syncId must match requested report")
+  assert(typeof report.generatedAt === "string" && report.generatedAt.length > 0, "generatedAt is required")
+
+  const nanoka = sourceById(registry, "nanoka-zzz")
+  assert(report.candidate?.sourceId === "nanoka-zzz", "candidate sourceId must be nanoka-zzz")
+  assert(report.candidate?.sourceVersion === nanoka.configuredLiveVersion, "candidate sourceVersion must match configured live version")
+  assert(report.candidate?.contentHash === nanoka.contentHash, "candidate contentHash must match source registry")
+  assert(report.candidate.sourceVersion !== nanoka.latestResearchVersion, "candidate must not use latest research version")
+  assert(report.matrixStatus === matrix.status, "matrixStatus must match current nanoka coverage matrix")
+  assert(report.runtimeCutoverReady === false, "Phase 3 drift reports must not imply runtime cutover")
+
+  assert(Array.isArray(report.baselines), "baselines must be an array")
+  for (const sourceId of requiredBaselineIds) {
+    const baseline = report.baselines.find(item => item.sourceId === sourceId)
+    const registrySource = sourceById(registry, sourceId)
+    assert(baseline !== undefined, `Missing drift baseline ${sourceId}`)
+    assert(baseline.sourceVersion === registrySource.configuredLiveVersion, `${sourceId}: baseline sourceVersion drifted`)
+    assert(baseline.archived === true, `${sourceId}: baseline must be archived`)
+  }
+
+  validateRows(report)
+}
+
+function validateReport({ syncId }) {
+  const { rootJson, packageJson, markdown } = reportPaths(syncId)
+  assert(existsSync(rootJson), `Missing root drift report ${rootJson}`)
+  assert(existsSync(packageJson), `Missing package drift report ${packageJson}`)
+  assert(readFileSync(rootJson, "utf8") === readFileSync(packageJson, "utf8"), "package drift report must mirror root report byte-for-byte")
+
+  const rootRegistryText = readFileSync(rootRegistryPath, "utf8")
+  const packageRegistryText = readFileSync(packageRegistryPath, "utf8")
+  assert(rootRegistryText === packageRegistryText, "package source-registry must mirror root source-registry byte-for-byte")
+
+  const report = JSON.parse(readFileSync(rootJson, "utf8"))
+  validateReportShape(report, {
+    registry: JSON.parse(rootRegistryText),
+    matrix: readJson(matrixPath),
+    syncId,
+  })
+
+  assert(existsSync(markdown), `Missing human drift report ${markdown}`)
+  const markdownText = readFileSync(markdown, "utf8")
+  assert(markdownText.includes(`# Nanoka Drift Report: ${syncId}`), "human report must include sync heading")
+  assert(markdownText.includes("Archived Excel / D-17 / D-12 sources remain audit baselines"), "human report must document no runtime fallback boundary")
+}
+
+function validateReportFixture({ reportPath, syncId }) {
+  assert(typeof reportPath === "string" && reportPath.length > 0, "verify-fixture requires --report <path>")
+  const rootRegistryText = readFileSync(rootRegistryPath, "utf8")
+  const report = readJson(reportPath)
+  validateReportShape(report, {
+    registry: JSON.parse(rootRegistryText),
+    matrix: readJson(matrixPath),
+    syncId,
+  })
+}
+
+function audit({ syncId, generatedAt }) {
+  const report = buildFoundationReport({ syncId, generatedAt })
+  const { rootJson, packageJson, markdown } = reportPaths(syncId)
+  writeJson(rootJson, report)
+  writeJson(packageJson, report)
+  writeText(markdown, renderMarkdown(report))
+  validateReport({ syncId })
+  console.log(`source migration drift audit wrote ${syncId}`)
+}
+
+function main() {
+  const { command, flags } = parseArgs(process.argv.slice(2))
+  const syncId = String(flags["sync-id"] ?? defaultSyncId)
+  const generatedAt = String(flags["generated-at"] ?? defaultGeneratedAt)
+
+  if (command === "audit") {
+    audit({ syncId, generatedAt })
+    return
+  }
+
+  if (command === "verify") {
+    validateReport({ syncId })
+    console.log(`source migration drift verification passed for ${syncId}`)
+    return
+  }
+
+  if (command === "verify-fixture") {
+    validateReportFixture({ reportPath: flags.report, syncId })
+    console.log(`source migration drift fixture verification passed for ${syncId}`)
+    return
+  }
+
+  throw new Error(`Unsupported source migration drift command: ${command}`)
+}
+
+main()

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -124,7 +124,7 @@ function validateMatrixAgainstRegistry(matrix, registry) {
   const nanoka = sourceById(registry, "nanoka-zzz")
   validateNanokaRegistry(nanoka)
 
-  assert(matrix.status === "phase-2-disorder-daze-level-audit-gate", "matrix status must match the latest Disorder daze-level audit gate")
+  assert(matrix.status === "phase-3-drift-foundation-gate", "matrix status must match the Phase 3 drift foundation gate")
   assert(matrix.sourceVersionPolicy?.liveVersionRef === nanoka.liveVersionRef, "matrix liveVersionRef must match nanoka registry")
   assert(matrix.sourceVersionPolicy?.defaultReleaseSourceVersion === nanoka.configuredLiveVersion, "matrix default release version must match configuredLiveVersion")
   assert(matrix.sourceVersionResolved === nanoka.configuredLiveVersion, "matrix resolved sourceVersion must match configuredLiveVersion")
@@ -197,12 +197,16 @@ function validateMatrixAgainstRegistry(matrix, registry) {
 
   const driveDiscSlotRow = resourceRows.get("driveDiscs.slotAndSubstatTables")
   assert(driveDiscSlotRow !== undefined, "driveDiscs.slotAndSubstatTables: missing Drive Disc slot/stat row")
-  assert(driveDiscSlotRow.status === "needs-owner-research", "driveDiscs.slotAndSubstatTables: row must escalate after failed nanoka audit")
-  assert(driveDiscSlotRow.promotable === false, "driveDiscs.slotAndSubstatTables: failed-evidence row must not be promotable")
+  assert(driveDiscSlotRow.status === "deferred", "driveDiscs.slotAndSubstatTables: row must be deferred after owner scope decision")
+  assert(driveDiscSlotRow.sourcePolicy === "out-of-scope", "driveDiscs.slotAndSubstatTables: row must be out-of-scope for V0.1.0 formal data")
+  assert(driveDiscSlotRow.fieldClass === "removed-out-of-product-scope", "driveDiscs.slotAndSubstatTables: fieldClass must be removed-out-of-product-scope")
+  assert(driveDiscSlotRow.promotable === false, "driveDiscs.slotAndSubstatTables: out-of-scope row must not be promotable")
   assert(driveDiscSlotRow.sampleEntity === "nanoka-equipment-woodpecker-live-31000", "driveDiscs.slotAndSubstatTables: row must use approved live Woodpecker sample evidence")
-  assert(driveDiscSlotRow.blockedBy?.includes("owner:drive-disc-slot-stat-source-required"), "driveDiscs.slotAndSubstatTables: row must carry owner escalation blocker")
+  assert(driveDiscSlotRow.blockedBy?.includes("scope:user-provided-snapshot-boundary"), "driveDiscs.slotAndSubstatTables: row must carry user-provided snapshot boundary blocker")
   assert(driveDiscSlotRow.auditArtifact === "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json", "driveDiscs.slotAndSubstatTables: row must point to failed-evidence audit artifact")
   assert(driveDiscSlotRow.transformRule?.includes("do not synthesize"), "driveDiscs.slotAndSubstatTables: transform must preserve no-fabrication boundary")
+  assert(driveDiscSlotRow.transformRule?.includes("user snapshot input supplies the final Agent panel"), "driveDiscs.slotAndSubstatTables: transform must document final panel snapshot boundary")
+  assert(driveDiscSlotRow.transformRule?.includes("do not reverse-engineer user panel values"), "driveDiscs.slotAndSubstatTables: transform must reject runtime reverse engineering")
   for (const rawPath of ["/id", "/name", "/desc2", "/desc4"]) {
     assert(driveDiscSlotRow.rawFieldPaths?.includes(rawPath), `driveDiscs.slotAndSubstatTables: missing observed raw path ${rawPath}`)
   }
@@ -368,7 +372,7 @@ function validateDriveDiscSlotStatAudit(registry) {
   assert(audit.sampleEntity === "nanoka-equipment-woodpecker-live-31000", "Drive Disc slot/stat audit sampleEntity drifted")
   assert(audit.runtimeCutoverReady === false, "Drive Disc slot/stat audit must not imply runtime cutover")
   assert(audit.summary?.foundSlotMainSubstatTable === false, "Drive Disc slot/stat audit must not claim slot/stat table found")
-  assert(audit.summary?.ownerResearchRequired === true, "Drive Disc slot/stat audit must require owner research")
+  assert(audit.summary?.ownerResearchRequired === false, "Drive Disc slot/stat audit owner research should be resolved by the V0.1.0 scope decision")
 
   const endpoints = audit.checkedEndpoints ?? []
   assert(endpoints.some(endpoint => endpoint.url === "https://static.nanoka.cc/zzz/2.8/equipment.json" && endpoint.status === 200), "Drive Disc slot/stat audit must record live equipment index check")
@@ -383,8 +387,10 @@ function validateDriveDiscSlotStatAudit(registry) {
   }
   assert(endpoints.some(endpoint => endpoint.status === 404 && endpoint.url.endsWith("/equipment_main_property.json")), "Drive Disc slot/stat audit must record missing main-property candidate endpoint")
   assert(endpoints.some(endpoint => endpoint.status === 404 && endpoint.url.endsWith("/equipment_rand_property.json")), "Drive Disc slot/stat audit must record missing substat candidate endpoint")
-  assert(audit.decision?.matrixStatus === "needs-owner-research", "Drive Disc slot/stat audit decision must match owner-research matrix status")
-  assert(audit.decision?.blockedBy?.includes("owner:drive-disc-slot-stat-source-required"), "Drive Disc slot/stat audit decision must carry owner blocker")
+  assert(audit.decision?.matrixStatus === "deferred", "Drive Disc slot/stat audit decision must match deferred matrix status")
+  assert(audit.decision?.sourcePolicy === "out-of-scope", "Drive Disc slot/stat audit decision must mark the row out-of-scope")
+  assert(audit.decision?.blockedBy?.includes("scope:user-provided-snapshot-boundary"), "Drive Disc slot/stat audit decision must carry user-provided snapshot boundary")
+  assert(audit.decision?.ownerDecision?.includes("remove Drive Disc slot/main/substat tables from V0.1.0 formal-data scope"), "Drive Disc slot/stat audit must record the owner scope decision")
 }
 
 function validateDisorderFormulaAudit(registry) {

--- a/packages/data/src/missing-fields-failloud.test.ts
+++ b/packages/data/src/missing-fields-failloud.test.ts
@@ -50,14 +50,16 @@ describe("missing-fields fail-loud gate", () => {
     expect(unresolved).toEqual([])
   })
 
-  it("keeps owner-escalated rows machine-readable and non-promotable", () => {
+  it("has resolved owner-escalated rows into scoped decisions", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const ownerRows = matrix.rows.filter(row => row.status === "needs-owner-research")
-    const driveDiscRow = ownerRows.find(row => row.fieldId === "driveDiscs.slotAndSubstatTables")
+    const driveDiscRow = matrix.rows.find(row => row.fieldId === "driveDiscs.slotAndSubstatTables")
 
+    expect(ownerRows).toEqual([])
     expect(driveDiscRow).toBeDefined()
+    expect(driveDiscRow?.status).toBe("deferred")
     expect(driveDiscRow?.promotable).toBe(false)
-    expect(driveDiscRow?.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(driveDiscRow?.blockedBy).toContain("scope:user-provided-snapshot-boundary")
     expect(driveDiscRow?.auditArtifact).toBe("data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json")
   })
 

--- a/packages/data/src/nanoka-drive-disc-slot-audit.test.ts
+++ b/packages/data/src/nanoka-drive-disc-slot-audit.test.ts
@@ -26,7 +26,9 @@ type DriveDiscSlotStatAudit = {
   }>
   decision: {
     matrixStatus: string
+    sourcePolicy: string
     blockedBy: string[]
+    ownerDecision: string
   }
 }
 
@@ -54,13 +56,15 @@ describe("nanoka Drive Disc slot/stat failed-evidence audit", () => {
       runtimeCutoverReady: false,
       summary: {
         foundSlotMainSubstatTable: false,
-        ownerResearchRequired: true,
+        ownerResearchRequired: false,
       },
       decision: {
-        matrixStatus: "needs-owner-research",
+        matrixStatus: "deferred",
+        sourcePolicy: "out-of-scope",
       },
     })
-    expect(audit.decision.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(audit.decision.blockedBy).toContain("scope:user-provided-snapshot-boundary")
+    expect(audit.decision.ownerDecision).toContain("remove Drive Disc slot/main/substat tables from V0.1.0 formal-data scope")
     expect(audit.checkedEndpoints).toHaveLength(audit.summary.checkedEndpointCount)
     expect(audit.checkedEndpoints).toEqual(expect.arrayContaining([
       expect.objectContaining({

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -112,7 +112,7 @@ describe("nanoka source gate", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
 
-    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
+    expect(matrix.status).toBe("phase-3-drift-foundation-gate")
     expect(rows.get("metadata.sources")).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -145,7 +145,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("agents.promotionExtraStats")
 
-    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
+    expect(matrix.status).toBe("phase-3-drift-foundation-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -172,7 +172,7 @@ describe("nanoka source gate", () => {
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("bangboos.element")
 
-    expect(matrix.status).toBe("phase-2-disorder-daze-level-audit-gate")
+    expect(matrix.status).toBe("phase-3-drift-foundation-gate")
     expect(row).toMatchObject({
       status: "verified-from-nanoka",
       promotable: true,
@@ -211,18 +211,20 @@ describe("nanoka source gate", () => {
       expect(row.blockedBy ?? []).not.toContain("field:variant-mapping-required")
   })
 
-  it("escalates Drive Disc slot/stat tables with failed nanoka evidence", () => {
+  it("excludes Drive Disc slot/stat tables from V0.1.0 formal data after owner decision", () => {
     const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
     const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
     const row = rows.get("driveDiscs.slotAndSubstatTables")
 
     expect(row).toMatchObject({
-      status: "needs-owner-research",
+      fieldClass: "removed-out-of-product-scope",
+      sourcePolicy: "out-of-scope",
+      status: "deferred",
       promotable: false,
       sampleEntity: "nanoka-equipment-woodpecker-live-31000",
       auditArtifact: "data/cleaned/audit/nanoka-drive-disc-slot-stat-audit.json",
     })
-    expect(row?.blockedBy).toContain("owner:drive-disc-slot-stat-source-required")
+    expect(row?.blockedBy).toContain("scope:user-provided-snapshot-boundary")
     expect(row?.rawFieldPaths).toEqual(expect.arrayContaining([
       "/id",
       "/name",
@@ -230,6 +232,8 @@ describe("nanoka source gate", () => {
       "/desc4",
     ]))
     expect(row?.transformRule).toContain("do not synthesize")
+    expect(row?.transformRule).toContain("user snapshot input supplies the final Agent panel")
+    expect(row?.transformRule).toContain("do not reverse-engineer user panel values")
   })
 
   it("classifies the Disorder formula as implementation-owned after failed nanoka evidence", () => {

--- a/packages/data/src/source-migration-drift.test.ts
+++ b/packages/data/src/source-migration-drift.test.ts
@@ -1,0 +1,179 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+const dataPackageRoot = join(repoRoot, "packages/data")
+const syncId = "phase3-sync-000-foundation"
+
+type DriftReport = {
+  schemaVersion: string
+  syncId: string
+  candidate: {
+    sourceId: string
+    sourceVersion: string
+    contentHash: string
+  }
+  baselines: Array<{
+    sourceId: string
+    sourceVersion: string
+    archived: boolean
+  }>
+  matrixStatus: string
+  runtimeCutoverReady: boolean
+  counts: Record<"same" | "changed" | "missing" | "new" | "semantic-mismatch", number>
+  rows: unknown[]
+  unresolvedCount: number
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8")) as T
+}
+
+function npmPackFiles(): string[] {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: dataPackageRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  const result = JSON.parse(output) as Array<{ files: Array<{ path: string }> }>
+  return result[0]?.files.map(file => file.path) ?? []
+}
+
+describe("Phase 3 source migration drift report foundation", () => {
+  it("passes the executable source-migration verifier", () => {
+    const output = execFileSync("node", ["scripts/source-migration-drift.mjs", "verify", "--sync-id", syncId], {
+      cwd: dataPackageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    expect(output).toContain(`source migration drift verification passed for ${syncId}`)
+  })
+
+  it("keeps the package drift report mirror byte-identical", () => {
+    expect(readFileSync(join(repoRoot, `packages/data/cleaned/audit/nanoka-drift-report/${syncId}.json`), "utf8")).toBe(
+      readFileSync(join(repoRoot, `data/cleaned/audit/nanoka-drift-report/${syncId}.json`), "utf8"),
+    )
+  })
+
+  it("locks the minimal report contract without runtime cutover", () => {
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${syncId}.json`)
+
+    expect(report).toMatchObject({
+      schemaVersion: "nanoka-drift-report/v0.1",
+      syncId,
+      candidate: {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+        contentHash: "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d",
+      },
+      matrixStatus: "phase-3-drift-foundation-gate",
+      runtimeCutoverReady: false,
+      counts: {
+        same: 0,
+        changed: 0,
+        missing: 0,
+        new: 0,
+        "semantic-mismatch": 0,
+      },
+      unresolvedCount: 0,
+    })
+    expect(report.rows).toEqual([])
+    expect(report.baselines).toEqual(expect.arrayContaining([
+      {
+        sourceId: "lo-user-excel",
+        sourceVersion: "2.6.0_R14028417",
+        archived: true,
+      },
+      {
+        sourceId: "mihoyo-zzz-critical-assault",
+        sourceVersion: "2026-05-05T0850Z",
+        archived: true,
+      },
+      {
+        sourceId: "buhflipexplode-zzz-da",
+        sourceVersion: "2026-05-05T0445Z",
+        archived: true,
+      },
+    ]))
+  })
+
+  it("rejects non-same drift rows that try to bypass the ruling queue", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const fixturePath = join(tempDir, "bypassing-report.json")
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${syncId}.json`)
+    const bypassingReport = {
+      ...report,
+      counts: {
+        same: 0,
+        changed: 1,
+        missing: 0,
+        new: 0,
+        "semantic-mismatch": 0,
+      },
+      rows: [
+        {
+          entityType: "agent",
+          entityId: "1021",
+          fieldId: "agents.baseStats",
+          canonicalPath: "GameData.agents[1021].baseStats",
+          fieldPath: "/stats",
+          baselineSourceRef: {
+            sourceId: "lo-user-excel",
+            sourceVersion: "2.6.0_R14028417",
+            sourceAnchor: "data/source/excel/data.xlsx",
+            dataPath: "/agents/1021/baseStats",
+          },
+          candidateSourceRef: {
+            sourceId: "nanoka-zzz",
+            sourceVersion: "2.8",
+            sourceAnchor: "https://static.nanoka.cc/zzz/2.8/zh/character/1021.json",
+            dataPath: "/stats",
+          },
+          status: "changed",
+          severity: "blocking",
+          rulingStatus: "not-required",
+          rulingId: "D-TEST-BYPASS",
+          blockedBy: [],
+          notes: "Regression fixture for Gate 8 ruling queue bypass.",
+        },
+      ],
+      unresolvedCount: 0,
+    }
+
+    try {
+      writeFileSync(fixturePath, `${JSON.stringify(bypassingReport, null, 2)}\n`)
+
+      expect(() =>
+        execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", syncId, "--report", fixturePath], {
+          cwd: dataPackageRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).toThrow("non-same rows require explicit ruling queue status")
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("documents the no-runtime-fallback boundary in the human report", () => {
+    const report = readFileSync(join(repoRoot, `docs/data-source/drift-reports/${syncId}.md`), "utf8")
+
+    expect(report).toContain(`# Nanoka Drift Report: ${syncId}`)
+    expect(report).toContain("full G01-G26 comparison begins in the next Phase 3 slice")
+    expect(report).toContain("Archived Excel / D-17 / D-12 sources remain audit baselines")
+    expect(report).toContain("Runtime cutover ready: **false**")
+  })
+
+  it("packs the drift report artifact without raw source archives", () => {
+    const files = npmPackFiles()
+
+    expect(files).toContain(`cleaned/audit/nanoka-drift-report/${syncId}.json`)
+    expect(files.some(file => file.startsWith("source/raw/"))).toBe(false)
+    expect(files.some(file => file.endsWith(".xlsx"))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- add Phase 3 source-migration drift report schema, verifier, and minimal `phase3-sync-000-foundation` fixture
- add `audit:source-migration` / `verify:source-migration`, wire the release workflow gate, and pack the mirrored drift artifact without raw source archives
- fold in the Drive Disc owner decision: `driveDiscs.slotAndSubstatTables` is now V0.1.0 out-of-scope / user-provided final-panel boundary, with no remaining owner-research rows

## Scope boundaries

- no runtime cleaned-data cutover
- archived Excel / D-17 Mihoyo / D-12 buhflipexplode remain audit baselines only, not runtime fallback inputs
- full G01-G26 compare and G27/G28 anchors stay in later Phase 3 slices

## Verification

- `pnpm --filter @randomplay/data audit:source-migration --sync-id phase3-sync-000-foundation --generated-at 2026-05-15T16:20:00+08:00`
- `pnpm --filter @randomplay/data verify:source-migration --sync-id phase3-sync-000-foundation`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:source-migration`
- `pnpm --filter @randomplay/data test -- source-migration-drift.test.ts nanoka-source-gate.test.ts missing-fields-failloud.test.ts nanoka-drive-disc-slot-audit.test.ts`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data test`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data pack --dry-run --json`
- custom matrix/audit/drift mirror + pack inclusion/exclusion checks
- `git diff --check`
- workflow YAML parse smoke
