### PR TITLE
feat(data): add first Phase 3 drift sync

### DIFF
--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,0 +1,2654 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-001-g01-g26",
+  "generatedAt": "2026-05-15T16:45:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 4,
+    "new": 0,
+    "semantic-mismatch": 22
+  },
+  "rows": [
+    {
+      "entityType": "enemy",
+      "entityId": "G01",
+      "fieldId": "goldenAnchors.G01.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G01.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G01/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G01/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G01/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G01/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Default boss defense multiplier replays against sourced DA slot 0 boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus enemy defense defaults for the sourced boss replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G02",
+      "fieldId": "goldenAnchors.G02.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G02.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G02/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G02/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G02/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G02/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted-shield state uses the core 1.8x defense multiplier with sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus corrupted-shield defense-state coverage.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G03",
+      "fieldId": "goldenAnchors.G03.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G03.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G03/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G03/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G03/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Crit expected value uses 1 + critRate * critDamage."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent panel fields needed by crit expected-value replay.",
+        "fieldIds": [
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G04",
+      "fieldId": "goldenAnchors.G04.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G04.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G04/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+        "dataPath": "/anchors/G04/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/38"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+            "dataPath": "/anchors/G04/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned penetration and damage formula constants.",
+        "fieldIds": [
+          "rules.baseDamageFormula",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G05",
+      "fieldId": "goldenAnchors.G05.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G05.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G05/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G05/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G05/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G05/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer damage skips defense while regular damage sees corrupted-shield defense."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for defense-skip replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required",
+        "implementation-owned-runtime-formula",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G06",
+      "fieldId": "goldenAnchors.G06.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G06.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G06/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G06/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G06/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G06/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer vs default boss ratio replays with the same sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for sheer-vs-default ratio replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required",
+        "implementation-owned-runtime-formula",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G07",
+      "fieldId": "goldenAnchors.G07.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G07.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G07/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G07/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/39"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G07/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Two fractional segments ceil before summing."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned rounding contract for per-segment ceil behavior.",
+        "fieldIds": [
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G08",
+      "fieldId": "goldenAnchors.G08.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G08.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G08/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G08/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G08/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Anomaly Mastery floors before buildup."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent anomaly panel fields plus rounding behavior for buildup replay.",
+        "fieldIds": [
+          "agents.basePanel",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G09",
+      "fieldId": "goldenAnchors.G09.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G09.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G09/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G09/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G09/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G09/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max-daze and enemy-level context for daze-cap replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G10",
+      "fieldId": "goldenAnchors.G10.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G10.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G10/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G10/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G10/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and enemy resistance source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "enemies.resistance"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.resistance",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:resistance-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:attribute-mapping-source-required",
+        "field:resistance-unit-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G11",
+      "fieldId": "goldenAnchors.G11.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G11.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G11/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G11/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G11/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost/Auric use Ice/Ether damage-bonus panel fields."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and combat-panel damage-bonus source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "agents.combatPanelStats"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "agents.combatPanelStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:stat-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:attribute-mapping-source-required",
+        "field:stat-unit-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G12",
+      "fieldId": "goldenAnchors.G12.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G12.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G12/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G12/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G12/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G12/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Boss trigger-count threshold and physical 1.2x multiplier replay from core constants."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold source coverage and trigger-rank rule mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:anomaly-threshold-rule-source-required",
+        "field:anomaly-threshold-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G13",
+      "fieldId": "goldenAnchors.G13.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G13.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G13/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+        "dataPath": "/anchors/G13/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+            "dataPath": "/anchors/G13/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+          "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold modifiers plus monster_info variant mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:anomaly-threshold-rule-source-required",
+        "field:anomaly-threshold-mapping-required",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G14",
+      "fieldId": "goldenAnchors.G14.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G14.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G14/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G14/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G14/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A4:AF4",
+            "dataPath": "/anchors/G14/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Virtual contribution rows include Bangboo exclusion and overflow handling."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "SourceRef emission plus implementation-owned virtual-contribution behavior.",
+        "fieldIds": [
+          "metadata.sourceRefs",
+          "rules.baseDamageFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "metadata.sourceRefs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "derived-from-source-registry",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G15",
+      "fieldId": "goldenAnchors.G15.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G15.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G15/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G15/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G15/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "All seven disorder formula paths replay, including polarity disorder."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder formula boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G16",
+      "fieldId": "goldenAnchors.G16.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G16.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G16/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G16/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G16/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Disorder daze-level zone uses formula actor level 60."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder daze-level zone boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderDazeLevelZone"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderDazeLevelZone",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G17",
+      "fieldId": "goldenAnchors.G17.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G17.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G17/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G17/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G17/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G17/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted shield cleanse uses sourced DA boss maxHp as event base."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max HP and enemy context for corrupted-shield cleanse replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G18",
+      "fieldId": "goldenAnchors.G18.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G18.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G18/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A139:AU139",
+        "dataPath": "/anchors/G18/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30004.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A139:AU139",
+            "dataPath": "/anchors/G18/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71",
+            "dataPath": "/anchors/G18/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Greta monster_info variant, level defaults, and part-break special-rule coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.levelDefaults",
+          "enemies.specialRules"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.specialRules",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-greta-live-30004"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required",
+        "typed-modifier-template-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G19",
+      "fieldId": "goldenAnchors.G19.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G19.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G19/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A216:AU216",
+        "dataPath": "/anchors/G19/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200141.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A216:AU216",
+            "dataPath": "/anchors/G19/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G19/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Ruthless Fiend variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-ruthless-fiend-live-200141"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:daze-recovery-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G20",
+      "fieldId": "goldenAnchors.G20.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G20.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G20/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A89:AU89",
+        "dataPath": "/anchors/G20/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200014.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A89:AU89",
+            "dataPath": "/anchors/G20/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G20/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Armored Hati daze recovery uses Excel base 8.33%/s and guide §2.3.2 modifier composition (+100% -13%) to replay 15.58%/s and 6.42s.",
+          "The guide sentence has a denominator typo (`1/11.58%`) but its formula and final 6.42s result match 15.58%/s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Hati/Armored Hati variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:daze-recovery-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G21",
+      "fieldId": "goldenAnchors.G21.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G21.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G21/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G21/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G21/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "One-agent Yixuan path has no teammate modifiers and keeps sheer defense skip."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yixuan panel and rupture/sheer source coverage.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G22",
+      "fieldId": "goldenAnchors.G22.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G22.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G22/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G22/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/13"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G22/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Nicole passive modifier source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing",
+        "typed-modifier-template-required"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G23",
+      "fieldId": "goldenAnchors.G23.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G23.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G23/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G23/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/13"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G23/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D23:J23",
+            "dataPath": "/anchors/G23/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人技能描述!C298",
+            "dataPath": "/anchors/G23/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+          "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Yanagi passive/disorder source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers",
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          },
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing",
+        "typed-modifier-template-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G24",
+      "fieldId": "goldenAnchors.G24.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G24.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G24/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A42:T42",
+        "dataPath": "/anchors/G24/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/19"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A42:T42",
+            "dataPath": "/anchors/G24/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A2:H2",
+            "dataPath": "/anchors/G24/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A3:H3",
+            "dataPath": "/anchors/G24/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Penguinboo active skill replays Excel-only numeric contribution: level-60 attack 6198.0006 × 4.62 = 28634.762772 base damage.",
+          "Daze uses impact 90 × 2.7 = 243, and anomaly buildup uses 346 × floor(120)/100 = 415.2 before enemy resistance.",
+          "Excel Path X has no element field; the fixture supplies an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G25",
+      "fieldId": "goldenAnchors.G25.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G25.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G25/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A24:T24",
+        "dataPath": "/anchors/G25/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/19"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A24:T24",
+            "dataPath": "/anchors/G25/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A17:H17",
+            "dataPath": "/anchors/G25/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A18:H18",
+            "dataPath": "/anchors/G25/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Sharkboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 3.84 = 30939.262464 base damage.",
+          "Daze uses impact 99 × 1.4 = 138.6, and anomaly buildup uses 180 × floor(132)/100 = 237.6 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G26",
+      "fieldId": "goldenAnchors.G26.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G26.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G26/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A18:T18",
+        "dataPath": "/anchors/G26/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A18:T18",
+            "dataPath": "/anchors/G26/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A29:H29",
+            "dataPath": "/anchors/G26/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A30:H30",
+            "dataPath": "/anchors/G26/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Plugboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 5.12 = 41252.349952 base damage.",
+          "Daze uses impact 99 × 1.87 = 185.13, and anomaly buildup uses 240 × floor(132)/100 = 316.8 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Plugboo panel, skill numeric, and element source coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.element",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    }
+  ],
+  "unresolvedCount": 26,
+  "notes": [
+    "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
+    "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
+++ b/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
@@ -1,0 +1,74 @@
+# Nanoka Drift Report: phase3-sync-001-g01-g26
+
+Status: Phase 3 drift audit first G01-G26 sync
+Generated: 2026-05-15T16:45:00+08:00
+
+This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths. Full runtime cutover remains disabled.
+
+## Candidate
+
+| Source | Version | Content Hash |
+|---|---|---|
+| `nanoka-zzz` | `2.8` | `sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d` |
+
+## Baselines
+
+| Source | Version | Archived |
+|---|---|---|
+| `lo-user-excel` | `2.6.0_R14028417` | yes |
+| `mihoyo-zzz-critical-assault` | `2026-05-05T0850Z` | yes |
+| `buhflipexplode-zzz-da` | `2026-05-05T0445Z` | yes |
+
+## Counts
+
+| Status | Count |
+|---|---:|
+| `same` | 0 |
+| `changed` | 0 |
+| `missing` | 4 |
+| `new` | 0 |
+| `semantic-mismatch` | 22 |
+
+Unresolved blocking drift rows: **26**
+
+Runtime cutover ready: **false**
+
+## Drift Rows
+
+| Entity | Field | Status | Ruling | Notes |
+|---|---|---|---|---|
+| `G01` | `goldenAnchors.G01.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G02` | `goldenAnchors.G02.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G03` | `goldenAnchors.G03.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G04` | `goldenAnchors.G04.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G05` | `goldenAnchors.G05.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G06` | `goldenAnchors.G06.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G07` | `goldenAnchors.G07.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G08` | `goldenAnchors.G08.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G09` | `goldenAnchors.G09.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G10` | `goldenAnchors.G10.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G11` | `goldenAnchors.G11.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G12` | `goldenAnchors.G12.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G13` | `goldenAnchors.G13.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G14` | `goldenAnchors.G14.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G15` | `goldenAnchors.G15.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G16` | `goldenAnchors.G16.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G17` | `goldenAnchors.G17.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G18` | `goldenAnchors.G18.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G19` | `goldenAnchors.G19.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G20` | `goldenAnchors.G20.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G21` | `goldenAnchors.G21.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031. |
+| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221. |
+| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001. |
+| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001. |
+| `G26` | `goldenAnchors.G26.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+
+
+## Boundary
+
+- This sync does not promote nanoka to runtime cleaned data.
+- Archived Excel / D-17 / D-12 sources remain audit baselines, not runtime
+  fallback.
+- Any future `changed`, `missing`, `new`, or `semantic-mismatch` row must
+  carry source refs and a ruling before Phase 3 exit.

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,0 +1,2654 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-001-g01-g26",
+  "generatedAt": "2026-05-15T16:45:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 4,
+    "new": 0,
+    "semantic-mismatch": 22
+  },
+  "rows": [
+    {
+      "entityType": "enemy",
+      "entityId": "G01",
+      "fieldId": "goldenAnchors.G01.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G01.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G01/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G01/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G01/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G01/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Default boss defense multiplier replays against sourced DA slot 0 boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus enemy defense defaults for the sourced boss replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G02",
+      "fieldId": "goldenAnchors.G02.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G02.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G02/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G02/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G02/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G02/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted-shield state uses the core 1.8x defense multiplier with sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus corrupted-shield defense-state coverage.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G03",
+      "fieldId": "goldenAnchors.G03.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G03.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G03/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G03/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G03/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Crit expected value uses 1 + critRate * critDamage."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent panel fields needed by crit expected-value replay.",
+        "fieldIds": [
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G04",
+      "fieldId": "goldenAnchors.G04.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G04.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G04/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+        "dataPath": "/anchors/G04/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/38"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+            "dataPath": "/anchors/G04/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned penetration and damage formula constants.",
+        "fieldIds": [
+          "rules.baseDamageFormula",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G05",
+      "fieldId": "goldenAnchors.G05.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G05.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G05/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G05/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G05/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G05/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer damage skips defense while regular damage sees corrupted-shield defense."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for defense-skip replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required",
+        "implementation-owned-runtime-formula",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G06",
+      "fieldId": "goldenAnchors.G06.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G06.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G06/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G06/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G06/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G06/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer vs default boss ratio replays with the same sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for sheer-vs-default ratio replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required",
+        "implementation-owned-runtime-formula",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G07",
+      "fieldId": "goldenAnchors.G07.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G07.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G07/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G07/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/39"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G07/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Two fractional segments ceil before summing."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned rounding contract for per-segment ceil behavior.",
+        "fieldIds": [
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G08",
+      "fieldId": "goldenAnchors.G08.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G08.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G08/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G08/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G08/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Anomaly Mastery floors before buildup."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent anomaly panel fields plus rounding behavior for buildup replay.",
+        "fieldIds": [
+          "agents.basePanel",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G09",
+      "fieldId": "goldenAnchors.G09.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G09.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G09/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G09/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G09/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G09/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max-daze and enemy-level context for daze-cap replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G10",
+      "fieldId": "goldenAnchors.G10.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G10.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G10/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G10/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G10/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and enemy resistance source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "enemies.resistance"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.resistance",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:resistance-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:attribute-mapping-source-required",
+        "field:resistance-unit-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G11",
+      "fieldId": "goldenAnchors.G11.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G11.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G11/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G11/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G11/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost/Auric use Ice/Ether damage-bonus panel fields."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and combat-panel damage-bonus source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "agents.combatPanelStats"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "agents.combatPanelStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:stat-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:attribute-mapping-source-required",
+        "field:stat-unit-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G12",
+      "fieldId": "goldenAnchors.G12.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G12.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G12/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G12/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G12/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G12/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Boss trigger-count threshold and physical 1.2x multiplier replay from core constants."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold source coverage and trigger-rank rule mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:anomaly-threshold-rule-source-required",
+        "field:anomaly-threshold-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G13",
+      "fieldId": "goldenAnchors.G13.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G13.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G13/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+        "dataPath": "/anchors/G13/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+            "dataPath": "/anchors/G13/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+          "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold modifiers plus monster_info variant mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:anomaly-threshold-rule-source-required",
+        "field:anomaly-threshold-mapping-required",
+        "field:runtime-cutover-drift-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G14",
+      "fieldId": "goldenAnchors.G14.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G14.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G14/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G14/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G14/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A4:AF4",
+            "dataPath": "/anchors/G14/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Virtual contribution rows include Bangboo exclusion and overflow handling."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "SourceRef emission plus implementation-owned virtual-contribution behavior.",
+        "fieldIds": [
+          "metadata.sourceRefs",
+          "rules.baseDamageFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "metadata.sourceRefs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "derived-from-source-registry",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G15",
+      "fieldId": "goldenAnchors.G15.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G15.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G15/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G15/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G15/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "All seven disorder formula paths replay, including polarity disorder."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder formula boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G16",
+      "fieldId": "goldenAnchors.G16.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G16.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G16/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G16/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G16/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Disorder daze-level zone uses formula actor level 60."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder daze-level zone boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderDazeLevelZone"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderDazeLevelZone",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G17",
+      "fieldId": "goldenAnchors.G17.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G17.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G17/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G17/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G17/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G17/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted shield cleanse uses sourced DA boss maxHp as event base."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max HP and enemy context for corrupted-shield cleanse replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G18",
+      "fieldId": "goldenAnchors.G18.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G18.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G18/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A139:AU139",
+        "dataPath": "/anchors/G18/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30004.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A139:AU139",
+            "dataPath": "/anchors/G18/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71",
+            "dataPath": "/anchors/G18/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Greta monster_info variant, level defaults, and part-break special-rule coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.levelDefaults",
+          "enemies.specialRules"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.specialRules",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-greta-live-30004"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:enemy-level-formula-required",
+        "typed-modifier-template-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G19",
+      "fieldId": "goldenAnchors.G19.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G19.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G19/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A216:AU216",
+        "dataPath": "/anchors/G19/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200141.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A216:AU216",
+            "dataPath": "/anchors/G19/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G19/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Ruthless Fiend variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-ruthless-fiend-live-200141"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:daze-recovery-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G20",
+      "fieldId": "goldenAnchors.G20.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G20.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G20/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A89:AU89",
+        "dataPath": "/anchors/G20/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200014.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A89:AU89",
+            "dataPath": "/anchors/G20/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G20/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Armored Hati daze recovery uses Excel base 8.33%/s and guide §2.3.2 modifier composition (+100% -13%) to replay 15.58%/s and 6.42s.",
+          "The guide sentence has a denominator typo (`1/11.58%`) but its formula and final 6.42s result match 15.58%/s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Hati/Armored Hati variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:runtime-cutover-drift-required",
+        "field:daze-recovery-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G21",
+      "fieldId": "goldenAnchors.G21.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G21.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G21/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G21/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G21/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "One-agent Yixuan path has no teammate modifiers and keeps sheer defense skip."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yixuan panel and rupture/sheer source coverage.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required",
+        "field:rupture-semantic-mapping-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G22",
+      "fieldId": "goldenAnchors.G22.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G22.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G22/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G22/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/13"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G22/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Nicole passive modifier source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing",
+        "typed-modifier-template-required"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G23",
+      "fieldId": "goldenAnchors.G23.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G23.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G23/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G23/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/13"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G23/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D23:J23",
+            "dataPath": "/anchors/G23/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人技能描述!C298",
+            "dataPath": "/anchors/G23/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+          "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Yanagi passive/disorder source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers",
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          },
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing",
+        "typed-modifier-template-required",
+        "implementation-owned-runtime-formula"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G24",
+      "fieldId": "goldenAnchors.G24.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G24.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G24/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A42:T42",
+        "dataPath": "/anchors/G24/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/19"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A42:T42",
+            "dataPath": "/anchors/G24/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A2:H2",
+            "dataPath": "/anchors/G24/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A3:H3",
+            "dataPath": "/anchors/G24/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Penguinboo active skill replays Excel-only numeric contribution: level-60 attack 6198.0006 × 4.62 = 28634.762772 base damage.",
+          "Daze uses impact 90 × 2.7 = 243, and anomaly buildup uses 346 × floor(120)/100 = 415.2 before enemy resistance.",
+          "Excel Path X has no element field; the fixture supplies an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G25",
+      "fieldId": "goldenAnchors.G25.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G25.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G25/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A24:T24",
+        "dataPath": "/anchors/G25/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/19"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A24:T24",
+            "dataPath": "/anchors/G25/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A17:H17",
+            "dataPath": "/anchors/G25/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A18:H18",
+            "dataPath": "/anchors/G25/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Sharkboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 3.84 = 30939.262464 base damage.",
+          "Daze uses impact 99 × 1.4 = 138.6, and anomaly buildup uses 180 × floor(132)/100 = 237.6 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "missing-required-sample",
+        "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ]
+      },
+      "status": "missing",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:candidate-source-missing"
+      ],
+      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G26",
+      "fieldId": "goldenAnchors.G26.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G26.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G26/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A18:T18",
+        "dataPath": "/anchors/G26/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A18:T18",
+            "dataPath": "/anchors/G26/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A29:H29",
+            "dataPath": "/anchors/G26/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A30:H30",
+            "dataPath": "/anchors/G26/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Plugboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 5.12 = 41252.349952 base damage.",
+          "Daze uses impact 99 × 1.87 = 185.13, and anomaly buildup uses 240 × floor(132)/100 = 316.8 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Plugboo panel, skill numeric, and element source coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.element",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": []
+      },
+      "status": "semantic-mismatch",
+      "severity": "blocking",
+      "rulingStatus": "pending",
+      "blockedBy": [
+        "phase3:ruling-required",
+        "phase3:semantic-equivalence-ruling-required"
+      ],
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+    }
+  ],
+  "unresolvedCount": 26,
+  "notes": [
+    "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
+    "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/packages/data/scripts/source-migration-drift.mjs
+++ b/packages/data/scripts/source-migration-drift.mjs
@@ -11,9 +11,11 @@ const matrixPath = join(repoRoot, "data/cleaned/audit/nanoka-coverage-matrix.jso
 const rootReportDir = join(repoRoot, "data/cleaned/audit/nanoka-drift-report")
 const packageReportDir = join(packageDir, "cleaned/audit/nanoka-drift-report")
 const docsReportDir = join(repoRoot, "docs/data-source/drift-reports")
+const goldenReplayReportPath = join(repoRoot, "data/cleaned/golden/v1-replay-report.json")
 
 const schemaVersion = "nanoka-drift-report/v0.1"
 const defaultSyncId = "phase3-sync-000-foundation"
+const firstSyncId = "phase3-sync-001-g01-g26"
 const defaultGeneratedAt = "2026-05-15T16:20:00+08:00"
 const driftStatuses = ["same", "changed", "missing", "new", "semantic-mismatch"]
 const entityTypes = ["agent", "bangboo", "enemy", "wEngine", "driveDisc", "deadlyAssault", "metadata", "rules"]
@@ -90,6 +92,13 @@ function zeroCounts() {
   }
 }
 
+function countsForRows(rows) {
+  const counts = zeroCounts()
+  for (const row of rows)
+    counts[row.status] += 1
+  return counts
+}
+
 function reportPaths(syncId) {
   return {
     rootJson: join(rootReportDir, `${syncId}.json`),
@@ -98,7 +107,7 @@ function reportPaths(syncId) {
   }
 }
 
-function buildFoundationReport({ syncId, generatedAt }) {
+function reportHeader({ syncId, generatedAt }) {
   const registry = readJson(rootRegistryPath)
   const matrix = readJson(matrixPath)
   const nanoka = sourceById(registry, "nanoka-zzz")
@@ -115,6 +124,12 @@ function buildFoundationReport({ syncId, generatedAt }) {
     baselines: requiredBaselineIds.map(sourceId => baselineFromRegistry(registry, sourceId)),
     matrixStatus: matrix.status,
     runtimeCutoverReady: false,
+  }
+}
+
+function buildFoundationReport({ syncId, generatedAt }) {
+  return {
+    ...reportHeader({ syncId, generatedAt }),
     counts: zeroCounts(),
     rows: [],
     unresolvedCount: 0,
@@ -125,6 +140,407 @@ function buildFoundationReport({ syncId, generatedAt }) {
   }
 }
 
+const anchorCandidateSpecs = {
+  G01: {
+    entityType: "enemy",
+    fieldIds: ["deadlyAssault.periodsBossesBuffs", "enemies.levelDefaults", "enemies.variantMapping"],
+    requiredSampleEntities: ["nanoka-boss-live-69036"],
+    expectedCandidate: "DA boss context plus enemy defense defaults for the sourced boss replay.",
+  },
+  G02: {
+    entityType: "enemy",
+    fieldIds: ["deadlyAssault.periodsBossesBuffs", "enemies.levelDefaults", "enemies.variantMapping"],
+    requiredSampleEntities: ["nanoka-boss-live-69036"],
+    expectedCandidate: "DA boss context plus corrupted-shield defense-state coverage.",
+  },
+  G03: {
+    entityType: "agent",
+    fieldIds: ["agents.basePanel"],
+    requiredSampleEntities: ["nanoka-character-nekomata-live-1021"],
+    expectedCandidate: "Agent panel fields needed by crit expected-value replay.",
+  },
+  G04: {
+    entityType: "rules",
+    fieldIds: ["rules.baseDamageFormula", "rules.rounding"],
+    expectedCandidate: "Implementation-owned penetration and damage formula constants.",
+  },
+  G05: {
+    entityType: "agent",
+    fieldIds: ["agents.ruptureStats", "rules.baseDamageFormula", "deadlyAssault.periodsBossesBuffs"],
+    requiredSampleEntities: ["nanoka-character-yixuan-1371", "nanoka-boss-live-69036"],
+    expectedCandidate: "Rupture/sheer semantics and DA boss context for defense-skip replay.",
+  },
+  G06: {
+    entityType: "agent",
+    fieldIds: ["agents.ruptureStats", "rules.baseDamageFormula", "deadlyAssault.periodsBossesBuffs"],
+    requiredSampleEntities: ["nanoka-character-yixuan-1371", "nanoka-boss-live-69036"],
+    expectedCandidate: "Rupture/sheer semantics and DA boss context for sheer-vs-default ratio replay.",
+  },
+  G07: {
+    entityType: "rules",
+    fieldIds: ["rules.rounding"],
+    expectedCandidate: "Implementation-owned rounding contract for per-segment ceil behavior.",
+  },
+  G08: {
+    entityType: "agent",
+    fieldIds: ["agents.basePanel", "rules.rounding"],
+    requiredSampleEntities: ["nanoka-character-nekomata-live-1021"],
+    expectedCandidate: "Agent anomaly panel fields plus rounding behavior for buildup replay.",
+  },
+  G09: {
+    entityType: "deadlyAssault",
+    fieldIds: ["deadlyAssault.periodsBossesBuffs", "enemies.levelDefaults"],
+    requiredSampleEntities: ["nanoka-boss-live-69036"],
+    expectedCandidate: "DA boss max-daze and enemy-level context for daze-cap replay.",
+  },
+  G10: {
+    entityType: "agent",
+    fieldIds: ["rules.attributeMapping", "enemies.resistance"],
+    requiredSampleEntities: ["nanoka-character-yixuan-1371", "nanoka-monster-dullahan-live-30000"],
+    expectedCandidate: "Attribute alias mapping and enemy resistance source coverage.",
+  },
+  G11: {
+    entityType: "agent",
+    fieldIds: ["rules.attributeMapping", "agents.combatPanelStats"],
+    requiredSampleEntities: ["nanoka-character-yixuan-1371"],
+    expectedCandidate: "Attribute alias mapping and combat-panel damage-bonus source coverage.",
+  },
+  G12: {
+    entityType: "enemy",
+    fieldIds: ["rules.anomalyThresholdRankTriggerTable", "enemies.anomalyThresholds"],
+    requiredSampleEntities: ["nanoka-monster-dullahan-live-30000"],
+    expectedCandidate: "Enemy anomaly threshold source coverage and trigger-rank rule mapping.",
+  },
+  G13: {
+    entityType: "enemy",
+    fieldIds: ["rules.anomalyThresholdRankTriggerTable", "enemies.anomalyThresholds", "enemies.variantMapping"],
+    requiredSampleEntities: ["nanoka-monster-dullahan-live-30000", "nanoka-monster-notorious-pompey-live-300211"],
+    expectedCandidate: "Enemy anomaly threshold modifiers plus monster_info variant mapping.",
+  },
+  G14: {
+    entityType: "agent",
+    fieldIds: ["metadata.sourceRefs", "rules.baseDamageFormula"],
+    expectedCandidate: "SourceRef emission plus implementation-owned virtual-contribution behavior.",
+  },
+  G15: {
+    entityType: "rules",
+    fieldIds: ["rules.disorderFormula"],
+    expectedCandidate: "Implementation-owned Disorder formula boundary with failed nanoka evidence.",
+  },
+  G16: {
+    entityType: "rules",
+    fieldIds: ["rules.disorderDazeLevelZone"],
+    expectedCandidate: "Implementation-owned Disorder daze-level zone boundary with failed nanoka evidence.",
+  },
+  G17: {
+    entityType: "deadlyAssault",
+    fieldIds: ["deadlyAssault.periodsBossesBuffs", "enemies.levelDefaults"],
+    requiredSampleEntities: ["nanoka-boss-live-69036"],
+    expectedCandidate: "DA boss max HP and enemy context for corrupted-shield cleanse replay.",
+  },
+  G18: {
+    entityType: "enemy",
+    fieldIds: ["enemies.variantMapping", "enemies.levelDefaults", "enemies.specialRules"],
+    requiredSampleEntities: ["nanoka-monster-greta-live-30004"],
+    expectedCandidate: "Greta monster_info variant, level defaults, and part-break special-rule coverage.",
+  },
+  G19: {
+    entityType: "enemy",
+    fieldIds: ["enemies.variantMapping", "enemies.dazeRecovery"],
+    requiredSampleEntities: ["nanoka-monster-ruthless-fiend-live-200141"],
+    expectedCandidate: "Ruthless Fiend variant identity plus daze-recovery semantic coverage.",
+  },
+  G20: {
+    entityType: "enemy",
+    fieldIds: ["enemies.variantMapping", "enemies.dazeRecovery"],
+    requiredSampleEntities: ["nanoka-monster-notorious-hati-live-200014", "nanoka-monster-notorious-armored-hati-live-200034"],
+    expectedCandidate: "Hati/Armored Hati variant identity plus daze-recovery semantic coverage.",
+  },
+  G21: {
+    entityType: "agent",
+    fieldIds: ["agents.ruptureStats", "agents.basePanel"],
+    requiredSampleEntities: ["nanoka-character-yixuan-1371"],
+    expectedCandidate: "Yixuan panel and rupture/sheer source coverage.",
+  },
+  G22: {
+    entityType: "agent",
+    fieldIds: ["agents.passiveModifiers"],
+    requiredSampleEntities: ["nanoka-character-nicole-live-1031"],
+    expectedCandidate: "Nicole passive modifier source coverage.",
+  },
+  G23: {
+    entityType: "agent",
+    fieldIds: ["agents.passiveModifiers", "rules.disorderFormula"],
+    requiredSampleEntities: ["nanoka-character-yanagi-live-1221"],
+    expectedCandidate: "Yanagi passive/disorder source coverage.",
+  },
+  G24: {
+    entityType: "bangboo",
+    fieldIds: ["bangboos.basePanel", "bangboos.skillSegments"],
+    requiredSampleEntities: ["nanoka-bangboo-penguinboo-live-53001"],
+    expectedCandidate: "Penguinboo panel and skill numeric coverage.",
+  },
+  G25: {
+    entityType: "bangboo",
+    fieldIds: ["bangboos.basePanel", "bangboos.skillSegments"],
+    requiredSampleEntities: ["nanoka-bangboo-sharkboo-live-54001"],
+    expectedCandidate: "Sharkboo panel and skill numeric coverage.",
+  },
+  G26: {
+    entityType: "bangboo",
+    fieldIds: ["bangboos.basePanel", "bangboos.skillSegments", "bangboos.element"],
+    requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
+    expectedCandidate: "Plugboo panel, skill numeric, and element source coverage.",
+  },
+}
+
+function sourceRefWithDataPath(ref, anchorId, index) {
+  assert(ref !== undefined, `${anchorId}: baseline sourceRef is required`)
+  return {
+    sourceId: ref.sourceId,
+    sourceVersion: ref.sourceVersion,
+    sourceAnchor: ref.sourceAnchor,
+    dataPath: ref.dataPath ?? `/anchors/${anchorId}/sourceRefs/${index}`,
+  }
+}
+
+function unique(values) {
+  return [...new Set(values.filter(value => value !== null && value !== undefined && value !== ""))]
+}
+
+function matrixRowsByFieldId(matrix) {
+  const rows = new Map()
+  for (const [index, row] of matrix.rows.entries())
+    rows.set(row.fieldId, { ...row, matrixRowIndex: index })
+  return rows
+}
+
+function rowBlockers(row) {
+  return Array.isArray(row.blockedBy) ? row.blockedBy : []
+}
+
+function rowSamples(row) {
+  return unique([
+    row.sampleEntity,
+    ...(Array.isArray(row.supportingSampleEntities) ? row.supportingSampleEntities : []),
+  ])
+}
+
+function rawAnchorForSample(sampleEntity, sourceVersion) {
+  if (sampleEntity === "nanoka-manifest")
+    return `data/source/raw/nanoka/zzz/${sourceVersion}/manifest.json`
+
+  const idMatch = sampleEntity.match(/-(\d+)$/)
+  if (idMatch === null)
+    return null
+
+  const id = idMatch[1]
+  let kind = null
+  if (sampleEntity.includes("character"))
+    kind = "character"
+  else if (sampleEntity.includes("bangboo"))
+    kind = "bangboo"
+  else if (sampleEntity.includes("monster"))
+    kind = "monster"
+  else if (sampleEntity.includes("boss"))
+    kind = "boss"
+  else if (sampleEntity.includes("equipment"))
+    kind = "equipment"
+  else if (sampleEntity.includes("weapon"))
+    kind = "weapon"
+
+  if (kind === null)
+    return null
+
+  const sourceAnchor = `data/source/raw/nanoka/zzz/${sourceVersion}/zh/${kind}/${id}.json`
+  return existsSync(join(repoRoot, sourceAnchor)) ? sourceAnchor : null
+}
+
+function dataPathForSample(sampleEntity) {
+  if (sampleEntity === "nanoka-manifest")
+    return "/zzz/live"
+  if (sampleEntity.includes("character"))
+    return "/stats"
+  if (sampleEntity.includes("bangboo"))
+    return "/stats"
+  if (sampleEntity.includes("monster"))
+    return "/monster_info"
+  if (sampleEntity.includes("boss"))
+    return "/boss_adjust"
+  if (sampleEntity.includes("equipment"))
+    return "/desc2"
+  if (sampleEntity.includes("weapon"))
+    return "/stats"
+  return "/"
+}
+
+function coverageMatrixSourceRef({ sourceVersion, matrixRow }) {
+  return {
+    sourceId: "nanoka-zzz",
+    sourceVersion,
+    sourceAnchor: "data/cleaned/audit/nanoka-coverage-matrix.json",
+    dataPath: `/rows/${matrixRow?.matrixRowIndex ?? "unmapped"}`,
+  }
+}
+
+function sourceRefForMatrixRow({ sourceVersion, matrixRow }) {
+  const sampleEntity = rowSamples(matrixRow)[0]
+  if (sampleEntity !== undefined) {
+    const sourceAnchor = rawAnchorForSample(sampleEntity, sourceVersion)
+    if (sourceAnchor !== null) {
+      return {
+        sourceId: "nanoka-zzz",
+        sourceVersion,
+        sourceAnchor,
+        dataPath: dataPathForSample(sampleEntity),
+      }
+    }
+  }
+
+  if (typeof matrixRow.auditArtifact === "string" && matrixRow.auditArtifact.length > 0) {
+    return {
+      sourceId: "nanoka-zzz",
+      sourceVersion,
+      sourceAnchor: matrixRow.auditArtifact,
+      dataPath: "/summary",
+    }
+  }
+
+  return coverageMatrixSourceRef({ sourceVersion, matrixRow })
+}
+
+function rowSummary(row) {
+  return {
+    fieldId: row.fieldId,
+    status: row.status,
+    sourcePolicy: row.sourcePolicy,
+    fieldClass: row.fieldClass,
+    promotable: row.promotable === true,
+    rawAvailable: row.rawAvailable === true,
+    sampleEntities: rowSamples(row),
+    auditArtifact: row.auditArtifact ?? null,
+    blockedBy: rowBlockers(row),
+  }
+}
+
+function candidateSourceRefForAnchor({ sourceVersion, matrixRows, requiredSampleEntities, missingRequiredSampleEntities }) {
+  if (missingRequiredSampleEntities.length > 0)
+    return coverageMatrixSourceRef({ sourceVersion, matrixRow: matrixRows[0]?.row })
+
+  for (const sampleEntity of requiredSampleEntities) {
+    const sourceAnchor = rawAnchorForSample(sampleEntity, sourceVersion)
+    if (sourceAnchor !== null) {
+      return {
+        sourceId: "nanoka-zzz",
+        sourceVersion,
+        sourceAnchor,
+        dataPath: dataPathForSample(sampleEntity),
+      }
+    }
+  }
+
+  const sourceBackedRow = matrixRows.find(({ row }) => rowSamples(row).some(sample => rawAnchorForSample(sample, sourceVersion) !== null))
+  if (sourceBackedRow !== undefined)
+    return sourceRefForMatrixRow({ sourceVersion, matrixRow: sourceBackedRow.row })
+
+  const auditRow = matrixRows.find(({ row }) => typeof row.auditArtifact === "string" && row.auditArtifact.length > 0)
+  if (auditRow !== undefined)
+    return sourceRefForMatrixRow({ sourceVersion, matrixRow: auditRow.row })
+
+  return coverageMatrixSourceRef({ sourceVersion, matrixRow: matrixRows[0]?.row })
+}
+
+function buildG01G26Report({ syncId, generatedAt }) {
+  const header = reportHeader({ syncId, generatedAt })
+  const matrix = readJson(matrixPath)
+  const rowsByFieldId = matrixRowsByFieldId(matrix)
+  const replay = readJson(goldenReplayReportPath)
+  const anchorIds = Array.from({ length: 26 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`)
+
+  assert(JSON.stringify(replay.v1AnchorIds) === JSON.stringify(anchorIds), "G01-G26 replay anchor set must stay complete and ordered")
+  assert(replay.summary?.passed === 26, "G01-G26 replay report must have 26 passed anchors")
+  assert(replay.summary?.releaseReady === true, "G01-G26 replay report must remain releaseReady")
+
+  const rows = anchorIds.map((anchorId) => {
+    const anchor = replay.anchors.find(item => item.id === anchorId)
+    const spec = anchorCandidateSpecs[anchorId]
+    assert(anchor !== undefined, `${anchorId}: replay anchor is missing`)
+    assert(anchor.status === "passed", `${anchorId}: replay anchor must be passed before drift sync`)
+    assert(spec !== undefined, `${anchorId}: candidate drift spec is missing`)
+
+    const matrixRows = spec.fieldIds.map((fieldId) => {
+      const row = rowsByFieldId.get(fieldId)
+      assert(row !== undefined, `${anchorId}: missing matrix row for ${fieldId}`)
+      return { fieldId, row }
+    })
+    const availableSampleEntities = unique(matrixRows.flatMap(({ row }) => rowSamples(row)))
+    const requiredSampleEntities = spec.requiredSampleEntities ?? []
+    const missingRequiredSampleEntities = requiredSampleEntities.filter(sample => !availableSampleEntities.includes(sample))
+    const status = missingRequiredSampleEntities.length > 0 ? "missing" : "semantic-mismatch"
+    const blockedBy = unique([
+      "phase3:ruling-required",
+      status === "missing" ? "phase3:candidate-source-missing" : "phase3:semantic-equivalence-ruling-required",
+      ...matrixRows.flatMap(({ row }) => rowBlockers(row)),
+    ])
+
+    return {
+      entityType: spec.entityType,
+      entityId: anchorId,
+      fieldId: `goldenAnchors.${anchorId}.nanokaCandidateCoverage`,
+      canonicalPath: `data.cleaned.golden.v1Replay.anchors.${anchorId}.nanokaCandidateCoverage`,
+      fieldPath: `/anchors/${anchorId}/nanokaCandidateCoverage`,
+      baselineSourceRef: sourceRefWithDataPath(anchor.sourceRefs[0], anchorId, 0),
+      candidateSourceRef: candidateSourceRefForAnchor({
+        sourceVersion: header.candidate.sourceVersion,
+        matrixRows,
+        requiredSampleEntities,
+        missingRequiredSampleEntities,
+      }),
+      baselineValue: {
+        replayStatus: anchor.status,
+        sourceRefs: anchor.sourceRefs.map((ref, index) => sourceRefWithDataPath(ref, anchorId, index)),
+        notes: anchor.notes ?? [],
+      },
+      candidateValue: {
+        coverageStatus: status === "missing" ? "missing-required-sample" : "candidate-covered-not-yet-ruled-equivalent",
+        expectedCandidate: spec.expectedCandidate,
+        fieldIds: spec.fieldIds,
+        matrixRows: matrixRows.map(({ row }) => rowSummary(row)),
+        requiredSampleEntities,
+        availableSampleEntities,
+        missingRequiredSampleEntities,
+      },
+      status,
+      severity: "blocking",
+      rulingStatus: "pending",
+      blockedBy,
+      notes: status === "missing"
+        ? `First sync is missing required approved-live nanoka candidate sample(s): ${missingRequiredSampleEntities.join(", ")}.`
+        : "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline.",
+    }
+  })
+
+  return {
+    ...header,
+    counts: countsForRows(rows),
+    rows,
+    unresolvedCount: rows.length,
+    notes: [
+      "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
+      "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+      "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs.",
+    ],
+  }
+}
+
+function buildReport({ syncId, generatedAt }) {
+  if (syncId === defaultSyncId)
+    return buildFoundationReport({ syncId, generatedAt })
+  if (syncId === firstSyncId)
+    return buildG01G26Report({ syncId, generatedAt })
+  throw new Error(`Unsupported source migration drift syncId: ${syncId}`)
+}
+
 function renderMarkdown(report) {
   const countRows = driftStatuses
     .map(status => `| \`${status}\` | ${report.counts[status]} |`)
@@ -132,14 +548,24 @@ function renderMarkdown(report) {
   const baselines = report.baselines
     .map(baseline => `| \`${baseline.sourceId}\` | \`${baseline.sourceVersion}\` | ${baseline.archived ? "yes" : "no"} |`)
     .join("\n")
+  const hasRows = report.rows.length > 0
+  const statusLine = hasRows ? "Phase 3 drift audit first G01-G26 sync" : "Phase 3 drift audit foundation fixture"
+  const intro = hasRows
+    ? "This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths. Full runtime cutover remains disabled."
+    : `This report is a schema/verifier fixture. It intentionally contains no field
+comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.`
+  const driftRows = hasRows
+    ? report.rows
+        .map(row => `| \`${row.entityId}\` | \`${row.fieldId}\` | \`${row.status}\` | \`${row.rulingStatus}\` | ${row.notes} |`)
+        .join("\n")
+    : ""
 
   return `# Nanoka Drift Report: ${report.syncId}
 
-Status: Phase 3 drift audit foundation fixture
+Status: ${statusLine}
 Generated: ${report.generatedAt}
 
-This report is a schema/verifier fixture. It intentionally contains no field
-comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.
+${intro}
 
 ## Candidate
 
@@ -163,9 +589,18 @@ Unresolved blocking drift rows: **${report.unresolvedCount}**
 
 Runtime cutover ready: **${report.runtimeCutoverReady}**
 
+${hasRows
+  ? `## Drift Rows
+
+| Entity | Field | Status | Ruling | Notes |
+|---|---|---|---|---|
+${driftRows}
+`
+  : ""}
+
 ## Boundary
 
-- This artifact does not compare production fields yet.
+- ${hasRows ? "This sync does not promote nanoka to runtime cleaned data." : "This artifact does not compare production fields yet."}
 - Archived Excel / D-17 / D-12 sources remain audit baselines, not runtime
   fallback.
 - Any future \`changed\`, \`missing\`, \`new\`, or \`semantic-mismatch\` row must
@@ -191,6 +626,8 @@ function validateRows(report) {
     assert(typeof row.fieldId === "string" && row.fieldId.length > 0, `${label}: fieldId is required`)
     assert(typeof row.canonicalPath === "string" && row.canonicalPath.length > 0, `${label}: canonicalPath is required`)
     assert(typeof row.fieldPath === "string" && row.fieldPath.length > 0, `${label}: fieldPath is required`)
+    assert(Object.hasOwn(row, "baselineValue"), `${label}: baselineValue is required`)
+    assert(Object.hasOwn(row, "candidateValue"), `${label}: candidateValue is required`)
     validateSourceRef(row.baselineSourceRef, `${label}.baselineSourceRef`)
     validateSourceRef(row.candidateSourceRef, `${label}.candidateSourceRef`)
     assert(driftStatuses.includes(row.status), `${label}: invalid status ${row.status}`)
@@ -205,6 +642,7 @@ function validateRows(report) {
       assert(row.severity === "info", `${label}: same rows must be informational`)
       assert(row.rulingStatus === "not-required", `${label}: same rows must not require a ruling`)
       assert(row.blockedBy.length === 0, `${label}: same rows must not carry blockers`)
+      assert(JSON.stringify(row.baselineValue) === JSON.stringify(row.candidateValue), `${label}: same rows must have equal normalized values`)
     }
     else {
       assert(row.severity === "blocking", `${label}: non-same drift rows are blocking until ruled`)
@@ -282,7 +720,7 @@ function validateReportFixture({ reportPath, syncId }) {
 }
 
 function audit({ syncId, generatedAt }) {
-  const report = buildFoundationReport({ syncId, generatedAt })
+  const report = buildReport({ syncId, generatedAt })
   const { rootJson, packageJson, markdown } = reportPaths(syncId)
   writeJson(rootJson, report)
   writeJson(packageJson, report)

--- a/packages/data/src/source-migration-drift.test.ts
+++ b/packages/data/src/source-migration-drift.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest"
 const repoRoot = join(import.meta.dirname, "../../..")
 const dataPackageRoot = join(repoRoot, "packages/data")
 const syncId = "phase3-sync-000-foundation"
+const firstSyncId = "phase3-sync-001-g01-g26"
 
 type DriftReport = {
   schemaVersion: string
@@ -24,7 +25,29 @@ type DriftReport = {
   matrixStatus: string
   runtimeCutoverReady: boolean
   counts: Record<"same" | "changed" | "missing" | "new" | "semantic-mismatch", number>
-  rows: unknown[]
+  rows: Array<{
+    entityType: string
+    entityId: string
+    fieldId: string
+    candidateSourceRef: {
+      sourceId: string
+      sourceVersion: string
+      sourceAnchor: string
+      dataPath: string
+    }
+    baselineValue: unknown
+    candidateValue: {
+      coverageStatus: string
+      fieldIds: string[]
+      requiredSampleEntities: string[]
+      availableSampleEntities: string[]
+      missingRequiredSampleEntities: string[]
+    }
+    status: string
+    severity: string
+    rulingStatus: string
+    blockedBy: string[]
+  }>
   unresolvedCount: number
 }
 
@@ -133,6 +156,8 @@ describe("Phase 3 source migration drift report foundation", () => {
             sourceAnchor: "https://static.nanoka.cc/zzz/2.8/zh/character/1021.json",
             dataPath: "/stats",
           },
+          baselineValue: "excel",
+          candidateValue: "nanoka",
           status: "changed",
           severity: "blocking",
           rulingStatus: "not-required",
@@ -169,10 +194,94 @@ describe("Phase 3 source migration drift report foundation", () => {
     expect(report).toContain("Runtime cutover ready: **false**")
   })
 
+  it("verifies the first G01-G26 sync report", () => {
+    const output = execFileSync("node", ["scripts/source-migration-drift.mjs", "verify", "--sync-id", firstSyncId], {
+      cwd: dataPackageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${firstSyncId}.json`)
+
+    expect(output).toContain(`source migration drift verification passed for ${firstSyncId}`)
+    expect(report).toMatchObject({
+      schemaVersion: "nanoka-drift-report/v0.1",
+      syncId: firstSyncId,
+      candidate: {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+      },
+      runtimeCutoverReady: false,
+      counts: {
+        same: 0,
+        changed: 0,
+        missing: 4,
+        new: 0,
+        "semantic-mismatch": 22,
+      },
+      unresolvedCount: 26,
+    })
+    expect(report.rows).toHaveLength(26)
+    expect(report.rows.map(row => row.entityId)).toEqual(Array.from({ length: 26 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`))
+    expect(report.rows.every(row =>
+      row.severity === "blocking"
+      && row.rulingStatus === "pending"
+      && row.blockedBy.includes("phase3:ruling-required"),
+    )).toBe(true)
+    expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor.startsWith("data/source/raw/nanoka/zzz/2.8/"))).toBe(true)
+    expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor === "data/cleaned/audit/nanoka-coverage-matrix.json")).toBe(true)
+    expect(report.rows.every(row => row.fieldId.endsWith(".nanokaCandidateCoverage"))).toBe(true)
+    expect(report.rows.every(row => row.baselineValue !== "passed")).toBe(true)
+    expect(report.rows.every(row => row.candidateValue.coverageStatus !== "passed")).toBe(true)
+
+    const g22 = report.rows.find(row => row.entityId === "G22")
+    const g24 = report.rows.find(row => row.entityId === "G24")
+    const g26 = report.rows.find(row => row.entityId === "G26")
+    expect(g22).toMatchObject({
+      status: "missing",
+      candidateValue: {
+        missingRequiredSampleEntities: ["nanoka-character-nicole-live-1031"],
+      },
+      candidateSourceRef: {
+        sourceAnchor: "data/cleaned/audit/nanoka-coverage-matrix.json",
+      },
+    })
+    expect(g24).toMatchObject({
+      status: "missing",
+      candidateValue: {
+        missingRequiredSampleEntities: ["nanoka-bangboo-penguinboo-live-53001"],
+      },
+    })
+    expect(g26).toMatchObject({
+      status: "semantic-mismatch",
+      candidateSourceRef: {
+        sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        dataPath: "/stats",
+      },
+      candidateValue: {
+        coverageStatus: "candidate-covered-not-yet-ruled-equivalent",
+        requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
+      },
+    })
+  })
+
+  it("keeps the first sync report mirror and human report in sync", () => {
+    expect(readFileSync(join(repoRoot, `packages/data/cleaned/audit/nanoka-drift-report/${firstSyncId}.json`), "utf8")).toBe(
+      readFileSync(join(repoRoot, `data/cleaned/audit/nanoka-drift-report/${firstSyncId}.json`), "utf8"),
+    )
+
+    const report = readFileSync(join(repoRoot, `docs/data-source/drift-reports/${firstSyncId}.md`), "utf8")
+    expect(report).toContain(`# Nanoka Drift Report: ${firstSyncId}`)
+    expect(report).toContain("Phase 3 drift audit first G01-G26 sync")
+    expect(report).toContain("Unresolved blocking drift rows: **26**")
+    expect(report).toContain("`goldenAnchors.G26.nanokaCandidateCoverage`")
+    expect(report).toContain("Runtime cutover ready: **false**")
+  })
+
   it("packs the drift report artifact without raw source archives", () => {
     const files = npmPackFiles()
 
     expect(files).toContain(`cleaned/audit/nanoka-drift-report/${syncId}.json`)
+    expect(files).toContain(`cleaned/audit/nanoka-drift-report/${firstSyncId}.json`)
     expect(files.some(file => file.startsWith("source/raw/"))).toBe(false)
     expect(files.some(file => file.endsWith(".xlsx"))).toBe(false)
   })


### PR DESCRIPTION
## Summary

- extend the Phase 3 source-migration drift verifier to generate and validate the first real G01-G26 nanoka candidate coverage sync report
- add mirrored `phase3-sync-001-g01-g26` JSON artifacts plus human Markdown report
- replace the earlier replay-status smoke with per-anchor archived-baseline vs nanoka-candidate coverage rows
- current first sync result is intentionally **not exit-clean**: `same=0`, `missing=4`, `semantic-mismatch=22`, `unresolvedCount=26`, `runtimeCutoverReady=false`
- candidate rows now carry source-backed evidence: relevant matrix field IDs/statuses, required vs available sample entities, blockers, and `candidateSourceRef` paths to retained nanoka raw artifacts, failed-evidence audit artifacts, or the coverage matrix
- keep archived Excel / D-17 Mihoyo / D-12 buhflipexplode as audit baselines only, not runtime fallback inputs

## Scope boundaries

- no runtime cleaned-data cutover
- no G01-G26 numeric expected-value rewrite
- no Phase 3 exit claim from this sync; rulings must clear the `missing` / `semantic-mismatch` queue first
- no G27/G28 anchors yet; those stay for Phase 3 PR3 after Product/lo-user sample selection

## Verification

- `pnpm --filter @randomplay/data audit:source-migration --sync-id phase3-sync-001-g01-g26 --generated-at 2026-05-15T16:45:00+08:00`
- `pnpm --filter @randomplay/data verify:source-migration --sync-id phase3-sync-001-g01-g26`
- `pnpm --filter @randomplay/data verify:source-migration --sync-id phase3-sync-000-foundation`
- `pnpm --filter @randomplay/data test -- source-migration-drift.test.ts`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `npm pack --dry-run --json` in `packages/data` + drift artifact inclusion and raw/xlsx exclusion check
- `git diff --check`
