### PR TITLE
feat(data): add Phase 3 missing anchor candidates

### DIFF
--- a/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "generatedAt": "2026-05-15T17:15:00+08:00",
   "status": "phase-3-drift-foundation-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
@@ -309,6 +309,46 @@
       "server": "live",
       "approvedForCleanedOutput": true,
       "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-character-nicole-live-1031",
+      "entityType": "agent",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1031.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g22-passive-candidate-gate"
+    },
+    {
+      "id": "nanoka-character-yanagi-live-1221",
+      "entityType": "agent",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1221.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g23-passive-candidate-gate"
+    },
+    {
+      "id": "nanoka-bangboo-penguinboo-live-53001",
+      "entityType": "bangboo",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/53001.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g24-bangboo-candidate-gate"
+    },
+    {
+      "id": "nanoka-bangboo-sharkboo-live-54001",
+      "entityType": "bangboo",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/54001.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g25-bangboo-candidate-gate"
     }
   ],
   "rows": [
@@ -604,12 +644,18 @@
         "/skill/*/description/*/desc"
       ],
       "transformRule": "passive/talent/skill text exists; formal corePassiveModifiers require deterministic typed modifier templates before promotion",
-      "sampleEntity": "nanoka-character-yixuan-1371",
+      "sampleEntity": "nanoka-character-nicole-live-1031",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
         "typed-modifier-template-required"
-      ]
+      ],
+      "supportingSampleEntities": [
+        "nanoka-character-nicole-live-1031",
+        "nanoka-character-yanagi-live-1221",
+        "nanoka-character-yixuan-live-1371"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Nicole and Yanagi character detail samples for G22/G23 passive candidate coverage; typed modifier template remains unresolved before formal promotion."
     },
     {
       "fieldId": "adrenaline.maxAdrenaline",
@@ -715,7 +761,13 @@
       "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
       "promotable": true,
-      "blockedBy": []
+      "blockedBy": [],
+      "supportingSampleEntities": [
+        "nanoka-bangboo-plugboo-live-54008",
+        "nanoka-bangboo-penguinboo-live-53001",
+        "nanoka-bangboo-sharkboo-live-54001"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Penguinboo and Sharkboo samples for G24/G25 candidate coverage."
     },
     {
       "fieldId": "bangboos.skillSegments",
@@ -733,7 +785,13 @@
       "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
       "promotable": true,
-      "blockedBy": []
+      "blockedBy": [],
+      "supportingSampleEntities": [
+        "nanoka-bangboo-plugboo-live-54008",
+        "nanoka-bangboo-penguinboo-live-53001",
+        "nanoka-bangboo-sharkboo-live-54001"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Penguinboo and Sharkboo samples for G24/G25 candidate coverage."
     },
     {
       "fieldId": "bangboos.element",

--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-drift-report/v0.1",
   "syncId": "phase3-sync-001-g01-g26",
-  "generatedAt": "2026-05-15T16:45:00+08:00",
+  "generatedAt": "2026-05-15T17:25:00+08:00",
   "candidate": {
     "sourceId": "nanoka-zzz",
     "sourceVersion": "2.8",
@@ -29,9 +29,9 @@
   "counts": {
     "same": 0,
     "changed": 0,
-    "missing": 4,
+    "missing": 0,
     "new": 0,
-    "semantic-mismatch": 22
+    "semantic-mismatch": 26
   },
   "rows": [
     {
@@ -2167,8 +2167,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/13"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2186,7 +2186,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Nicole passive modifier source coverage.",
         "fieldIds": [
           "agents.passiveModifiers"
@@ -2200,7 +2200,9 @@
             "promotable": false,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-character-yixuan-1371"
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
             ],
             "auditArtifact": null,
             "blockedBy": [
@@ -2212,21 +2214,21 @@
           "nanoka-character-nicole-live-1031"
         ],
         "availableSampleEntities": [
-          "nanoka-character-yixuan-1371"
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-character-nicole-live-1031"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing",
+        "phase3:semantic-equivalence-ruling-required",
         "typed-modifier-template-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "agent",
@@ -2243,8 +2245,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/13"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2275,7 +2277,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Yanagi passive/disorder source coverage.",
         "fieldIds": [
           "agents.passiveModifiers",
@@ -2290,7 +2292,9 @@
             "promotable": false,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-character-yixuan-1371"
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
             ],
             "auditArtifact": null,
             "blockedBy": [
@@ -2315,22 +2319,22 @@
           "nanoka-character-yanagi-live-1221"
         ],
         "availableSampleEntities": [
-          "nanoka-character-yixuan-1371"
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-character-yanagi-live-1221"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing",
+        "phase3:semantic-equivalence-ruling-required",
         "typed-modifier-template-required",
         "implementation-owned-runtime-formula"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2347,8 +2351,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/19"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2379,7 +2383,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
         "fieldIds": [
           "bangboos.basePanel",
@@ -2394,7 +2398,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2407,7 +2413,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2417,20 +2425,20 @@
           "nanoka-bangboo-penguinboo-live-53001"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-bangboo-penguinboo-live-53001"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing"
+        "phase3:semantic-equivalence-ruling-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2447,8 +2455,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/19"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2479,7 +2487,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
         "fieldIds": [
           "bangboos.basePanel",
@@ -2494,7 +2502,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2507,7 +2517,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2517,20 +2529,20 @@
           "nanoka-bangboo-sharkboo-live-54001"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
-        ],
-        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
-        ]
+        ],
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing"
+        "phase3:semantic-equivalence-ruling-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2595,7 +2607,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2608,7 +2622,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2631,7 +2647,9 @@
           "nanoka-bangboo-plugboo-live-54008"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
         ],
         "missingRequiredSampleEntities": []
       },

--- a/data/source-registry.json
+++ b/data/source-registry.json
@@ -24,8 +24,8 @@
         "versionedIndexUrls": "^https://static\\.nanoka\\.cc/zzz/(?:\\d[\\dA-Za-z.+-]*)/boss\\.json$",
         "localizedDetailUrls": "^https://static\\.nanoka\\.cc/zzz/(?:\\d[\\dA-Za-z.+-]*)/(?:zh|en|ja|ko)/[a-z]+/\\d+\\.json$"
       },
-      "fetchedAt": "2026-05-15T12:20:00+08:00",
-      "lastVerifiedAt": "2026-05-15T12:20:00+08:00",
+      "fetchedAt": "2026-05-15T17:15:00+08:00",
+      "lastVerifiedAt": "2026-05-15T17:15:00+08:00",
       "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d",
       "takedownPath": "docs/data-source/takedown-rollback.md#nanoka",
       "fallbackPlan": "archived Excel V0.0.4 snapshot + D-17 Mihoyo archived + D-12 buhflipexplode archived",

--- a/data/source/raw/nanoka/zzz/2.8/fetch-manifest.json
+++ b/data/source/raw/nanoka/zzz/2.8/fetch-manifest.json
@@ -2,8 +2,8 @@
   "schemaVersion": "nanoka-fetch-manifest-v1",
   "sourceId": "nanoka-zzz",
   "snapshotId": "2.8",
-  "fetchedAt": "2026-05-15T13:20:00+08:00",
-  "generatedAt": "2026-05-15T13:20:00+08:00",
+  "fetchedAt": "2026-05-15T17:15:00+08:00",
+  "generatedAt": "2026-05-15T17:15:00+08:00",
   "parserVersion": "nanoka-source-v0.1.0",
   "userAgent": "fairy-data-source-audit/0.1 (+https://github.com/LoTwT/fairy)",
   "formalLivePolicy": {
@@ -107,6 +107,48 @@
       },
       "bytes": 94293,
       "sha256": "710c0e2fa5fca2779819b76c23a4abf8d445ba7e4a2f1cbfccd9145185143c94"
+    },
+    {
+      "id": "character-nicole-1031",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1031.json",
+      "path": "zh/character/1031.json",
+      "entityType": "character",
+      "language": "zh",
+      "entityId": 1031,
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g22-passive-candidate-gate",
+      "sourceVersion": "2.8",
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+      "status": 200,
+      "headers": {
+        "etag": "\"69fa92b8-16dda\"",
+        "lastModified": "Wed, 06 May 2026 01:00:40 GMT",
+        "contentType": "application/json",
+        "cacheControl": "max-age=120"
+      },
+      "bytes": 93659,
+      "sha256": "559d3c5959867b26d41581777d9235de4f17d671a12b68944e3422f07696dcbf"
+    },
+    {
+      "id": "character-yanagi-1221",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1221.json",
+      "path": "zh/character/1221.json",
+      "entityType": "character",
+      "language": "zh",
+      "entityId": 1221,
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g23-passive-candidate-gate",
+      "sourceVersion": "2.8",
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
+      "status": 200,
+      "headers": {
+        "etag": "\"69fa92b9-12142\"",
+        "lastModified": "Wed, 06 May 2026 01:00:41 GMT",
+        "contentType": "application/json",
+        "cacheControl": "max-age=120"
+      },
+      "bytes": 74051,
+      "sha256": "028108dc56d4f4daf3219de3e46c16a015a8163136c6d6f25f5a5ab400a812f0"
     },
     {
       "id": "boss-69036",
@@ -298,6 +340,48 @@
       "sha256": "02a203d3bcdf5b6c1d756e0a5f2957658a13b889305da5dbd8ce27f9a8dbee60"
     },
     {
+      "id": "bangboo-penguinboo-53001",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/53001.json",
+      "path": "zh/bangboo/53001.json",
+      "entityType": "bangboo",
+      "language": "zh",
+      "entityId": 53001,
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g24-bangboo-candidate-gate",
+      "sourceVersion": "2.8",
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+      "status": 200,
+      "headers": {
+        "etag": "\"69fa92b8-3b8b\"",
+        "lastModified": "Wed, 06 May 2026 01:00:40 GMT",
+        "contentType": "application/json",
+        "cacheControl": "max-age=120"
+      },
+      "bytes": 15244,
+      "sha256": "86fcf7cdb96f636c71568689f81c5bbe8bf94bd7ff26089787a42b7d521f1023"
+    },
+    {
+      "id": "bangboo-sharkboo-54001",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/54001.json",
+      "path": "zh/bangboo/54001.json",
+      "entityType": "bangboo",
+      "language": "zh",
+      "entityId": 54001,
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g25-bangboo-candidate-gate",
+      "sourceVersion": "2.8",
+      "localPath": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
+      "status": 200,
+      "headers": {
+        "etag": "\"69fa92b8-420c\"",
+        "lastModified": "Wed, 06 May 2026 01:00:40 GMT",
+        "contentType": "application/json",
+        "cacheControl": "max-age=120"
+      },
+      "bytes": 16909,
+      "sha256": "c4c4f2685dd8913ad65658721b1acf96162a0f3203b2a7c1da070058b6361b2c"
+    },
+    {
       "id": "weapon-yixuan-signature-14137",
       "url": "https://static.nanoka.cc/zzz/2.8/zh/weapon/14137.json",
       "path": "zh/weapon/14137.json",
@@ -373,6 +457,32 @@
         "/skill/basic/description/4/param/0/param/1371001/rp_recovery"
       ]
     },
+    "passiveCharacterSamples": [
+      {
+        "id": 1031,
+        "codeName": "Nicole",
+        "hasStats": true,
+        "skillKeys": [
+          "basic",
+          "dodge",
+          "special",
+          "chain",
+          "assist"
+        ]
+      },
+      {
+        "id": 1221,
+        "codeName": "Yanagi",
+        "hasStats": true,
+        "skillKeys": [
+          "basic",
+          "dodge",
+          "special",
+          "chain",
+          "assist"
+        ]
+      }
+    ],
     "deadlyAssaultSample": {
       "id": 69036,
       "zoneCount": 3,
@@ -481,6 +591,20 @@
       "hasStats": true,
       "hasSkillProp": true
     },
+    "bangbooCandidateSamples": [
+      {
+        "id": 53001,
+        "codeName": "Penguinboo",
+        "hasStats": true,
+        "hasSkillProp": true
+      },
+      {
+        "id": 54001,
+        "codeName": "Sharkboo",
+        "hasStats": true,
+        "hasSkillProp": true
+      }
+    ],
     "wEngineSample": {
       "id": 14137,
       "codeName": "Weapon_S_1371",
@@ -492,6 +616,6 @@
       "name": "啄木鸟电音",
       "hasSetDescriptions": true
     },
-    "retainedAssetCount": 15
+    "retainedAssetCount": 19
   }
 }

--- a/data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json
+++ b/data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json
@@ -1,0 +1,443 @@
+{
+  "id": 53001,
+  "code_name": "Penguinboo",
+  "name": "企鹅布",
+  "desc": "摇摇，晃晃。冰冰，凉凉。",
+  "rarity": 3,
+  "icon": "UI/Sprite/A1DynamicLoad/BangbooModGarage/UnPacker/BangbooRole/BangbooGarageRole12.png",
+  "stats": {
+    "endurance": 180,
+    "hp_max": 360,
+    "hpupgrade": 428397,
+    "attack": 50,
+    "attack_upgrade": 252034,
+    "break_stun": 90,
+    "element_abnormal_power": 120,
+    "defence": 30,
+    "def_upgrade": 85729,
+    "crit": 500,
+    "pen_ratio": 0,
+    "crit_dmg": 5000
+  },
+  "level": {
+    "1": {
+      "hp_max": 0,
+      "attack": 0,
+      "defence": 0,
+      "level_max": 10,
+      "level_min": 0,
+      "materials": {
+        "10": 15000,
+        "102010": 4
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 0
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "2": {
+      "hp_max": 188,
+      "attack": 47,
+      "defence": 38,
+      "level_max": 20,
+      "level_min": 10,
+      "materials": {
+        "10": 35000,
+        "102020": 12
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 450
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "3": {
+      "hp_max": 376,
+      "attack": 233,
+      "defence": 75,
+      "level_max": 30,
+      "level_min": 20,
+      "materials": {
+        "10": 75000,
+        "102020": 20
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 2250
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "4": {
+      "hp_max": 564,
+      "attack": 699,
+      "defence": 113,
+      "level_max": 40,
+      "level_min": 30,
+      "materials": {
+        "10": 125000,
+        "102030": 10
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 2250
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 2500
+        }
+      }
+    },
+    "5": {
+      "hp_max": 752,
+      "attack": 1864,
+      "defence": 151,
+      "level_max": 50,
+      "level_min": 40,
+      "materials": {
+        "10": 250000,
+        "102030": 20
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 4500
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 2500
+        }
+      }
+    },
+    "6": {
+      "hp_max": 940,
+      "attack": 4661,
+      "defence": 188,
+      "level_max": 60,
+      "level_min": 50,
+      "materials": {},
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 4500
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 5000
+        }
+      }
+    }
+  },
+  "skill": {
+    "a": {
+      "level": {
+        "1": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "2": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "3": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "4": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "5": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "6": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "7": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "8": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "9": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        },
+        "10": {
+          "name": "冰刀舞",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，舞动冰刀对敌人进行连续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{Skill:5300101, Prop:1001}|{Skill:5300101, Prop:1002}|20秒"
+        }
+      }
+    },
+    "b": {
+      "level": {
+        "1": {
+          "name": "干冰场地",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升60%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "60%"
+        },
+        "2": {
+          "name": "干冰场地",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升75%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "75%"
+        },
+        "3": {
+          "name": "干冰场地",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升90%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "90%"
+        },
+        "4": {
+          "name": "干冰场地",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升105%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "105%"
+        },
+        "5": {
+          "name": "干冰场地",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升120%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "120%"
+        }
+      }
+    },
+    "c": {
+      "level": {
+        "1": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "2": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "3": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "4": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "5": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "6": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "7": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "8": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "9": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        },
+        "10": {
+          "name": "冰暴回旋",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n对目标进行持续斩击，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5300102, Prop:1001}|{Skill:5300102, Prop:1002}"
+        }
+      }
+    }
+  },
+  "skill_prop": {
+    "5300101": {
+      "1001": {
+        "main": 46200,
+        "growth": 4620,
+        "format": "%"
+      },
+      "1002": {
+        "main": 27000,
+        "growth": 2700,
+        "format": "%"
+      },
+      "element_accumulation_value": 34600
+    },
+    "5300102": {
+      "1001": {
+        "main": 95700,
+        "growth": 9570,
+        "format": "%"
+      },
+      "1002": {
+        "main": 13700,
+        "growth": 1370,
+        "format": "%"
+      },
+      "element_accumulation_value": 41000
+    }
+  }
+}

--- a/data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json
+++ b/data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json
@@ -1,0 +1,456 @@
+{
+  "id": 54001,
+  "code_name": "Sharkboo",
+  "name": "鲨牙布",
+  "desc": "出没于远洋及生鲜超市海产区。",
+  "rarity": 4,
+  "icon": "UI/Sprite/A1DynamicLoad/BangbooModGarage/UnPacker/BangbooRole/BangbooGarageRole07.png",
+  "stats": {
+    "endurance": 180,
+    "hp_max": 396,
+    "hpupgrade": 471237,
+    "attack": 65,
+    "attack_upgrade": 327644,
+    "break_stun": 99,
+    "element_abnormal_power": 132,
+    "defence": 30,
+    "def_upgrade": 85729,
+    "crit": 500,
+    "pen_ratio": 0,
+    "crit_dmg": 5000
+  },
+  "level": {
+    "1": {
+      "hp_max": 0,
+      "attack": 0,
+      "defence": 0,
+      "level_max": 10,
+      "level_min": 0,
+      "materials": {
+        "10": 15000,
+        "102010": 4
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 0
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "2": {
+      "hp_max": 207,
+      "attack": 61,
+      "defence": 38,
+      "level_max": 20,
+      "level_min": 10,
+      "materials": {
+        "10": 35000,
+        "102020": 12
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 450
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "3": {
+      "hp_max": 414,
+      "attack": 303,
+      "defence": 75,
+      "level_max": 30,
+      "level_min": 20,
+      "materials": {
+        "10": 75000,
+        "102020": 20
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 2250
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 0
+        }
+      }
+    },
+    "4": {
+      "hp_max": 621,
+      "attack": 909,
+      "defence": 113,
+      "level_max": 40,
+      "level_min": 30,
+      "materials": {
+        "10": 125000,
+        "102030": 10
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 2250
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 2500
+        }
+      }
+    },
+    "5": {
+      "hp_max": 828,
+      "attack": 2424,
+      "defence": 151,
+      "level_max": 50,
+      "level_min": 40,
+      "materials": {
+        "10": 250000,
+        "102030": 20
+      },
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 4500
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 2500
+        }
+      }
+    },
+    "6": {
+      "hp_max": 1034,
+      "attack": 6059,
+      "defence": 188,
+      "level_max": 60,
+      "level_min": 50,
+      "materials": {},
+      "extra": {
+        "20101": {
+          "prop": 20101,
+          "name": "暴击率",
+          "format": "{0:0.#%}",
+          "value": 4500
+        },
+        "21101": {
+          "prop": 21101,
+          "name": "暴击伤害",
+          "format": "{0:0.#%}",
+          "value": 5000
+        }
+      }
+    }
+  },
+  "skill": {
+    "a": {
+      "level": {
+        "1": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "2": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "3": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "4": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "5": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "6": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "7": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "8": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "9": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        },
+        "10": {
+          "name": "旱地猎鲨",
+          "desc": "<color=#FFFFFF>[主动技]</color>\n招式发动时，在原地设置追踪陷阱，触发时撕咬敌人并召唤鱼雷打击，造成<color=#98EFF0>冰属性伤害</color>并累积<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率",
+            "冷却时间"
+          ],
+          "param": "{{Skill:5400101, Prop:1001}/3}+{{Skill:5400101, Prop:1001}*2/3}|{{Skill:5400101, Prop:1002}/3}+{{Skill:5400101, Prop:1002}*2/3}|12秒"
+        }
+      }
+    },
+    "b": {
+      "level": {
+        "1": {
+          "name": "寒流涌动",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升100%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "100%"
+        },
+        "2": {
+          "name": "寒流涌动",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升125%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "125%"
+        },
+        "3": {
+          "name": "寒流涌动",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升150%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "150%"
+        },
+        "4": {
+          "name": "寒流涌动",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升175%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "175%"
+        },
+        "5": {
+          "name": "寒流涌动",
+          "desc": "<color=#FFFFFF>[额外能力]</color>\n队伍中存在2名或以上<color=#98EFF0>[冰属性]</color>角色时触发：<color=#FFFFFF>[邦布连携技]</color>累积的属性异常积蓄值提升200%。",
+          "property": [
+            "属性异常积蓄值提升"
+          ],
+          "param": "200%"
+        }
+      }
+    },
+    "c": {
+      "level": {
+        "1": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "2": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "3": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "4": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "5": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "6": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "7": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "8": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "9": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        },
+        "10": {
+          "name": "追猎不休",
+          "desc": "<color=#FFFFFF>[邦布连携技]</color>\n召唤追踪陷阱并跳向目标，落地时引发爆炸，造成<color=#98EFF0>冰属性伤害</color>并累积大量<color=#98EFF0>冰属性异常积蓄值</color>。",
+          "property": [
+            "伤害倍率",
+            "失衡倍率"
+          ],
+          "param": "{Skill:5400102, Prop:1001}|{Skill:5400102, Prop:1002}"
+        }
+      }
+    }
+  },
+  "skill_prop": {
+    "5400101": {
+      "1001": {
+        "main": 38400,
+        "growth": 3840,
+        "format": "%"
+      },
+      "1002": {
+        "main": 14000,
+        "growth": 1400,
+        "format": "%"
+      },
+      "element_accumulation_value": 18000
+    },
+    "5400102": {
+      "1001": {
+        "main": 46100,
+        "growth": 4610,
+        "format": "%"
+      },
+      "1002": {
+        "main": 9300,
+        "growth": 930,
+        "format": "%"
+      },
+      "element_accumulation_value": 19000
+    },
+    "5400103": {
+      "1001": {
+        "main": 120000,
+        "growth": 12000,
+        "format": "%"
+      },
+      "1002": {
+        "main": 35100,
+        "growth": 3510,
+        "format": "%"
+      },
+      "element_accumulation_value": 45000
+    }
+  }
+}

--- a/data/source/raw/nanoka/zzz/2.8/zh/character/1031.json
+++ b/data/source/raw/nanoka/zzz/2.8/zh/character/1031.json
@@ -1,0 +1,2640 @@
+{
+  "id": 1031,
+  "icon": "IconRole12",
+  "name": "妮可",
+  "code_name": "Nicole",
+  "rarity": 3,
+  "weapon_type": {
+    "4": "支援"
+  },
+  "element_type": {
+    "205": "以太"
+  },
+  "special_element_type": {},
+  "hit_type": {
+    "102": "打击"
+  },
+  "camp": {
+    "1": "狡兔屋"
+  },
+  "gender": 2,
+  "partner_info": {
+    "birthday": "11/11",
+    "full_name": "妮可·德玛拉",
+    "gender": "女",
+    "icon_path": "UI/Sprite/A1DynamicLoad/IconRoleCircle/UnPacker/IconRoleCircle12.png",
+    "impression_f": "原来妮可在圈子里比我想象的还要有名诶！",
+    "impression_m": "比起这些锐评，我还是更想看到妮可到目前为止拖欠的所有账单整合。",
+    "profile_desc": "在数据库中搜索：妮可，返回相关结果：\n「万能事务所『狡兔屋』的经营者」，「街头摸爬滚打出来的人精」，「父母成谜的孤儿」。\n妮可旗下事务所原名为「gentle house」，温柔之家。但因其狡猾抠门的处事风格而被戏称为「狡兔屋」。\n「这人真是钻钱眼里去了！真不知道她搞这么多钱是要干嘛，好像什么也没干。」\n——以上信息原文摘录自绳网热贴：「挂一家离谱的万事屋，我从未见过这种钻到钱眼里的老板！」\n对此，当事人的表态为：「这、这是污蔑！听好了，我妮可从来没有钻到钱眼里——因为根本就没钱！」\n根据可靠消息，狡兔屋常年处于赤字状态。经营者的「精打细算」似乎并没有为这个组织带来正面效果。",
+    "role_icon": "IconRole/UnPacker/IconRole12",
+    "stature": "165",
+    "unlock_condition": [
+      "获得代理人",
+      "完成委托「安比的困扰」"
+    ],
+    "trust_lv": {
+      "1": "在数据库中搜索：妮可，返回相关结果：\n「万能事务所『狡兔屋』的经营者」，「街头摸爬滚打出来的人精」，「父母成谜的孤儿」。\n妮可旗下事务所原名为「gentle house」，温柔之家。但因其狡猾抠门的处事风格而被戏称为「狡兔屋」。\n「这人真是钻钱眼里去了！真不知道她搞这么多钱是要干嘛，好像什么也没干。」\n——以上信息原文摘录自绳网热贴：「挂一家离谱的万事屋，我从未见过这种钻到钱眼里的老板！」\n对此，当事人的表态为：「这、这是污蔑！听好了，我妮可从来没有钻到钱眼里——因为根本就没钱！」\n根据可靠消息，狡兔屋常年处于赤字状态。经营者的「精打细算」似乎并没有为这个组织带来正面效果。",
+      "2": "",
+      "3": "妮可早年曾在孤儿院内待过较长时间。\n有传闻称，妮可曾和有名望的家庭达成过收养协议。但不久之后，妮可却再次独自现身于新艾利都某处，并由此开始混迹街头巷尾的生活，直至现在。",
+      "4": ""
+    }
+  },
+  "skin": {
+    "3110310": {
+      "name": "妮可·一点点俏皮",
+      "desc": "狡兔屋老大的经典穿搭，隐藏了几分灵动的小心机，俏皮又可爱。",
+      "image": "IconRole12"
+    },
+    "3110311": {
+      "name": "妮可·狡黠甜心",
+      "desc": "粉色！粉色！粉色！粉色就是妮可的本命色，心动了吗？",
+      "image": "IconRole12_01"
+    }
+  },
+  "stats": {
+    "armor": 0,
+    "armor_growth": 0,
+    "attack": 93,
+    "attack_growth": 53249,
+    "avatar_piece_id": 5031,
+    "break_stun": 88,
+    "crit": 500,
+    "crit_damage": 5000,
+    "crit_dmg_res": 0,
+    "crit_res": 0,
+    "defence": 50,
+    "defence_growth": 67901,
+    "element_abnormal_power": 90,
+    "element_mystery": 93,
+    "endurance": 0,
+    "hp_growth": 888787,
+    "hp_max": 655,
+    "pen_delta": 0,
+    "pen_rate": 0,
+    "rbl": 1,
+    "rbl_correction_factor": 10000,
+    "rbl_probability": 0,
+    "shield": 0,
+    "shield_growth": 0,
+    "sp_bar_point": 120,
+    "sp_recover": 120,
+    "stun": 0,
+    "tags": [
+      "Nostradamus",
+      "Ether",
+      "Punch",
+      "Female",
+      "Camp1",
+      "Size2",
+      "AidTypeParry",
+      "Nicole",
+      "EtherEyesSize2"
+    ],
+    "rp_max": 0,
+    "rp_recover": 0
+  },
+  "level": {
+    "1": {
+      "hp_max": 0,
+      "attack": 0,
+      "defence": 0,
+      "level_max": 10,
+      "level_min": 0,
+      "materials": {
+        "10": 24000,
+        "100214": 4
+      }
+    },
+    "2": {
+      "hp_max": 449,
+      "attack": 33,
+      "defence": 34,
+      "level_max": 20,
+      "level_min": 10,
+      "materials": {
+        "10": 56000,
+        "100224": 12
+      }
+    },
+    "3": {
+      "hp_max": 899,
+      "attack": 67,
+      "defence": 69,
+      "level_max": 30,
+      "level_min": 20,
+      "materials": {
+        "10": 120000,
+        "100224": 20
+      }
+    },
+    "4": {
+      "hp_max": 1348,
+      "attack": 100,
+      "defence": 103,
+      "level_max": 40,
+      "level_min": 30,
+      "materials": {
+        "10": 200000,
+        "100234": 10
+      }
+    },
+    "5": {
+      "hp_max": 1798,
+      "attack": 133,
+      "defence": 137,
+      "level_max": 50,
+      "level_min": 40,
+      "materials": {
+        "10": 400000,
+        "100234": 20
+      }
+    },
+    "6": {
+      "hp_max": 2247,
+      "attack": 167,
+      "defence": 172,
+      "level_max": 60,
+      "level_min": 50,
+      "materials": {}
+    }
+  },
+  "extra_level": {
+    "1": {
+      "max_level": 15,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 0
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 12
+        }
+      }
+    },
+    "2": {
+      "max_level": 25,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 25
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 12
+        }
+      }
+    },
+    "3": {
+      "max_level": 35,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 25
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 24
+        }
+      }
+    },
+    "4": {
+      "max_level": 45,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 50
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 24
+        }
+      }
+    },
+    "5": {
+      "max_level": 55,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 50
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 36
+        }
+      }
+    },
+    "6": {
+      "max_level": 60,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 75
+        },
+        "30501": {
+          "prop": 30501,
+          "name": "基础能量自动回复",
+          "format": "{0:0.##}",
+          "value": 36
+        }
+      }
+    }
+  },
+  "level_exp": [
+    50,
+    150,
+    250,
+    400,
+    600,
+    800,
+    1000,
+    1250,
+    1500,
+    1800,
+    1935,
+    2065,
+    2200,
+    2335,
+    2465,
+    2600,
+    2735,
+    2865,
+    3000,
+    4680,
+    4975,
+    5265,
+    5560,
+    5855,
+    6145,
+    6440,
+    6735,
+    7025,
+    7320,
+    10800,
+    11400,
+    12000,
+    12600,
+    13200,
+    13800,
+    14400,
+    15000,
+    15600,
+    16200,
+    17100,
+    18300,
+    19500,
+    20700,
+    21900,
+    23100,
+    24300,
+    25500,
+    26700,
+    27900,
+    34200,
+    36600,
+    39000,
+    41400,
+    43800,
+    46200,
+    48600,
+    51000,
+    53400,
+    55800,
+    0
+  ],
+  "skill": {
+    "basic": {
+      "description": [
+        {
+          "name": "普通攻击：狡兔连打",
+          "desc": "点按 <IconMap:Icon_Normal> 发动：\n向前方进行至多三段的打击，造成<color=#F0D12B>物理伤害</color>。",
+          "potential": []
+        },
+        {
+          "name": "普通攻击：为所欲为",
+          "desc": "发动<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式后，能够上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，提升子弹的威力。",
+          "potential": []
+        },
+        {
+          "name": "普通攻击：狡兔连打",
+          "param": [
+            {
+              "name": "一段伤害倍率",
+              "desc": "{Skill:1031001, Prop:1001} + {{Skill:1031002, Prop:1001}/3}*3",
+              "param": {
+                "1031001": {
+                  "main": 3890,
+                  "growth": 360,
+                  "format": "%",
+                  "damage_percentage": 3890,
+                  "damage_percentage_growth": 360,
+                  "stun_ratio": 1950,
+                  "stun_ratio_growth": 90,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1943
+                },
+                "1031002": {
+                  "main": 2710,
+                  "growth": 250,
+                  "format": "%",
+                  "damage_percentage": 2710,
+                  "damage_percentage_growth": 250,
+                  "stun_ratio": 2090,
+                  "stun_ratio_growth": 100,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2082
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段伤害倍率",
+              "desc": "{Skill:1031004, Prop:1001} + {{Skill:1031005, Prop:1001}/4}*4",
+              "param": {
+                "1031004": {
+                  "main": 3530,
+                  "growth": 330,
+                  "format": "%",
+                  "damage_percentage": 3530,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2892
+                },
+                "1031005": {
+                  "main": 3610,
+                  "growth": 330,
+                  "format": "%",
+                  "damage_percentage": 3610,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2775
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段伤害倍率",
+              "desc": "{Skill:1031007, Prop:1001} + {{Skill:1031008, Prop:1001}/20}*20",
+              "param": {
+                "1031007": {
+                  "main": 12430,
+                  "growth": 1130,
+                  "format": "%",
+                  "damage_percentage": 12430,
+                  "damage_percentage_growth": 1130,
+                  "stun_ratio": 10430,
+                  "stun_ratio_growth": 480,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10427
+                },
+                "1031008": {
+                  "main": 18040,
+                  "growth": 1640,
+                  "format": "%",
+                  "damage_percentage": 18040,
+                  "damage_percentage_growth": 1640,
+                  "stun_ratio": 13880,
+                  "stun_ratio_growth": 640,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10406
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "一段失衡倍率",
+              "desc": "{Skill:1031001, Prop:1002} + {{Skill:1031002, Prop:1002}/3}*3",
+              "param": {
+                "1031001": {
+                  "main": 1950,
+                  "growth": 90,
+                  "format": "%",
+                  "damage_percentage": 3890,
+                  "damage_percentage_growth": 360,
+                  "stun_ratio": 1950,
+                  "stun_ratio_growth": 90,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1943
+                },
+                "1031002": {
+                  "main": 2090,
+                  "growth": 100,
+                  "format": "%",
+                  "damage_percentage": 2710,
+                  "damage_percentage_growth": 250,
+                  "stun_ratio": 2090,
+                  "stun_ratio_growth": 100,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2082
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段失衡倍率",
+              "desc": "{Skill:1031004, Prop:1002} + {{Skill:1031005, Prop:1002}/4}*4",
+              "param": {
+                "1031004": {
+                  "main": 2900,
+                  "growth": 140,
+                  "format": "%",
+                  "damage_percentage": 3530,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2892
+                },
+                "1031005": {
+                  "main": 2780,
+                  "growth": 130,
+                  "format": "%",
+                  "damage_percentage": 3610,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2775
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段失衡倍率",
+              "desc": "{Skill:1031007, Prop:1002} + {{Skill:1031008, Prop:1002}/20}*20",
+              "param": {
+                "1031007": {
+                  "main": 10430,
+                  "growth": 480,
+                  "format": "%",
+                  "damage_percentage": 12430,
+                  "damage_percentage_growth": 1130,
+                  "stun_ratio": 10430,
+                  "stun_ratio_growth": 480,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10427
+                },
+                "1031008": {
+                  "main": 13880,
+                  "growth": 640,
+                  "format": "%",
+                  "damage_percentage": 18040,
+                  "damage_percentage_growth": 1640,
+                  "stun_ratio": 13880,
+                  "stun_ratio_growth": 640,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10406
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "普通攻击：为所欲为",
+          "param": [
+            {
+              "name": "一段伤害倍率",
+              "desc": "{Skill:1031001, Prop:1001} + {{Skill:1031003, Prop:1001}/3}*3",
+              "param": {
+                "1031001": {
+                  "main": 3890,
+                  "growth": 360,
+                  "format": "%",
+                  "damage_percentage": 3890,
+                  "damage_percentage_growth": 360,
+                  "stun_ratio": 1950,
+                  "stun_ratio_growth": 90,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1943
+                },
+                "1031003": {
+                  "main": 4940,
+                  "growth": 450,
+                  "format": "%",
+                  "damage_percentage": 4940,
+                  "damage_percentage_growth": 450,
+                  "stun_ratio": 2090,
+                  "stun_ratio_growth": 100,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2082
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段伤害倍率",
+              "desc": "{Skill:1031004, Prop:1001} + {{Skill:1031006, Prop:1001}/4}*4",
+              "param": {
+                "1031004": {
+                  "main": 3530,
+                  "growth": 330,
+                  "format": "%",
+                  "damage_percentage": 3530,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2892
+                },
+                "1031006": {
+                  "main": 6580,
+                  "growth": 600,
+                  "format": "%",
+                  "damage_percentage": 6580,
+                  "damage_percentage_growth": 600,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2775
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段伤害倍率",
+              "desc": "{Skill:1031007, Prop:1001} + {{Skill:1031009, Prop:1001}/20}*20",
+              "param": {
+                "1031007": {
+                  "main": 12430,
+                  "growth": 1130,
+                  "format": "%",
+                  "damage_percentage": 12430,
+                  "damage_percentage_growth": 1130,
+                  "stun_ratio": 10430,
+                  "stun_ratio_growth": 480,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10427
+                },
+                "1031009": {
+                  "main": 32900,
+                  "growth": 3000,
+                  "format": "%",
+                  "damage_percentage": 32900,
+                  "damage_percentage_growth": 3000,
+                  "stun_ratio": 13880,
+                  "stun_ratio_growth": 640,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10406
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "一段失衡倍率",
+              "desc": "{Skill:1031001, Prop:1002} + {{Skill:1031003, Prop:1002}/3}*3",
+              "param": {
+                "1031001": {
+                  "main": 1950,
+                  "growth": 90,
+                  "format": "%",
+                  "damage_percentage": 3890,
+                  "damage_percentage_growth": 360,
+                  "stun_ratio": 1950,
+                  "stun_ratio_growth": 90,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1943
+                },
+                "1031003": {
+                  "main": 2090,
+                  "growth": 100,
+                  "format": "%",
+                  "damage_percentage": 4940,
+                  "damage_percentage_growth": 450,
+                  "stun_ratio": 2090,
+                  "stun_ratio_growth": 100,
+                  "sp_recovery": 7000,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 53625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2082
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段失衡倍率",
+              "desc": "{Skill:1031004, Prop:1002} + {{Skill:1031006, Prop:1002}/4}*4",
+              "param": {
+                "1031004": {
+                  "main": 2900,
+                  "growth": 140,
+                  "format": "%",
+                  "damage_percentage": 3530,
+                  "damage_percentage_growth": 330,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2892
+                },
+                "1031006": {
+                  "main": 2780,
+                  "growth": 130,
+                  "format": "%",
+                  "damage_percentage": 6580,
+                  "damage_percentage_growth": 600,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10410,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 79750,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2775
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段失衡倍率",
+              "desc": "{Skill:1031007, Prop:1002} + {{Skill:1031009, Prop:1002}/20}*20",
+              "param": {
+                "1031007": {
+                  "main": 10430,
+                  "growth": 480,
+                  "format": "%",
+                  "damage_percentage": 12430,
+                  "damage_percentage_growth": 1130,
+                  "stun_ratio": 10430,
+                  "stun_ratio_growth": 480,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10427
+                },
+                "1031009": {
+                  "main": 13880,
+                  "growth": 640,
+                  "format": "%",
+                  "damage_percentage": 32900,
+                  "damage_percentage_growth": 3000,
+                  "stun_ratio": 13880,
+                  "stun_ratio_growth": 640,
+                  "sp_recovery": 37540,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 286825,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10406
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100115": 2
+        },
+        "2": {
+          "10": 3000,
+          "100115": 3
+        },
+        "3": {
+          "10": 6000,
+          "100125": 2
+        },
+        "4": {
+          "10": 9000,
+          "100125": 3
+        },
+        "5": {
+          "10": 12000,
+          "100125": 4
+        },
+        "6": {
+          "10": 18000,
+          "100125": 6
+        },
+        "7": {
+          "10": 45000,
+          "100135": 5
+        },
+        "8": {
+          "10": 67500,
+          "100135": 8
+        },
+        "9": {
+          "10": 90000,
+          "100135": 10
+        },
+        "10": {
+          "10": 112500,
+          "100135": 12
+        },
+        "11": {
+          "10": 135000,
+          "100135": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "dodge": {
+      "description": [
+        {
+          "name": "闪避：脱兔",
+          "desc": "点按 <IconMap:Icon_Evade> 发动：\n快速的冲刺闪避；\n招式发动期间拥有无敌效果；\n拖曳{LAYOUT_CONSOLECONTROLLER#操作杆}{LAYOUT_FALLBACK#摇杆}发动闪避时，长按 <IconMap:Icon_Evade> ，可以在闪避中途上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "冲刺攻击：惊喜开箱",
+          "desc": "拖曳{LAYOUT_CONSOLECONTROLLER#操作杆}{LAYOUT_FALLBACK#摇杆}发动闪避后，点按 <IconMap:Icon_Normal> 发动：\n向对应方向冲刺，并对身周敌人进行打击，造成<color=#F0D12B>物理伤害</color>；\n未拖曳{LAYOUT_CONSOLECONTROLLER#操作杆}{LAYOUT_FALLBACK#摇杆}发动闪避后，点按 <IconMap:Icon_Normal> 发动：\n向后躲避，并对前方敌人发动远程打击，造成<color=#F0D12B>物理伤害</color>；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "闪避反击：牵制炮击",
+          "desc": "触发<color=#FFFFFF>[极限闪避]</color>后，点按 <IconMap:Icon_Normal> 发动：\n向后闪避，并对前方敌人发动远程打击，造成<color=#FE437E>以太伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "冲刺攻击：惊喜开箱",
+          "param": [
+            {
+              "name": "前闪攻击伤害倍率",
+              "desc": "{Skill:1031201, Prop:1001} + {{Skill:1031202, Prop:1001}/13}*13",
+              "param": {
+                "1031201": {
+                  "main": 4120,
+                  "growth": 380,
+                  "format": "%",
+                  "damage_percentage": 4120,
+                  "damage_percentage_growth": 380,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2891
+                },
+                "1031202": {
+                  "main": 11730,
+                  "growth": 1070,
+                  "format": "%",
+                  "damage_percentage": 11730,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 4510,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4509
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "后闪攻击伤害倍率",
+              "desc": "{Skill:1031204, Prop:1001}",
+              "param": {
+                "1031204": {
+                  "main": 6000,
+                  "growth": 550,
+                  "format": "%",
+                  "damage_percentage": 6000,
+                  "damage_percentage_growth": 550,
+                  "stun_ratio": 6000,
+                  "stun_ratio_growth": 280,
+                  "sp_recovery": 21590,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 82500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2999
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "前闪攻击失衡倍率",
+              "desc": "{Skill:1031201, Prop:1002} + {{Skill:1031202, Prop:1002}/13}*13",
+              "param": {
+                "1031201": {
+                  "main": 2900,
+                  "growth": 140,
+                  "format": "%",
+                  "damage_percentage": 4120,
+                  "damage_percentage_growth": 380,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2891
+                },
+                "1031202": {
+                  "main": 4510,
+                  "growth": 210,
+                  "format": "%",
+                  "damage_percentage": 11730,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 4510,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4509
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "后闪攻击失衡倍率",
+              "desc": "{Skill:1031204, Prop:1002}",
+              "param": {
+                "1031204": {
+                  "main": 6000,
+                  "growth": 280,
+                  "format": "%",
+                  "damage_percentage": 6000,
+                  "damage_percentage_growth": 550,
+                  "stun_ratio": 6000,
+                  "stun_ratio_growth": 280,
+                  "sp_recovery": 21590,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 82500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2999
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "冲刺攻击：为所欲为",
+          "param": [
+            {
+              "name": "前闪攻击伤害倍率",
+              "desc": "{Skill:1031201, Prop:1001} + {{Skill:1031203, Prop:1001}/13}*13",
+              "param": {
+                "1031201": {
+                  "main": 4120,
+                  "growth": 380,
+                  "format": "%",
+                  "damage_percentage": 4120,
+                  "damage_percentage_growth": 380,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2891
+                },
+                "1031203": {
+                  "main": 11730,
+                  "growth": 1070,
+                  "format": "%",
+                  "damage_percentage": 11730,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 4510,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 12129,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4509
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "前闪攻击失衡倍率",
+              "desc": "{Skill:1031201, Prop:1002} + {{Skill:1031203, Prop:1002}/13}*13",
+              "param": {
+                "1031201": {
+                  "main": 2900,
+                  "growth": 140,
+                  "format": "%",
+                  "damage_percentage": 4120,
+                  "damage_percentage_growth": 380,
+                  "stun_ratio": 2900,
+                  "stun_ratio_growth": 140,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2891
+                },
+                "1031203": {
+                  "main": 4510,
+                  "growth": 210,
+                  "format": "%",
+                  "damage_percentage": 11730,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 4510,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 10200,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 78100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 12129,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4509
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "闪避反击：牵制炮击",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{{Skill:1031205, Prop:1001} + {Skill:1031206, Prop:1001}}",
+              "param": {
+                "1031205": {
+                  "main": 9120,
+                  "growth": 830,
+                  "format": "%",
+                  "damage_percentage": 9120,
+                  "damage_percentage_growth": 830,
+                  "stun_ratio": 8170,
+                  "stun_ratio_growth": 380,
+                  "sp_recovery": 22790,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10665
+                },
+                "1031206": {
+                  "main": 9120,
+                  "growth": 830,
+                  "format": "%",
+                  "damage_percentage": 9120,
+                  "damage_percentage_growth": 830,
+                  "stun_ratio": 8170,
+                  "stun_ratio_growth": 380,
+                  "sp_recovery": 19190,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10665
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{{Skill:1031205, Prop:1002} + {Skill:1031206, Prop:1002}}",
+              "param": {
+                "1031205": {
+                  "main": 8170,
+                  "growth": 380,
+                  "format": "%",
+                  "damage_percentage": 9120,
+                  "damage_percentage_growth": 830,
+                  "stun_ratio": 8170,
+                  "stun_ratio_growth": 380,
+                  "sp_recovery": 22790,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10665
+                },
+                "1031206": {
+                  "main": 8170,
+                  "growth": 380,
+                  "format": "%",
+                  "damage_percentage": 9120,
+                  "damage_percentage_growth": 830,
+                  "stun_ratio": 8170,
+                  "stun_ratio_growth": 380,
+                  "sp_recovery": 19190,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 10665
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100115": 2
+        },
+        "2": {
+          "10": 3000,
+          "100115": 3
+        },
+        "3": {
+          "10": 6000,
+          "100125": 2
+        },
+        "4": {
+          "10": 9000,
+          "100125": 3
+        },
+        "5": {
+          "10": 12000,
+          "100125": 4
+        },
+        "6": {
+          "10": 18000,
+          "100125": 6
+        },
+        "7": {
+          "10": 45000,
+          "100135": 5
+        },
+        "8": {
+          "10": 67500,
+          "100135": 8
+        },
+        "9": {
+          "10": 90000,
+          "100135": 10
+        },
+        "10": {
+          "10": 112500,
+          "100135": 12
+        },
+        "11": {
+          "10": 135000,
+          "100135": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "special": {
+      "description": [
+        {
+          "name": "特殊技：糖衣炮弹",
+          "desc": "点按 <IconMap:Icon_Special> 发动：\n对前方敌人发动远程打击，造成<color=#FE437E>以太伤害</color>；\n招式发动期间抗打断等级提升；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "强化特殊技：夹心糖衣炮弹",
+          "desc": "能量足够时，点按 <IconMap:Icon_SpecialReady> 发动：\n对前方敌人发动强力远程打击，并在目标处生成能量场，持续牵引敌人，造成<color=#FE437E>以太伤害</color>；\n长按 <IconMap:Icon_SpecialReady> 可以进行蓄力，在炮口生成小型能量场，持续消耗能量并对近处的敌人造成额外伤害；\n招式发动期间拥有无敌效果；\n招式命中敌人时，将触发<color=#FFFFFF>[快速支援]</color>；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "特殊技：糖衣炮弹",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{{Skill:1031101, Prop:1001} + {Skill:1031102, Prop:1001}}",
+              "param": {
+                "1031101": {
+                  "main": 2630,
+                  "growth": 240,
+                  "format": "%",
+                  "damage_percentage": 2630,
+                  "damage_percentage_growth": 240,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 72325,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 2624,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2625
+                },
+                "1031102": {
+                  "main": 2630,
+                  "growth": 240,
+                  "format": "%",
+                  "damage_percentage": 2630,
+                  "damage_percentage_growth": 240,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 72325,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 2624,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2625
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{{Skill:1031101, Prop:1002} + {Skill:1031102, Prop:1002}}",
+              "param": {
+                "1031101": {
+                  "main": 2500,
+                  "growth": 120,
+                  "format": "%",
+                  "damage_percentage": 2630,
+                  "damage_percentage_growth": 240,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 72325,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 2624,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2625
+                },
+                "1031102": {
+                  "main": 2500,
+                  "growth": 120,
+                  "format": "%",
+                  "damage_percentage": 2630,
+                  "damage_percentage_growth": 240,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 72325,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 2624,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2625
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "强化特殊技：夹心糖衣炮弹",
+          "param": [
+            {
+              "name": "蓄力伤害倍率",
+              "desc": "{Skill:1031103, Prop:1001}",
+              "param": {
+                "1031103": {
+                  "main": 21500,
+                  "growth": 1960,
+                  "format": "%",
+                  "damage_percentage": 21500,
+                  "damage_percentage_growth": 1960,
+                  "stun_ratio": 17980,
+                  "stun_ratio_growth": 820,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 688050,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19735,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7418
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "炮击伤害倍率",
+              "desc": "{{Skill:1031104, Prop:1001} + {Skill:1031105, Prop:1001}}",
+              "param": {
+                "1031104": {
+                  "main": 10750,
+                  "growth": 980,
+                  "format": "%",
+                  "damage_percentage": 10750,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 8990,
+                  "stun_ratio_growth": 410,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 344025,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9867,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 3709
+                },
+                "1031105": {
+                  "main": 10750,
+                  "growth": 980,
+                  "format": "%",
+                  "damage_percentage": 10750,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 8990,
+                  "stun_ratio_growth": 410,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 344025,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9867,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 3709
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场伤害倍率",
+              "desc": "{Skill:1031106, Prop:1001}",
+              "param": {
+                "1031106": {
+                  "main": 38700,
+                  "growth": 3520,
+                  "format": "%",
+                  "damage_percentage": 38700,
+                  "damage_percentage_growth": 3520,
+                  "stun_ratio": 32360,
+                  "stun_ratio_growth": 1480,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1376100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 39471,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 14835
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "蓄力失衡倍率",
+              "desc": "{Skill:1031103, Prop:1002}",
+              "param": {
+                "1031103": {
+                  "main": 17980,
+                  "growth": 820,
+                  "format": "%",
+                  "damage_percentage": 21500,
+                  "damage_percentage_growth": 1960,
+                  "stun_ratio": 17980,
+                  "stun_ratio_growth": 820,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 688050,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19735,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7418
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "炮击失衡倍率",
+              "desc": "{{Skill:1031104, Prop:1002} + {Skill:1031105, Prop:1002}}",
+              "param": {
+                "1031104": {
+                  "main": 8990,
+                  "growth": 410,
+                  "format": "%",
+                  "damage_percentage": 10750,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 8990,
+                  "stun_ratio_growth": 410,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 344025,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9867,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 3709
+                },
+                "1031105": {
+                  "main": 8990,
+                  "growth": 410,
+                  "format": "%",
+                  "damage_percentage": 10750,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 8990,
+                  "stun_ratio_growth": 410,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 344025,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9867,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 3709
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场失衡倍率",
+              "desc": "{Skill:1031106, Prop:1002}",
+              "param": {
+                "1031106": {
+                  "main": 32360,
+                  "growth": 1480,
+                  "format": "%",
+                  "damage_percentage": 38700,
+                  "damage_percentage_growth": 3520,
+                  "stun_ratio": 32360,
+                  "stun_ratio_growth": 1480,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1376100,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 39471,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 14835
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "蓄力能量消耗",
+              "desc": "20点/秒",
+              "potential": []
+            },
+            {
+              "name": "炮击能量消耗",
+              "desc": "60点",
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100115": 2
+        },
+        "2": {
+          "10": 3000,
+          "100115": 3
+        },
+        "3": {
+          "10": 6000,
+          "100125": 2
+        },
+        "4": {
+          "10": 9000,
+          "100125": 3
+        },
+        "5": {
+          "10": 12000,
+          "100125": 4
+        },
+        "6": {
+          "10": 18000,
+          "100125": 6
+        },
+        "7": {
+          "10": 45000,
+          "100135": 5
+        },
+        "8": {
+          "10": 67500,
+          "100135": 8
+        },
+        "9": {
+          "10": 90000,
+          "100135": 10
+        },
+        "10": {
+          "10": 112500,
+          "100135": 12
+        },
+        "11": {
+          "10": 135000,
+          "100135": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "chain": {
+      "description": [
+        {
+          "name": "连携技：高价以太爆弹",
+          "desc": "触发<color=#FFFFFF>[连携技]</color>时，选择对应角色发动：\n对前方小范围敌人发动强力远程打击，并在目标处生成能量场，持续牵引周围敌人，造成<color=#FE437E>以太伤害</color>；\n招式发动期间拥有无敌效果；\n招式命中敌人时，将触发<color=#FFFFFF>[快速支援]</color>；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "终结技：特制以太榴弹",
+          "desc": "喧响等级达到<color=#FFFFFF>[极]</color>时，点按 <IconMap:Icon_UltimateReady> 发动：\n对前方小范围敌人发动强力远程打击，并在目标处生成能量场，持续牵引周围敌人，造成<color=#FE437E>以太伤害</color>；\n招式发动时，队伍中其他角色回复10点能量，下一名换入前场的角色额外回复20点能量；\n招式发动期间拥有无敌效果；\n招式命中敌人时，将触发<color=#FFFFFF>[快速支援]</color>；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "连携技：高价以太爆弹",
+          "param": [
+            {
+              "name": "炮击伤害倍率",
+              "desc": "{{Skill:1031301, Prop:1001} + {Skill:1031302, Prop:1001}}",
+              "param": {
+                "1031301": {
+                  "main": 10480,
+                  "growth": 960,
+                  "format": "%",
+                  "damage_percentage": 10480,
+                  "damage_percentage_growth": 960,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 434500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 6489,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2500
+                },
+                "1031302": {
+                  "main": 10480,
+                  "growth": 960,
+                  "format": "%",
+                  "damage_percentage": 10480,
+                  "damage_percentage_growth": 960,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 434500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 6489,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2500
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场伤害倍率",
+              "desc": "{Skill:1031303, Prop:1001}",
+              "param": {
+                "1031303": {
+                  "main": 28300,
+                  "growth": 2580,
+                  "format": "%",
+                  "damage_percentage": 28300,
+                  "damage_percentage_growth": 2580,
+                  "stun_ratio": 6750,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1303500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19469,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7500
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "炮击失衡倍率",
+              "desc": "{{Skill:1031301, Prop:1002} + {Skill:1031302, Prop:1002}}",
+              "param": {
+                "1031301": {
+                  "main": 2500,
+                  "growth": 120,
+                  "format": "%",
+                  "damage_percentage": 10480,
+                  "damage_percentage_growth": 960,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 434500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 6489,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2500
+                },
+                "1031302": {
+                  "main": 2500,
+                  "growth": 120,
+                  "format": "%",
+                  "damage_percentage": 10480,
+                  "damage_percentage_growth": 960,
+                  "stun_ratio": 2500,
+                  "stun_ratio_growth": 120,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 434500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 6489,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2500
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场失衡倍率",
+              "desc": "{Skill:1031303, Prop:1002}",
+              "param": {
+                "1031303": {
+                  "main": 6750,
+                  "growth": 310,
+                  "format": "%",
+                  "damage_percentage": 28300,
+                  "damage_percentage_growth": 2580,
+                  "stun_ratio": 6750,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1303500,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19469,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7500
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "终结技：特制以太榴弹",
+          "param": [
+            {
+              "name": "炮击伤害倍率",
+              "desc": "{Skill:1031304, Prop:1001}",
+              "param": {
+                "1031304": {
+                  "main": 64680,
+                  "growth": 5880,
+                  "format": "%",
+                  "damage_percentage": 64680,
+                  "damage_percentage_growth": 5880,
+                  "stun_ratio": 3600,
+                  "stun_ratio_growth": 170,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3599,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 23600
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场伤害倍率",
+              "desc": "{Skill:1031305, Prop:1001}",
+              "param": {
+                "1031305": {
+                  "main": 87320,
+                  "growth": 7940,
+                  "format": "%",
+                  "damage_percentage": 87320,
+                  "damage_percentage_growth": 7940,
+                  "stun_ratio": 4860,
+                  "stun_ratio_growth": 230,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 5399,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 35400
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "炮击失衡倍率",
+              "desc": "{Skill:1031304, Prop:1002}",
+              "param": {
+                "1031304": {
+                  "main": 3600,
+                  "growth": 170,
+                  "format": "%",
+                  "damage_percentage": 64680,
+                  "damage_percentage_growth": 5880,
+                  "stun_ratio": 3600,
+                  "stun_ratio_growth": 170,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3599,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 23600
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "能量场失衡倍率",
+              "desc": "{Skill:1031305, Prop:1002}",
+              "param": {
+                "1031305": {
+                  "main": 4860,
+                  "growth": 230,
+                  "format": "%",
+                  "damage_percentage": 87320,
+                  "damage_percentage_growth": 7940,
+                  "stun_ratio": 4860,
+                  "stun_ratio_growth": 230,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 5399,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 35400
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100115": 2
+        },
+        "2": {
+          "10": 3000,
+          "100115": 3
+        },
+        "3": {
+          "10": 6000,
+          "100125": 2
+        },
+        "4": {
+          "10": 9000,
+          "100125": 3
+        },
+        "5": {
+          "10": 12000,
+          "100125": 4
+        },
+        "6": {
+          "10": 18000,
+          "100125": 6
+        },
+        "7": {
+          "10": 45000,
+          "100135": 5
+        },
+        "8": {
+          "10": 67500,
+          "100135": 8
+        },
+        "9": {
+          "10": 90000,
+          "100135": 10
+        },
+        "10": {
+          "10": 112500,
+          "100135": 12
+        },
+        "11": {
+          "10": 135000,
+          "100135": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "assist": {
+      "description": [
+        {
+          "name": "快速支援：救急炮击",
+          "desc": "当前操作中的角色被击飞时，点按 <IconMap:Icon_Switch> 发动：\n向后闪避，并对前方敌人发动远程打击，造成<color=#FE437E>以太伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后自动上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>，最多触发8次。",
+          "potential": []
+        },
+        {
+          "name": "招架支援：狡兔出手！",
+          "desc": "前场角色即将被攻击时，点按 <IconMap:Icon_Switch> 发动：\n招架敌人的攻击，累积大量失衡值；\n招式发动期间拥有无敌效果。",
+          "potential": []
+        },
+        {
+          "name": "支援突击：趁虚而入",
+          "desc": "发动<color=#FFFFFF>[招架支援]</color>后，点按 <IconMap:Icon_Normal> 发动：\n向前方突进后对敌人发动炮击，造成<color=#FE437E>以太伤害</color>；\n招式发动期间拥有无敌效果。",
+          "potential": []
+        },
+        {
+          "name": "快速支援：救急炮击",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{{Skill:1031401, Prop:1001} + {Skill:1031402, Prop:1001}}",
+              "param": {
+                "1031401": {
+                  "main": 3170,
+                  "growth": 290,
+                  "format": "%",
+                  "damage_percentage": 3170,
+                  "damage_percentage_growth": 290,
+                  "stun_ratio": 3170,
+                  "stun_ratio_growth": 150,
+                  "sp_recovery": 11400,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1583
+                },
+                "1031402": {
+                  "main": 3170,
+                  "growth": 290,
+                  "format": "%",
+                  "damage_percentage": 3170,
+                  "damage_percentage_growth": 290,
+                  "stun_ratio": 3170,
+                  "stun_ratio_growth": 150,
+                  "sp_recovery": 11400,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1583
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{{Skill:1031401, Prop:1002} + {Skill:1031402, Prop:1002}}",
+              "param": {
+                "1031401": {
+                  "main": 3170,
+                  "growth": 150,
+                  "format": "%",
+                  "damage_percentage": 3170,
+                  "damage_percentage_growth": 290,
+                  "stun_ratio": 3170,
+                  "stun_ratio_growth": 150,
+                  "sp_recovery": 11400,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1583
+                },
+                "1031402": {
+                  "main": 3170,
+                  "growth": 150,
+                  "format": "%",
+                  "damage_percentage": 3170,
+                  "damage_percentage_growth": 290,
+                  "stun_ratio": 3170,
+                  "stun_ratio_growth": 150,
+                  "sp_recovery": 11400,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 87175,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 3164,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 1583
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "招架支援：狡兔出手！",
+          "param": [
+            {
+              "name": "轻招架失衡倍率",
+              "desc": "{Skill:1031403, Prop:1002}",
+              "param": {
+                "1031403": {
+                  "main": 24670,
+                  "growth": 1130,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 24670,
+                  "stun_ratio_growth": 1130,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 36664
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "重招架失衡倍率",
+              "desc": "{Skill:1031404, Prop:1002}",
+              "param": {
+                "1031404": {
+                  "main": 31170,
+                  "growth": 1420,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 31170,
+                  "stun_ratio_growth": 1420,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 41664
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "连续招架失衡倍率",
+              "desc": "{Skill:1031405, Prop:1002}",
+              "param": {
+                "1031405": {
+                  "main": 15170,
+                  "growth": 690,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 15170,
+                  "stun_ratio_growth": 690,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 11664
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "支援突击：趁虚而入",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1031501, Prop:1001}",
+              "param": {
+                "1031501": {
+                  "main": 37710,
+                  "growth": 3430,
+                  "format": "%",
+                  "damage_percentage": 37710,
+                  "damage_percentage_growth": 3430,
+                  "stun_ratio": 33030,
+                  "stun_ratio_growth": 1510,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1165725,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 35367,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 18997
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1031501, Prop:1002}",
+              "param": {
+                "1031501": {
+                  "main": 33030,
+                  "growth": 1510,
+                  "format": "%",
+                  "damage_percentage": 37710,
+                  "damage_percentage_growth": 3430,
+                  "stun_ratio": 33030,
+                  "stun_ratio_growth": 1510,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1165725,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 35367,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 18997
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100115": 2
+        },
+        "2": {
+          "10": 3000,
+          "100115": 3
+        },
+        "3": {
+          "10": 6000,
+          "100125": 2
+        },
+        "4": {
+          "10": 9000,
+          "100125": 3
+        },
+        "5": {
+          "10": 12000,
+          "100125": 4
+        },
+        "6": {
+          "10": 18000,
+          "100125": 6
+        },
+        "7": {
+          "10": 45000,
+          "100135": 5
+        },
+        "8": {
+          "10": 67500,
+          "100135": 8
+        },
+        "9": {
+          "10": 90000,
+          "100135": 10
+        },
+        "10": {
+          "10": 112500,
+          "100135": 12
+        },
+        "11": {
+          "10": 135000,
+          "100135": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    }
+  },
+  "skill_list": {
+    "1031001": {
+      "name": "普通攻击：狡兔连打",
+      "desc": "<IconMap:Icon_Normal>",
+      "element_type": 200,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031002": {
+      "name": "普通攻击：为所欲为",
+      "desc": "<IconMap:Icon_Normal>（上弹后）",
+      "element_type": 200,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031003": {
+      "name": "特殊技：糖衣炮弹",
+      "desc": "<IconMap:Icon_Special>",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031004": {
+      "name": "强化特殊技：夹心糖衣炮弹",
+      "desc": "<IconMap:Icon_SpecialReady>（可长按）",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031005": {
+      "name": "闪避上弹",
+      "desc": "<IconMap:Icon_Evade>（任意方向）（长按）",
+      "element_type": 0,
+      "hit_type": 0,
+      "potential": []
+    },
+    "1031006": {
+      "name": "冲刺攻击：惊喜开箱·散射",
+      "desc": "<IconMap:Icon_Evade>（任意方向） ; <IconMap:Icon_Normal>",
+      "element_type": 200,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031007": {
+      "name": "冲刺攻击：惊喜开箱·集中",
+      "desc": "<IconMap:Icon_Evade> ; <IconMap:Icon_Normal>",
+      "element_type": 200,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031008": {
+      "name": "闪避反击：牵制炮击",
+      "desc": "<IconMap:Icon_Evade>（极限） ; <IconMap:Icon_Normal>",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031009": {
+      "name": "连携技：高价以太爆弹",
+      "desc": "<IconMap:Icon_QTE>",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031010": {
+      "name": "终结技：特制以太榴弹",
+      "desc": "<IconMap:Icon_UltimateReady>",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031011": {
+      "name": "快速支援：救急炮击",
+      "desc": "<IconMap:Icon_Switch>（触发快速支援时）",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    },
+    "1031012": {
+      "name": "招架支援：狡兔出手！",
+      "desc": "<IconMap:Icon_Switch>（触发招架支援时）",
+      "element_type": 0,
+      "hit_type": 0,
+      "potential": []
+    },
+    "1031013": {
+      "name": "支援突击：趁虚而入",
+      "desc": "<IconMap:Icon_Normal>（发动招架支援后）",
+      "element_type": 205,
+      "hit_type": 102,
+      "potential": []
+    }
+  },
+  "passive": {
+    "level": {
+      "1031501": {
+        "level": 1,
+        "id": 1031501,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>20%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031502": {
+        "level": 2,
+        "id": 1031502,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>25%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031503": {
+        "level": 3,
+        "id": 1031503,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>30%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031504": {
+        "level": 4,
+        "id": 1031504,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>34%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031505": {
+        "level": 5,
+        "id": 1031505,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>36%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031506": {
+        "level": 6,
+        "id": 1031506,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>38%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1031507": {
+        "level": 7,
+        "id": 1031507,
+        "name": [
+          "核心被动：机关箱",
+          "额外能力：狡兔三窟"
+        ],
+        "desc": [
+          "妮可在<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>等招式中，上弹并强化<color=#FFFFFF>[普通攻击]</color>与<color=#FFFFFF>[冲刺攻击]</color>；强化子弹或能量场命中敌人时，目标的防御力降低<color=#2BAD00>40%</color>，持续3.5秒。",
+          "队伍中存在与自身属性或阵营相同的角色时触发：\n妮可通过<color=#FFFFFF>[核心被动：机关箱]</color>对敌人施加减益效果时，所有单位对目标造成的<color=#FE437E>以太伤害</color>额外提升25%，持续3.5秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      }
+    },
+    "materials": {
+      "1": {
+        "10": 5000
+      },
+      "2": {
+        "10": 12000,
+        "110501": 2
+      },
+      "3": {
+        "10": 28000,
+        "110501": 4
+      },
+      "4": {
+        "10": 60000,
+        "110001": 2,
+        "110501": 9
+      },
+      "5": {
+        "10": 100000,
+        "110001": 3,
+        "110501": 15
+      },
+      "6": {
+        "10": 200000,
+        "110001": 4,
+        "110501": 30
+      }
+    }
+  },
+  "talent": {
+    "1": {
+      "level": 1,
+      "name": "增压强化弹",
+      "desc": "<color=#FFFFFF>[强化特殊技]</color>造成的伤害和累积的属性异常积蓄值提升16%；发动<color=#FFFFFF>[强化特殊技]</color>时，每多蓄力0.1秒，在目标处生成的能量场持续时间提升0.15秒。",
+      "desc2": "「你们都被我强化了，赶紧上！」\n「什么，我、我才没有想趁机逃跑，只是需要休息下而已！」"
+    },
+    "2": {
+      "level": 2,
+      "name": "聚能装置",
+      "desc": "触发<color=#FFFFFF>[核心被动：机关箱]</color>的减益效果时，妮可回复5点能量，15秒内最多触发一次。",
+      "desc2": "「不要小看增加的这一秒钟！」\n「你知道这一秒内，我能产生多少价值吗？那可是数都数不清！」\n「所以，我再多要10％的补贴，不过分吧？」"
+    },
+    "3": {
+      "level": 3,
+      "name": "狡兔智慧",
+      "desc": "<color=#FFFFFF>[普通攻击]</color>、<color=#FFFFFF>[闪避]</color>、<color=#FFFFFF>[支援技]</color>、<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[连携技]</color> 技能等级+2",
+      "desc2": "既没有卓绝的武力，也没有丰厚的资源，妮可能把狡兔屋运营至今靠的是灵活的头脑。"
+    },
+    "4": {
+      "level": 4,
+      "name": "领域扩增",
+      "desc": "妮可发动<color=#FFFFFF>[强化特殊技]</color>、<color=#FFFFFF>[连携技]</color>、<color=#FFFFFF>[终结技]</color>时，在目标处生成的能量场攻击范围提升，直径增加3米。",
+      "desc2": "「这里，还有这里，以后都会成为狡兔屋的领域，你听明白了吗！」\n「什么，你问多久之后？」\n「呃…按照我们现在的营收状况，也就10000年左右吧！」"
+    },
+    "5": {
+      "level": 5,
+      "name": "业界红人",
+      "desc": "<color=#FFFFFF>[普通攻击]</color>、<color=#FFFFFF>[闪避]</color>、<color=#FFFFFF>[支援技]</color>、<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[连携技]</color> 技能等级+2",
+      "desc2": "虽然在业界仇人众多，但妮可还是屡次率领部下们从九死一生的险境里生还，狡兔屋的名气和经验也因此稳步提升。"
+    },
+    "6": {
+      "level": 6,
+      "name": "侵蚀能量场",
+      "desc": "能量场对敌人造成伤害时，所有单位对该目标的暴击率提升1.5%，最多叠加10层，持续12秒，每层效果单独结算持续时间。",
+      "desc2": "选用更高级的机关弹药，装药量和浓缩以太物质含量均有所提高，更强的伤害、更长的持续时间…更贵的价格。"
+    }
+  },
+  "fairy_recommend": {
+    "slot4": 32300,
+    "slot2": 31600,
+    "slot_sub": 31000,
+    "part4": {
+      "prop": 20103,
+      "name": "暴击率",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconCrit.png"
+    },
+    "part5": {
+      "prop": 31903,
+      "name": "以太伤害加成",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconGeneralBuff/Packer/IconDungeonBuffEther.png"
+    },
+    "part6": {
+      "prop": 30502,
+      "name": "能量自动回复",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconSpRecover.png"
+    },
+    "part_sub": {
+      "prop": 12102,
+      "name": "攻击力",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconAttack.png"
+    }
+  },
+  "strategy": [
+    "04",
+    "<IconMap:Icon_GeneralBuff_DungeonBuffEther>以太属性，泛用型支援",
+    "聚怪减防增益"
+  ],
+  "potential": [],
+  "potential_detail": {}
+}

--- a/data/source/raw/nanoka/zzz/2.8/zh/character/1221.json
+++ b/data/source/raw/nanoka/zzz/2.8/zh/character/1221.json
@@ -1,0 +1,2087 @@
+{
+  "id": 1221,
+  "icon": "IconRole31",
+  "name": "柳",
+  "code_name": "Yanagi",
+  "rarity": 4,
+  "weapon_type": {
+    "3": "异常"
+  },
+  "element_type": {
+    "203": "电属性"
+  },
+  "special_element_type": {},
+  "hit_type": {
+    "101": "斩击"
+  },
+  "camp": {
+    "6": "对空洞特别行动部第六课"
+  },
+  "gender": 2,
+  "partner_info": {
+    "birthday": "9/21",
+    "full_name": "月城柳",
+    "gender": "女",
+    "icon_path": "UI/Sprite/A1DynamicLoad/IconRoleCircle/UnPacker/IconRoleCircle31.png",
+    "impression_f": "Fairy这是从哪里搞来的情报，原来那么完美的柳竟然也会有迷糊的时候吗！能不能详细讲讲？",
+    "impression_m": "怎么说呢…从这些内容来看，六课没了柳好像真的会散架。",
+    "profile_desc": "月城柳，对空洞事务特别行动部第六课所属副课长兼情报官。\n主要负责六课的人事管理、任务跟进与反馈、情报收集和现场支援等工作。\n与此同时，月城柳还是六课成员苍角的「保护者」。除了在日常生活上对苍角进行照顾之外，柳还需要对苍角在工作中的一切行为负责。\n\n六课课长星见雅性格较为特殊，成员浅羽悠真总是过于散漫随性，成员苍角在心性上还是个大大咧咧的「孩子」——综合以上原因，六课绝大多数工作安排都落在了月城柳的肩上。\n严谨认真，办事一丝不苟的月城柳，某种意义上算是六课唯一的「正常人」。也正是由于她的引导与指挥，才促使六课三名主要外勤队员的「武力」转变为「战斗力」。\n整体来看，月城柳是一位综合能力超群，处理事物利落高效的优秀执行官。\n但根据部分信息判断，月城柳在生活中似乎也会有迷糊的一面。",
+    "role_icon": "IconRole/UnPacker/IconRole31",
+    "stature": "169",
+    "unlock_condition": [
+      "获得代理人",
+      "完成主线：「悠然插曲·意外的新顾客」（主线第四章完成后开启）后解锁",
+      "完成独家视界「虚拟杀机」",
+      "完成委托「安比的困扰」"
+    ],
+    "trust_lv": {
+      "1": "月城柳，对空洞事务特别行动部第六课所属副课长兼情报官。\n主要负责六课的人事管理、任务跟进与反馈、情报收集和现场支援等工作。\n与此同时，月城柳还是六课成员苍角的「保护者」。除了在日常生活上对苍角进行照顾之外，柳还需要对苍角在工作中的一切行为负责。\n\n六课课长星见雅性格较为特殊，成员浅羽悠真总是过于散漫随性，成员苍角在心性上还是个大大咧咧的「孩子」——综合以上原因，六课绝大多数工作安排都落在了月城柳的肩上。\n严谨认真，办事一丝不苟的月城柳，某种意义上算是六课唯一的「正常人」。也正是由于她的引导与指挥，才促使六课三名主要外勤队员的「武力」转变为「战斗力」。\n整体来看，月城柳是一位综合能力超群，处理事物利落高效的优秀执行官。\n但根据部分信息判断，月城柳在生活中似乎也会有迷糊的一面。",
+      "2": "",
+      "3": "由于多年前的一场意外，月城柳体内流淌着一部分不属于她自己的血液。",
+      "4": ""
+    }
+  },
+  "skin": {
+    "3112210": {
+      "name": "月城柳·月影流华",
+      "desc": "反光镜片也难掩副课长眼底的清明，因为她需要时刻关注一位沉迷修行的武者，一位消极怠工的斥候，以及一位容易吃坏肚子的小朋友。",
+      "image": "IconRole31"
+    }
+  },
+  "stats": {
+    "armor": 0,
+    "armor_growth": 0,
+    "attack": 126,
+    "attack_growth": 75860,
+    "avatar_piece_id": 5221,
+    "break_stun": 86,
+    "crit": 500,
+    "crit_damage": 5000,
+    "crit_dmg_res": 0,
+    "crit_res": 0,
+    "defence": 49,
+    "defence_growth": 66882,
+    "element_abnormal_power": 112,
+    "element_mystery": 114,
+    "endurance": 0,
+    "hp_growth": 849779,
+    "hp_max": 626,
+    "pen_delta": 0,
+    "pen_rate": 0,
+    "rbl": 1,
+    "rbl_correction_factor": 10000,
+    "rbl_probability": 0,
+    "shield": 0,
+    "shield_growth": 0,
+    "sp_bar_point": 120,
+    "sp_recover": 120,
+    "stun": 0,
+    "tags": [
+      "Yanagi",
+      "Cut",
+      "Electric",
+      "Female",
+      "Camp6",
+      "Size3",
+      "AidTypeParry",
+      "Yanagi",
+      "EtherEyesSize3"
+    ],
+    "rp_max": 0,
+    "rp_recover": 0
+  },
+  "level": {
+    "1": {
+      "hp_max": 0,
+      "attack": 0,
+      "defence": 0,
+      "level_max": 10,
+      "level_min": 0,
+      "materials": {
+        "10": 24000,
+        "100213": 4
+      }
+    },
+    "2": {
+      "hp_max": 430,
+      "attack": 45,
+      "defence": 34,
+      "level_max": 20,
+      "level_min": 10,
+      "materials": {
+        "10": 56000,
+        "100223": 12
+      }
+    },
+    "3": {
+      "hp_max": 859,
+      "attack": 90,
+      "defence": 68,
+      "level_max": 30,
+      "level_min": 20,
+      "materials": {
+        "10": 120000,
+        "100223": 20
+      }
+    },
+    "4": {
+      "hp_max": 1289,
+      "attack": 134,
+      "defence": 101,
+      "level_max": 40,
+      "level_min": 30,
+      "materials": {
+        "10": 200000,
+        "100233": 10
+      }
+    },
+    "5": {
+      "hp_max": 1719,
+      "attack": 179,
+      "defence": 135,
+      "level_max": 50,
+      "level_min": 40,
+      "materials": {
+        "10": 400000,
+        "100233": 20
+      }
+    },
+    "6": {
+      "hp_max": 2149,
+      "attack": 224,
+      "defence": 169,
+      "level_max": 60,
+      "level_min": 50,
+      "materials": {}
+    }
+  },
+  "extra_level": {
+    "1": {
+      "max_level": 15,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 0
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 12
+        }
+      }
+    },
+    "2": {
+      "max_level": 25,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 25
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 12
+        }
+      }
+    },
+    "3": {
+      "max_level": 35,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 25
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 24
+        }
+      }
+    },
+    "4": {
+      "max_level": 45,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 50
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 24
+        }
+      }
+    },
+    "5": {
+      "max_level": 55,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 50
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 36
+        }
+      }
+    },
+    "6": {
+      "max_level": 60,
+      "extra": {
+        "12101": {
+          "prop": 12101,
+          "name": "基础攻击力",
+          "format": "{0:0.#}",
+          "value": 75
+        },
+        "31401": {
+          "prop": 31401,
+          "name": "异常掌控",
+          "format": "{0:0.#}",
+          "value": 36
+        }
+      }
+    }
+  },
+  "level_exp": [
+    50,
+    150,
+    250,
+    400,
+    600,
+    800,
+    1000,
+    1250,
+    1500,
+    1800,
+    1935,
+    2065,
+    2200,
+    2335,
+    2465,
+    2600,
+    2735,
+    2865,
+    3000,
+    4680,
+    4975,
+    5265,
+    5560,
+    5855,
+    6145,
+    6440,
+    6735,
+    7025,
+    7320,
+    10800,
+    11400,
+    12000,
+    12600,
+    13200,
+    13800,
+    14400,
+    15000,
+    15600,
+    16200,
+    17100,
+    18300,
+    19500,
+    20700,
+    21900,
+    23100,
+    24300,
+    25500,
+    26700,
+    27900,
+    34200,
+    36600,
+    39000,
+    41400,
+    43800,
+    46200,
+    48600,
+    51000,
+    53400,
+    55800,
+    0
+  ],
+  "skill": {
+    "basic": {
+      "description": [
+        {
+          "name": "普通攻击：夜见尊神乐",
+          "desc": "月城柳拥有<color=#FFFFFF>[上弦]</color>和<color=#FFFFFF>[下弦]</color>两种架势；\n点按 <IconMap:Icon_Normal> 发动：\n根据当前架势，向前方进行至多五段的斩击，造成<color=#F0D12B>物理伤害</color>和<color=#2EB6FF>电属性伤害</color>；\n在战斗中，月城柳可根据当前架势类型获得对应的架势增益：\n<color=#FFFFFF>[上弦]</color>架势增益：自身造成的<color=#2EB6FF>电属性伤害</color>提升10%，<color=#FFFFFF>[普通攻击]</color>发动期间抗打断等级提升；\n<color=#FFFFFF>[下弦]</color>架势增益：自身穿透率提升10%，<color=#FFFFFF>[普通攻击]</color>的打断等级提升；\n架势切换后，月城柳仍可继续保有上一架势的架势增益，持续8秒。",
+          "potential": []
+        },
+        {
+          "name": "架势：上弦",
+          "param": [
+            {
+              "name": "一段伤害倍率",
+              "desc": "{Skill:1221001, Prop:1001}",
+              "param": {
+                "1221001": {
+                  "main": 5660,
+                  "growth": 520,
+                  "format": "%",
+                  "damage_percentage": 5660,
+                  "damage_percentage_growth": 520,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10090,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 69575,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2801
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段伤害倍率",
+              "desc": "{Skill:1221002, Prop:1001}",
+              "param": {
+                "1221002": {
+                  "main": 9970,
+                  "growth": 910,
+                  "format": "%",
+                  "damage_percentage": 9970,
+                  "damage_percentage_growth": 910,
+                  "stun_ratio": 6810,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 24740,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 170225,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6871
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段伤害倍率",
+              "desc": "{Skill:1221003, Prop:1001}",
+              "param": {
+                "1221003": {
+                  "main": 11310,
+                  "growth": 1030,
+                  "format": "%",
+                  "damage_percentage": 11310,
+                  "damage_percentage_growth": 1030,
+                  "stun_ratio": 6940,
+                  "stun_ratio_growth": 320,
+                  "sp_recovery": 25220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 173525,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7991,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7004
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "四段伤害倍率",
+              "desc": "{Skill:1221004, Prop:1001}",
+              "param": {
+                "1221004": {
+                  "main": 12660,
+                  "growth": 1160,
+                  "format": "%",
+                  "damage_percentage": 12660,
+                  "damage_percentage_growth": 1160,
+                  "stun_ratio": 7760,
+                  "stun_ratio_growth": 360,
+                  "sp_recovery": 28220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 194150,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 8942,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7837
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "五段伤害倍率",
+              "desc": "{Skill:1221005, Prop:1001}",
+              "param": {
+                "1221005": {
+                  "main": 23690,
+                  "growth": 2160,
+                  "format": "%",
+                  "damage_percentage": 23690,
+                  "damage_percentage_growth": 2160,
+                  "stun_ratio": 14520,
+                  "stun_ratio_growth": 660,
+                  "sp_recovery": 52800,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 363000,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 16735,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 14667
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "一段失衡倍率",
+              "desc": "{Skill:1221001, Prop:1002}",
+              "param": {
+                "1221001": {
+                  "main": 2780,
+                  "growth": 130,
+                  "format": "%",
+                  "damage_percentage": 5660,
+                  "damage_percentage_growth": 520,
+                  "stun_ratio": 2780,
+                  "stun_ratio_growth": 130,
+                  "sp_recovery": 10090,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 69575,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 2801
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段失衡倍率",
+              "desc": "{Skill:1221002, Prop:1002}",
+              "param": {
+                "1221002": {
+                  "main": 6810,
+                  "growth": 310,
+                  "format": "%",
+                  "damage_percentage": 9970,
+                  "damage_percentage_growth": 910,
+                  "stun_ratio": 6810,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 24740,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 170225,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6871
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段失衡倍率",
+              "desc": "{Skill:1221003, Prop:1002}",
+              "param": {
+                "1221003": {
+                  "main": 6940,
+                  "growth": 320,
+                  "format": "%",
+                  "damage_percentage": 11310,
+                  "damage_percentage_growth": 1030,
+                  "stun_ratio": 6940,
+                  "stun_ratio_growth": 320,
+                  "sp_recovery": 25220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 173525,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7991,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7004
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "四段失衡倍率",
+              "desc": "{Skill:1221004, Prop:1002}",
+              "param": {
+                "1221004": {
+                  "main": 7760,
+                  "growth": 360,
+                  "format": "%",
+                  "damage_percentage": 12660,
+                  "damage_percentage_growth": 1160,
+                  "stun_ratio": 7760,
+                  "stun_ratio_growth": 360,
+                  "sp_recovery": 28220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 194150,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 8942,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 7837
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "五段失衡倍率",
+              "desc": "{Skill:1221005, Prop:1002}",
+              "param": {
+                "1221005": {
+                  "main": 14520,
+                  "growth": 660,
+                  "format": "%",
+                  "damage_percentage": 23690,
+                  "damage_percentage_growth": 2160,
+                  "stun_ratio": 14520,
+                  "stun_ratio_growth": 660,
+                  "sp_recovery": 52800,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 363000,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 16735,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 14667
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "架势：下弦",
+          "param": [
+            {
+              "name": "一段伤害倍率",
+              "desc": "{Skill:1221006, Prop:1001}",
+              "param": {
+                "1221006": {
+                  "main": 11310,
+                  "growth": 1030,
+                  "format": "%",
+                  "damage_percentage": 11310,
+                  "damage_percentage_growth": 1030,
+                  "stun_ratio": 5550,
+                  "stun_ratio_growth": 260,
+                  "sp_recovery": 20170,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 138875,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 5603
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段伤害倍率",
+              "desc": "{Skill:1221007, Prop:1001}",
+              "param": {
+                "1221007": {
+                  "main": 12920,
+                  "growth": 1180,
+                  "format": "%",
+                  "damage_percentage": 12920,
+                  "damage_percentage_growth": 1180,
+                  "stun_ratio": 9310,
+                  "stun_ratio_growth": 430,
+                  "sp_recovery": 33850,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 232925,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 9401
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段伤害倍率",
+              "desc": "{Skill:1221008, Prop:1001}",
+              "param": {
+                "1221008": {
+                  "main": 7280,
+                  "growth": 670,
+                  "format": "%",
+                  "damage_percentage": 7280,
+                  "damage_percentage_growth": 670,
+                  "stun_ratio": 4460,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 16220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 111650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 5138,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4504
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "四段伤害倍率",
+              "desc": "{Skill:1221009, Prop:1001}",
+              "param": {
+                "1221009": {
+                  "main": 10770,
+                  "growth": 980,
+                  "format": "%",
+                  "damage_percentage": 10770,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 6610,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 24010,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 165275,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7607,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6667
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "五段伤害倍率",
+              "desc": "{Skill:1221010, Prop:1001}",
+              "param": {
+                "1221010": {
+                  "main": 27180,
+                  "growth": 2480,
+                  "format": "%",
+                  "damage_percentage": 27180,
+                  "damage_percentage_growth": 2480,
+                  "stun_ratio": 16670,
+                  "stun_ratio_growth": 760,
+                  "sp_recovery": 60590,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 416625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19204,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 16831
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "一段失衡倍率",
+              "desc": "{Skill:1221006, Prop:1002}",
+              "param": {
+                "1221006": {
+                  "main": 5550,
+                  "growth": 260,
+                  "format": "%",
+                  "damage_percentage": 11310,
+                  "damage_percentage_growth": 1030,
+                  "stun_ratio": 5550,
+                  "stun_ratio_growth": 260,
+                  "sp_recovery": 20170,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 138875,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 5603
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "二段失衡倍率",
+              "desc": "{Skill:1221007, Prop:1002}",
+              "param": {
+                "1221007": {
+                  "main": 9310,
+                  "growth": 430,
+                  "format": "%",
+                  "damage_percentage": 12920,
+                  "damage_percentage_growth": 1180,
+                  "stun_ratio": 9310,
+                  "stun_ratio_growth": 430,
+                  "sp_recovery": 33850,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 232925,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 9401
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "三段失衡倍率",
+              "desc": "{Skill:1221008, Prop:1002}",
+              "param": {
+                "1221008": {
+                  "main": 4460,
+                  "growth": 210,
+                  "format": "%",
+                  "damage_percentage": 7280,
+                  "damage_percentage_growth": 670,
+                  "stun_ratio": 4460,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 16220,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 111650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 5138,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4504
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "四段失衡倍率",
+              "desc": "{Skill:1221009, Prop:1002}",
+              "param": {
+                "1221009": {
+                  "main": 6610,
+                  "growth": 310,
+                  "format": "%",
+                  "damage_percentage": 10770,
+                  "damage_percentage_growth": 980,
+                  "stun_ratio": 6610,
+                  "stun_ratio_growth": 310,
+                  "sp_recovery": 24010,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 165275,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7607,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6667
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "五段失衡倍率",
+              "desc": "{Skill:1221010, Prop:1002}",
+              "param": {
+                "1221010": {
+                  "main": 16670,
+                  "growth": 760,
+                  "format": "%",
+                  "damage_percentage": 27180,
+                  "damage_percentage_growth": 2480,
+                  "stun_ratio": 16670,
+                  "stun_ratio_growth": 760,
+                  "sp_recovery": 60590,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 416625,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 19204,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 16831
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100113": 2
+        },
+        "2": {
+          "10": 3000,
+          "100113": 3
+        },
+        "3": {
+          "10": 6000,
+          "100123": 2
+        },
+        "4": {
+          "10": 9000,
+          "100123": 3
+        },
+        "5": {
+          "10": 12000,
+          "100123": 4
+        },
+        "6": {
+          "10": 18000,
+          "100123": 6
+        },
+        "7": {
+          "10": 45000,
+          "100133": 5
+        },
+        "8": {
+          "10": 67500,
+          "100133": 8
+        },
+        "9": {
+          "10": 90000,
+          "100133": 10
+        },
+        "10": {
+          "10": 112500,
+          "100133": 12
+        },
+        "11": {
+          "10": 135000,
+          "100133": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "dodge": {
+      "description": [
+        {
+          "name": "闪避：流岚",
+          "desc": "点按 <IconMap:Icon_Evade> 发动：\n快速的冲刺闪避；\n招式发动期间拥有无敌效果。",
+          "potential": []
+        },
+        {
+          "name": "冲刺攻击：飞掠",
+          "desc": "闪避时，点按 <IconMap:Icon_Normal> 发动：\n向前方进行斩击，造成<color=#F0D12B>物理伤害</color>。",
+          "potential": []
+        },
+        {
+          "name": "闪避反击：疾反",
+          "desc": "触发<color=#FFFFFF>[极限闪避]</color>后，点按 <IconMap:Icon_Normal> 发动：\n对前方敌人发动斩击，造成<color=#2EB6FF>电属性伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "冲刺攻击：飞掠",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221013, Prop:1001}",
+              "param": {
+                "1221013": {
+                  "main": 5040,
+                  "growth": 460,
+                  "format": "%",
+                  "damage_percentage": 5040,
+                  "damage_percentage_growth": 460,
+                  "stun_ratio": 4540,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 16500,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 113575,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4582
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221013, Prop:1002}",
+              "param": {
+                "1221013": {
+                  "main": 4540,
+                  "growth": 210,
+                  "format": "%",
+                  "damage_percentage": 5040,
+                  "damage_percentage_growth": 460,
+                  "stun_ratio": 4540,
+                  "stun_ratio_growth": 210,
+                  "sp_recovery": 16500,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 113575,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4582
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "闪避反击：疾反",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221014, Prop:1001}",
+              "param": {
+                "1221014": {
+                  "main": 23160,
+                  "growth": 2110,
+                  "format": "%",
+                  "damage_percentage": 23160,
+                  "damage_percentage_growth": 2110,
+                  "stun_ratio": 18320,
+                  "stun_ratio_growth": 840,
+                  "sp_recovery": 30620,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 210650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7652,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 23504
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221014, Prop:1002}",
+              "param": {
+                "1221014": {
+                  "main": 18320,
+                  "growth": 840,
+                  "format": "%",
+                  "damage_percentage": 23160,
+                  "damage_percentage_growth": 2110,
+                  "stun_ratio": 18320,
+                  "stun_ratio_growth": 840,
+                  "sp_recovery": 30620,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 210650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7652,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 23504
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100113": 2
+        },
+        "2": {
+          "10": 3000,
+          "100113": 3
+        },
+        "3": {
+          "10": 6000,
+          "100123": 2
+        },
+        "4": {
+          "10": 9000,
+          "100123": 3
+        },
+        "5": {
+          "10": 12000,
+          "100123": 4
+        },
+        "6": {
+          "10": 18000,
+          "100123": 6
+        },
+        "7": {
+          "10": 45000,
+          "100133": 5
+        },
+        "8": {
+          "10": 67500,
+          "100133": 8
+        },
+        "9": {
+          "10": 90000,
+          "100133": 10
+        },
+        "10": {
+          "10": 112500,
+          "100133": 12
+        },
+        "11": {
+          "10": 135000,
+          "100133": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "special": {
+      "description": [
+        {
+          "name": "特殊技：流转",
+          "desc": "点按 <IconMap:Icon_Special> 发动：\n向前方进行斩击，造成<color=#2EB6FF>电属性伤害</color>，并切换当前架势；\n招式发动期间抗打断等级提升；\n若衔接在<color=#FFFFFF>[普通攻击]</color>第三、四、五段之后发动，则能够触发<color=#FFFFFF>[快速流转]</color>，以更快的速度进行斩击并切换当前架势；\n<color=#FFFFFF>[快速流转]</color>发动期间可以格挡敌人的攻击；\n触发<color=#FFFFFF>[快速流转]</color>后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "强化特殊技：月华流转",
+          "desc": "能量足够时，长按 <IconMap:Icon_SpecialReady> 发动：\n积蓄力量向前快速突刺，随后发动下落攻击，造成大量<color=#2EB6FF>电属性伤害</color>；\n突刺发动时，月城柳会切换当前架势，并进入<color=#FFFFFF>[森罗万象]</color>状态，持续15秒，状态持续期间，从<color=#FFFFFF>[普通攻击]</color>第五段或其他招式衔接后继<color=#FFFFFF>[普通攻击]</color>时，将直接从第三段<color=#FFFFFF>[普通攻击]</color> 起手；\n下落攻击命中处于属性异常状态下的敌人时，将会触发特殊的<color=#FFFFFF>[紊乱]</color>效果<color=#FFFFFF>[极性紊乱]</color>，对目标造成原本<color=#FFFFFF>[紊乱]</color>效果15%的伤害，并额外附加月城柳<color=#2BAD00>{CAL:5+AvatarSkillLevel(1)*2.25,100,2}%</color>异常精通的伤害，<color=#FFFFFF>[极性紊乱]</color>不会清除目标所处的属性异常状态；\n招式发动期间拥有无敌效果。",
+          "potential": []
+        },
+        {
+          "name": "特殊技：流转",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221011, Prop:1001}",
+              "param": {
+                "1221011": {
+                  "main": 11740,
+                  "growth": 1070,
+                  "format": "%",
+                  "damage_percentage": 11740,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 10570,
+                  "stun_ratio_growth": 490,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 264275,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9600,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 5334
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221011, Prop:1002}",
+              "param": {
+                "1221011": {
+                  "main": 10570,
+                  "growth": 490,
+                  "format": "%",
+                  "damage_percentage": 11740,
+                  "damage_percentage_growth": 1070,
+                  "stun_ratio": 10570,
+                  "stun_ratio_growth": 490,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 264275,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 9600,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 5334
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "强化特殊技：月华流转",
+          "param": [
+            {
+              "name": "能量消耗",
+              "desc": "40",
+              "potential": []
+            },
+            {
+              "name": "突刺攻击伤害倍率",
+              "desc": "{Skill:1221022, Prop:1001}",
+              "param": {
+                "1221022": {
+                  "main": 16380,
+                  "growth": 1490,
+                  "format": "%",
+                  "damage_percentage": 16380,
+                  "damage_percentage_growth": 1490,
+                  "stun_ratio": 12710,
+                  "stun_ratio_growth": 580,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 419375,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 14350,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6667
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "突刺攻击失衡倍率",
+              "desc": "{Skill:1221022, Prop:1002}",
+              "param": {
+                "1221022": {
+                  "main": 12710,
+                  "growth": 580,
+                  "format": "%",
+                  "damage_percentage": 16380,
+                  "damage_percentage_growth": 1490,
+                  "stun_ratio": 12710,
+                  "stun_ratio_growth": 580,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 419375,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 14350,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6667
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "下落攻击伤害倍率",
+              "desc": "{Skill:1221023, Prop:1001}",
+              "param": {
+                "1221023": {
+                  "main": 37780,
+                  "growth": 3440,
+                  "format": "%",
+                  "damage_percentage": 37780,
+                  "damage_percentage_growth": 3440,
+                  "stun_ratio": 10960,
+                  "stun_ratio_growth": 500,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 763400,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 26854,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6670
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "下落攻击失衡倍率",
+              "desc": "{Skill:1221023, Prop:1002}",
+              "param": {
+                "1221023": {
+                  "main": 10960,
+                  "growth": 500,
+                  "format": "%",
+                  "damage_percentage": 37780,
+                  "damage_percentage_growth": 3440,
+                  "stun_ratio": 10960,
+                  "stun_ratio_growth": 500,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 763400,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 26854,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 6670
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "额外附加伤害倍率",
+              "desc": "{CAL:5+AvatarSkillLevel(1)*2.25,100,2}%",
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100113": 2
+        },
+        "2": {
+          "10": 3000,
+          "100113": 3
+        },
+        "3": {
+          "10": 6000,
+          "100123": 2
+        },
+        "4": {
+          "10": 9000,
+          "100123": 3
+        },
+        "5": {
+          "10": 12000,
+          "100123": 4
+        },
+        "6": {
+          "10": 18000,
+          "100123": 6
+        },
+        "7": {
+          "10": 45000,
+          "100133": 5
+        },
+        "8": {
+          "10": 67500,
+          "100133": 8
+        },
+        "9": {
+          "10": 90000,
+          "100133": 10
+        },
+        "10": {
+          "10": 112500,
+          "100133": 12
+        },
+        "11": {
+          "10": 135000,
+          "100133": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "chain": {
+      "description": [
+        {
+          "name": "连携技：星月相随",
+          "desc": "触发<color=#FFFFFF>[连携技]</color>时，选择对应角色发动：\n切换当前架势，并对前方敌人发动强力斩击，造成大量<color=#2EB6FF>电属性伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "终结技：雷影天华",
+          "desc": "喧响等级达到<color=#FFFFFF>[极]</color>时，点按 <IconMap:Icon_UltimateReady> 发动：\n激发自身能力，在极短时间内对前方大范围敌人发动强力斩击，并追加落雷攻击，造成大量<color=#2EB6FF>电属性伤害</color>；\n落雷攻击命中处于属性异常状态下的敌人时，将会触发特殊的<color=#FFFFFF>[紊乱]</color>效果<color=#FFFFFF>[极性紊乱]</color>，对目标造成原本<color=#FFFFFF>[紊乱]</color>效果15%的伤害，并额外附加月城柳<color=#2BAD00>{CAL:5+AvatarSkillLevel(3)*2.25,100,2}%</color>异常精通的伤害，<color=#FFFFFF>[极性紊乱]</color>不会清除目标所处的属性异常状态；\n招式发动期间拥有无敌效果；\n招式发动后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "连携技：星月相随",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221015, Prop:1001}",
+              "param": {
+                "1221015": {
+                  "main": 59310,
+                  "growth": 5400,
+                  "format": "%",
+                  "damage_percentage": 59310,
+                  "damage_percentage_growth": 5400,
+                  "stun_ratio": 17830,
+                  "stun_ratio_growth": 820,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 2141150,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 35958,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 20004
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221015, Prop:1002}",
+              "param": {
+                "1221015": {
+                  "main": 17830,
+                  "growth": 820,
+                  "format": "%",
+                  "damage_percentage": 59310,
+                  "damage_percentage_growth": 5400,
+                  "stun_ratio": 17830,
+                  "stun_ratio_growth": 820,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 2141150,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 35958,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 20004
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "终结技：雷影天华",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221016, Prop:1001}",
+              "param": {
+                "1221016": {
+                  "main": 151180,
+                  "growth": 13750,
+                  "format": "%",
+                  "damage_percentage": 151180,
+                  "damage_percentage_growth": 13750,
+                  "stun_ratio": 9750,
+                  "stun_ratio_growth": 450,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 90439,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 72164
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221016, Prop:1002}",
+              "param": {
+                "1221016": {
+                  "main": 9750,
+                  "growth": 450,
+                  "format": "%",
+                  "damage_percentage": 151180,
+                  "damage_percentage_growth": 13750,
+                  "stun_ratio": 9750,
+                  "stun_ratio_growth": 450,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 90439,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 72164
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "额外附加伤害倍率",
+              "desc": "{CAL:5+AvatarSkillLevel(3)*2.25,100,2}%",
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100113": 2
+        },
+        "2": {
+          "10": 3000,
+          "100113": 3
+        },
+        "3": {
+          "10": 6000,
+          "100123": 2
+        },
+        "4": {
+          "10": 9000,
+          "100123": 3
+        },
+        "5": {
+          "10": 12000,
+          "100123": 4
+        },
+        "6": {
+          "10": 18000,
+          "100123": 6
+        },
+        "7": {
+          "10": 45000,
+          "100133": 5
+        },
+        "8": {
+          "10": 67500,
+          "100133": 8
+        },
+        "9": {
+          "10": 90000,
+          "100133": 10
+        },
+        "10": {
+          "10": 112500,
+          "100133": 12
+        },
+        "11": {
+          "10": 135000,
+          "100133": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    },
+    "assist": {
+      "description": [
+        {
+          "name": "快速支援：风华斩",
+          "desc": "当前操作中的角色被击飞时，点按 <IconMap:Icon_Switch> 发动：\n对前方敌人发动斩击，造成<color=#2EB6FF>电属性伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "招架支援：流光反",
+          "desc": "前场角色即将被攻击时，点按 <IconMap:Icon_Switch> 发动：\n招架敌人的攻击，累积大量失衡值；\n招式发动期间拥有无敌效果。",
+          "potential": []
+        },
+        {
+          "name": "支援突击：飞絮刺",
+          "desc": "发动<color=#FFFFFF>[招架支援]</color>后，点按 <IconMap:Icon_Normal> 发动：\n切换当前架势，对前方敌人快速发动多段斩击，造成<color=#2EB6FF>电属性伤害</color>；\n招式发动期间拥有无敌效果；\n招式发动后，可以直接衔接当前架势下第三段<color=#FFFFFF>[普通攻击]</color>。",
+          "potential": []
+        },
+        {
+          "name": "快速支援：风华斩",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221017, Prop:1001}",
+              "param": {
+                "1221017": {
+                  "main": 9360,
+                  "growth": 860,
+                  "format": "%",
+                  "damage_percentage": 9360,
+                  "damage_percentage_growth": 860,
+                  "stun_ratio": 8420,
+                  "stun_ratio_growth": 390,
+                  "sp_recovery": 30620,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 210650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7652,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4252
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221017, Prop:1002}",
+              "param": {
+                "1221017": {
+                  "main": 8420,
+                  "growth": 390,
+                  "format": "%",
+                  "damage_percentage": 9360,
+                  "damage_percentage_growth": 860,
+                  "stun_ratio": 8420,
+                  "stun_ratio_growth": 390,
+                  "sp_recovery": 30620,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 210650,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 7652,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 4252
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "招架支援：流光反",
+          "param": [
+            {
+              "name": "轻招架失衡倍率",
+              "desc": "{Skill:1221018, Prop:1002}",
+              "param": {
+                "1221018": {
+                  "main": 24420,
+                  "growth": 1110,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 24420,
+                  "stun_ratio_growth": 1110,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 36664
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "重招架失衡倍率",
+              "desc": "{Skill:1221019, Prop:1002}",
+              "param": {
+                "1221019": {
+                  "main": 30860,
+                  "growth": 1410,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 30860,
+                  "stun_ratio_growth": 1410,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 41664
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "连续招架失衡倍率",
+              "desc": "{Skill:1221020, Prop:1002}",
+              "param": {
+                "1221020": {
+                  "main": 15020,
+                  "growth": 690,
+                  "format": "%",
+                  "damage_percentage": 0,
+                  "damage_percentage_growth": 0,
+                  "stun_ratio": 15020,
+                  "stun_ratio_growth": 690,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 0,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 0,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 11664
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        },
+        {
+          "name": "支援突击：飞絮刺",
+          "param": [
+            {
+              "name": "伤害倍率",
+              "desc": "{Skill:1221021, Prop:1001}",
+              "param": {
+                "1221021": {
+                  "main": 40710,
+                  "growth": 3710,
+                  "format": "%",
+                  "damage_percentage": 40710,
+                  "damage_percentage_growth": 3710,
+                  "stun_ratio": 32060,
+                  "stun_ratio_growth": 1460,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1030700,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 31223,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 18497
+                }
+              },
+              "potential": []
+            },
+            {
+              "name": "失衡倍率",
+              "desc": "{Skill:1221021, Prop:1002}",
+              "param": {
+                "1221021": {
+                  "main": 32060,
+                  "growth": 1460,
+                  "format": "%",
+                  "damage_percentage": 40710,
+                  "damage_percentage_growth": 3710,
+                  "stun_ratio": 32060,
+                  "stun_ratio_growth": 1460,
+                  "sp_recovery": 0,
+                  "sp_recovery_growth": 0,
+                  "fever_recovery": 1030700,
+                  "fever_recovery_growth": 0,
+                  "attribute_infliction": 31223,
+                  "sp_consume": 0,
+                  "attack_data": [],
+                  "rp_recovery": 0,
+                  "rp_recovery_growth": 0,
+                  "ether_purify": 18497
+                }
+              },
+              "potential": []
+            }
+          ],
+          "potential": []
+        }
+      ],
+      "material": {
+        "1": {
+          "10": 2000,
+          "100113": 2
+        },
+        "2": {
+          "10": 3000,
+          "100113": 3
+        },
+        "3": {
+          "10": 6000,
+          "100123": 2
+        },
+        "4": {
+          "10": 9000,
+          "100123": 3
+        },
+        "5": {
+          "10": 12000,
+          "100123": 4
+        },
+        "6": {
+          "10": 18000,
+          "100123": 6
+        },
+        "7": {
+          "10": 45000,
+          "100133": 5
+        },
+        "8": {
+          "10": 67500,
+          "100133": 8
+        },
+        "9": {
+          "10": 90000,
+          "100133": 10
+        },
+        "10": {
+          "10": 112500,
+          "100133": 12
+        },
+        "11": {
+          "10": 135000,
+          "100133": 15,
+          "100941": 1
+        },
+        "12": {}
+      }
+    }
+  },
+  "skill_list": {
+    "1221001": {
+      "name": "普通攻击：夜见尊神乐（一、二段）",
+      "desc": "<IconMap:Icon_Normal>",
+      "element_type": 200,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221002": {
+      "name": "普通攻击：夜见尊神乐（三、四、五段）",
+      "desc": "<IconMap:Icon_Normal>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221003": {
+      "name": "特殊技：流转",
+      "desc": "<IconMap:Icon_Special>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221004": {
+      "name": "特殊技：流转（快速切换）",
+      "desc": "<IconMap:Icon_Normal>（三、四、五段） ; <IconMap:Icon_Special>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221005": {
+      "name": "特殊技：流转（抵挡攻击）",
+      "desc": "<IconMap:Icon_Normal>（三、四、五段） ; <IconMap:Icon_Special>（即将受到攻击时）",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221006": {
+      "name": "强化特殊技：月华流转",
+      "desc": "<IconMap:Icon_SpecialReady>（长按）",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221007": {
+      "name": "冲刺攻击：飞掠",
+      "desc": "<IconMap:Icon_Evade> ; <IconMap:Icon_Normal>",
+      "element_type": 200,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221008": {
+      "name": "闪避反击：疾反",
+      "desc": "<IconMap:Icon_Evade>（极限） ; <IconMap:Icon_Normal>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221009": {
+      "name": "连携技：星月相随",
+      "desc": "<IconMap:Icon_QTE>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221010": {
+      "name": "终结技：雷影天华",
+      "desc": "<IconMap:Icon_UltimateReady>",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221011": {
+      "name": "快速支援：风华斩",
+      "desc": "<IconMap:Icon_Switch>（触发快速支援时）",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    },
+    "1221012": {
+      "name": "招架支援：流光反",
+      "desc": "<IconMap:Icon_Switch>（触发招架支援时）",
+      "element_type": 0,
+      "hit_type": 0,
+      "potential": []
+    },
+    "1221013": {
+      "name": "支援突击：飞絮刺",
+      "desc": "<IconMap:Icon_Normal>（发动招架支援后）",
+      "element_type": 203,
+      "hit_type": 101,
+      "potential": []
+    }
+  },
+  "passive": {
+    "level": {
+      "1221501": {
+        "level": 1,
+        "id": 1221501,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>125%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>10%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221502": {
+        "level": 2,
+        "id": 1221502,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>145%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>11.6%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221503": {
+        "level": 3,
+        "id": 1221503,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>166%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>13.3%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221504": {
+        "level": 4,
+        "id": 1221504,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>188%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>15%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221505": {
+        "level": 5,
+        "id": 1221505,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>208%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>16.6%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221506": {
+        "level": 6,
+        "id": 1221506,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>230%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>18.3%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      },
+      "1221507": {
+        "level": 7,
+        "id": 1221507,
+        "name": [
+          "核心被动：月蚀",
+          "额外能力：月相"
+        ],
+        "desc": [
+          "月城柳发动<color=#FFFFFF>[强化特殊技]</color>后，队伍中任意角色对敌人施加<color=#FFFFFF>[紊乱]</color>效果时，<color=#FFFFFF>[紊乱]</color>效果的伤害倍率提升<color=#2BAD00>250%</color>，持续15秒；<color=#FFFFFF>[强化特殊技]</color>命中敌人时，月城柳对目标造成的<color=#2EB6FF>电属性伤害</color>提升<color=#2BAD00>20%</color>，持续15秒。",
+          "队伍中存在其他<color=#FFFFFF>[异常]</color>角色或与自身属性相同的角色时触发：\n架势切换后，月城柳发动<color=#FFFFFF>[普通攻击：夜见尊神乐]</color>命中敌人时累积的<color=#2EB6FF>电属性异常积蓄值</color>提升45%，持续8秒。"
+        ],
+        "extra_property": {},
+        "potential": []
+      }
+    },
+    "materials": {
+      "1": {
+        "10": 5000
+      },
+      "2": {
+        "10": 12000,
+        "110505": 2
+      },
+      "3": {
+        "10": 28000,
+        "110505": 4
+      },
+      "4": {
+        "10": 60000,
+        "110002": 2,
+        "110505": 9
+      },
+      "5": {
+        "10": 100000,
+        "110002": 3,
+        "110505": 15
+      },
+      "6": {
+        "10": 200000,
+        "110002": 4,
+        "110505": 30
+      }
+    }
+  },
+  "talent": {
+    "1": {
+      "level": 1,
+      "name": "知己知彼",
+      "desc": "队伍中任意角色对敌人施加属性异常效果时，月城柳会获得1层<color=#FFFFFF>[洞悉]</color>，持续15秒，最多叠加3层，重复触发时刷新持续时间；受到敌方攻击时，月城柳将消耗1层<color=#FFFFFF>[洞悉]</color>并获得无敌效果，持续1秒；拥有1层或以上<color=#FFFFFF>[洞悉]</color>时，月城柳的异常精通提升80点。",
+      "desc2": "「洞悉敌人的弱点，等同于为自己赢得更多的保障…和胜算。」\n柳推了推眼镜，即使已然胜券在握，她依然如像往常一般不动声色。"
+    },
+    "2": {
+      "level": 2,
+      "name": "卓越适应性",
+      "desc": "<color=#FFFFFF>[强化特殊技]</color>中，快速突刺累积的<color=#2EB6FF>电属性异常积蓄值</color>提升20%；快速突刺命中敌人时，保持长按「特殊攻击」按键，可以额外消耗10点能量，再次发动突刺攻击，能量不足或停止长按后将自动衔接下落攻击；下落攻击命中处于属性异常状态下的敌人并触发<color=#FFFFFF>[极性紊乱]</color>效果时，对目标造成的伤害倍率提升至原本<color=#FFFFFF>[紊乱]</color>效果的20%，每额外发动一次突刺攻击，该伤害倍率额外提升15%，伤害倍率额外提升效果最多触发2次。",
+      "desc2": "「柳的话…无论被丢到怎样异常的环境，一定都能处理好的。」\n「我比相信自己更加相信她。」\n——来自一位正在进行「斩断面前所有落叶」修行的武者"
+    },
+    "3": {
+      "level": 3,
+      "name": "月城氏管理学",
+      "desc": "<color=#FFFFFF>[普通攻击]</color>、<color=#FFFFFF>[闪避]</color>、<color=#FFFFFF>[支援技]</color>、<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[连携技]</color> 技能等级+2",
+      "desc2": "人人都说对空六课聚集了一帮怪人和天才，其中唯一的「正常人」便是月城柳了。\n但也正是她的存在，把怪人和天才们「粘合」了起来。"
+    },
+    "4": {
+      "level": 4,
+      "name": "掌棋者",
+      "desc": "月城柳对敌人造成属性异常伤害时，会为其施加<color=#FFFFFF>[识破]</color>效果，持续15秒；处于<color=#FFFFFF>[识破]</color>效果下的敌人受到攻击时，本次攻击的穿透率提升16%。",
+      "desc2": "无论在何种情况下，月城柳都能以最快的速度掌握当下所有信息，并据此做出最合适的判断。"
+    },
+    "5": {
+      "level": 5,
+      "name": "鬼「妈妈」",
+      "desc": "<color=#FFFFFF>[普通攻击]</color>、<color=#FFFFFF>[闪避]</color>、<color=#FFFFFF>[支援技]</color>、<color=#FFFFFF>[特殊技]</color>、<color=#FFFFFF>[连携技]</color> 技能等级+2",
+      "desc2": "目前，月城柳是苍角的唯一指定监护人。\n「苍角，这是课长的饭团，不可以随便吃——算了，过来，我给你加热一下。」\n「之后再买个一样的还给课长吧…」"
+    },
+    "6": {
+      "level": 6,
+      "name": "非人之血",
+      "desc": "在<color=#FFFFFF>[强化特殊技]</color>中发动突刺攻击后，<color=#FFFFFF>[森罗万象]</color>状态的持续时间提升至30秒，状态持续期间，<color=#FFFFFF>[强化特殊技]</color>造成的伤害提升20%；<color=#FFFFFF>[卓越适应性]</color>中，<color=#FFFFFF>[极性紊乱]</color>伤害倍率额外提升效果的触发次数上限提升至4次，前4次额外发动突刺攻击时所需的能量消耗减半。",
+      "desc2": "月城柳的身体中流淌着一部分不属于她的血液。\n这些血曾让她在绝境中获得了新生，也因此拥有了一些特殊的力量。\n「但如你所知，一切本不属于我的东西…终有代价。」"
+    }
+  },
+  "fairy_recommend": {
+    "slot4": 32400,
+    "slot2": 31300,
+    "slot_sub": 31800,
+    "part4": {
+      "prop": 31203,
+      "name": "异常精通",
+      "format": "{0:0}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconElementMystery.png"
+    },
+    "part5": {
+      "prop": 31803,
+      "name": "电属性伤害加成",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconGeneralBuff/Packer/IconThunder.png"
+    },
+    "part6": {
+      "prop": 12102,
+      "name": "攻击力",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconAttack.png"
+    },
+    "part_sub": {
+      "prop": 31402,
+      "name": "异常掌控",
+      "format": "{0:0.#%}",
+      "icon": "UI/Sprite/A1DynamicLoad/IconAttribute/UnPacker/Role/IconElementAbnormalPower.png"
+    }
+  },
+  "strategy": [
+    "03",
+    "<IconMap:Icon_GeneralBuff_Thunder>电属性，异常站场输出",
+    "切换架势获得战斗增益",
+    "触发[极性紊乱]造成额外伤害"
+  ],
+  "potential": [],
+  "potential_detail": {},
+  "live2_d": "UISpineYanagi"
+}

--- a/data/source/source-manifest.json
+++ b/data/source/source-manifest.json
@@ -59,12 +59,12 @@
       "id": "nanoka-zzz-2.8",
       "kind": "rawHttpSnapshot",
       "path": "data/source/raw/nanoka/zzz/2.8/fetch-manifest.json",
-      "sha256": "e21e89b5f71e863589938ac293d26712457c0d8c3ce40c4da63c183991245c48",
-      "bytes": 16170,
-      "fetchedAt": "2026-05-15T13:20:00+08:00",
+      "sha256": "a83e336feb3e052573eca826ba15b383114f97b303d64a528135f7cb13774384",
+      "bytes": 20048,
+      "fetchedAt": "2026-05-15T17:15:00+08:00",
       "providedBy": "static.nanoka.cc public JSON",
       "distribution": "raw-retained-not-packaged",
-      "usage": "Nanoka live 2.8 raw snapshot fixture for Phase 2 source-gate, adapter-skeleton, and enemy variant mapping tests; not a runtime cleaned-data cutover"
+      "usage": "Nanoka live 2.8 raw snapshot fixture for Phase 2 source-gate, adapter-skeleton, Phase 3 first-sync candidate coverage, and enemy variant mapping tests; not a runtime cleaned-data cutover"
     }
   ]
 }

--- a/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
+++ b/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
@@ -1,7 +1,7 @@
 # Nanoka Drift Report: phase3-sync-001-g01-g26
 
 Status: Phase 3 drift audit first G01-G26 sync
-Generated: 2026-05-15T16:45:00+08:00
+Generated: 2026-05-15T17:25:00+08:00
 
 This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths. Full runtime cutover remains disabled.
 
@@ -25,9 +25,9 @@ This report compares archived G01-G26 replay baselines against nanoka candidate 
 |---|---:|
 | `same` | 0 |
 | `changed` | 0 |
-| `missing` | 4 |
+| `missing` | 0 |
 | `new` | 0 |
-| `semantic-mismatch` | 22 |
+| `semantic-mismatch` | 26 |
 
 Unresolved blocking drift rows: **26**
 
@@ -58,10 +58,10 @@ Runtime cutover ready: **false**
 | `G19` | `goldenAnchors.G19.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
 | `G20` | `goldenAnchors.G20.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
 | `G21` | `goldenAnchors.G21.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031. |
-| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221. |
-| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001. |
-| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `missing` | `pending` | First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001. |
+| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
 | `G26` | `goldenAnchors.G26.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
 
 

--- a/packages/data/cleaned/audit/nanoka-coverage-matrix.json
+++ b/packages/data/cleaned/audit/nanoka-coverage-matrix.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "nanoka-coverage-matrix/v0.1",
-  "generatedAt": "2026-05-15T16:20:00+08:00",
+  "generatedAt": "2026-05-15T17:15:00+08:00",
   "status": "phase-3-drift-foundation-gate",
   "sourceVersion": "manifest.zzz.live",
   "canonicalSchemas": [
@@ -309,6 +309,46 @@
       "server": "live",
       "approvedForCleanedOutput": true,
       "evidenceUse": "release-gate-evidence"
+    },
+    {
+      "id": "nanoka-character-nicole-live-1031",
+      "entityType": "agent",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1031.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g22-passive-candidate-gate"
+    },
+    {
+      "id": "nanoka-character-yanagi-live-1221",
+      "entityType": "agent",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/character/1221.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g23-passive-candidate-gate"
+    },
+    {
+      "id": "nanoka-bangboo-penguinboo-live-53001",
+      "entityType": "bangboo",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/53001.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g24-bangboo-candidate-gate"
+    },
+    {
+      "id": "nanoka-bangboo-sharkboo-live-54001",
+      "entityType": "bangboo",
+      "version": "2.8",
+      "releaseChannel": "live",
+      "server": "global",
+      "url": "https://static.nanoka.cc/zzz/2.8/zh/bangboo/54001.json",
+      "approvedForCleanedOutput": true,
+      "evidenceUse": "phase3-g25-bangboo-candidate-gate"
     }
   ],
   "rows": [
@@ -604,12 +644,18 @@
         "/skill/*/description/*/desc"
       ],
       "transformRule": "passive/talent/skill text exists; formal corePassiveModifiers require deterministic typed modifier templates before promotion",
-      "sampleEntity": "nanoka-character-yixuan-1371",
+      "sampleEntity": "nanoka-character-nicole-live-1031",
       "rawAvailable": true,
       "promotable": false,
       "blockedBy": [
         "typed-modifier-template-required"
-      ]
+      ],
+      "supportingSampleEntities": [
+        "nanoka-character-nicole-live-1031",
+        "nanoka-character-yanagi-live-1221",
+        "nanoka-character-yixuan-live-1371"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Nicole and Yanagi character detail samples for G22/G23 passive candidate coverage; typed modifier template remains unresolved before formal promotion."
     },
     {
       "fieldId": "adrenaline.maxAdrenaline",
@@ -715,7 +761,13 @@
       "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
       "promotable": true,
-      "blockedBy": []
+      "blockedBy": [],
+      "supportingSampleEntities": [
+        "nanoka-bangboo-plugboo-live-54008",
+        "nanoka-bangboo-penguinboo-live-53001",
+        "nanoka-bangboo-sharkboo-live-54001"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Penguinboo and Sharkboo samples for G24/G25 candidate coverage."
     },
     {
       "fieldId": "bangboos.skillSegments",
@@ -733,7 +785,13 @@
       "sampleEntity": "nanoka-bangboo-plugboo-live-54008",
       "rawAvailable": true,
       "promotable": true,
-      "blockedBy": []
+      "blockedBy": [],
+      "supportingSampleEntities": [
+        "nanoka-bangboo-plugboo-live-54008",
+        "nanoka-bangboo-penguinboo-live-53001",
+        "nanoka-bangboo-sharkboo-live-54001"
+      ],
+      "notes": "Phase 3 Step 1 adds approved-live Penguinboo and Sharkboo samples for G24/G25 candidate coverage."
     },
     {
       "fieldId": "bangboos.element",

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-drift-report/v0.1",
   "syncId": "phase3-sync-001-g01-g26",
-  "generatedAt": "2026-05-15T16:45:00+08:00",
+  "generatedAt": "2026-05-15T17:25:00+08:00",
   "candidate": {
     "sourceId": "nanoka-zzz",
     "sourceVersion": "2.8",
@@ -29,9 +29,9 @@
   "counts": {
     "same": 0,
     "changed": 0,
-    "missing": 4,
+    "missing": 0,
     "new": 0,
-    "semantic-mismatch": 22
+    "semantic-mismatch": 26
   },
   "rows": [
     {
@@ -2167,8 +2167,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/13"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2186,7 +2186,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Nicole passive modifier source coverage.",
         "fieldIds": [
           "agents.passiveModifiers"
@@ -2200,7 +2200,9 @@
             "promotable": false,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-character-yixuan-1371"
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
             ],
             "auditArtifact": null,
             "blockedBy": [
@@ -2212,21 +2214,21 @@
           "nanoka-character-nicole-live-1031"
         ],
         "availableSampleEntities": [
-          "nanoka-character-yixuan-1371"
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-character-nicole-live-1031"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing",
+        "phase3:semantic-equivalence-ruling-required",
         "typed-modifier-template-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-nicole-live-1031."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "agent",
@@ -2243,8 +2245,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/13"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2275,7 +2277,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Yanagi passive/disorder source coverage.",
         "fieldIds": [
           "agents.passiveModifiers",
@@ -2290,7 +2292,9 @@
             "promotable": false,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-character-yixuan-1371"
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
             ],
             "auditArtifact": null,
             "blockedBy": [
@@ -2315,22 +2319,22 @@
           "nanoka-character-yanagi-live-1221"
         ],
         "availableSampleEntities": [
-          "nanoka-character-yixuan-1371"
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-character-yanagi-live-1221"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing",
+        "phase3:semantic-equivalence-ruling-required",
         "typed-modifier-template-required",
         "implementation-owned-runtime-formula"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-character-yanagi-live-1221."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2347,8 +2351,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/19"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2379,7 +2383,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
         "fieldIds": [
           "bangboos.basePanel",
@@ -2394,7 +2398,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2407,7 +2413,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2417,20 +2425,20 @@
           "nanoka-bangboo-penguinboo-live-53001"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": [
-          "nanoka-bangboo-penguinboo-live-53001"
-        ]
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing"
+        "phase3:semantic-equivalence-ruling-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-penguinboo-live-53001."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2447,8 +2455,8 @@
       "candidateSourceRef": {
         "sourceId": "nanoka-zzz",
         "sourceVersion": "2.8",
-        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
-        "dataPath": "/rows/19"
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
+        "dataPath": "/stats"
       },
       "baselineValue": {
         "replayStatus": "passed",
@@ -2479,7 +2487,7 @@
         ]
       },
       "candidateValue": {
-        "coverageStatus": "missing-required-sample",
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
         "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
         "fieldIds": [
           "bangboos.basePanel",
@@ -2494,7 +2502,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2507,7 +2517,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2517,20 +2529,20 @@
           "nanoka-bangboo-sharkboo-live-54001"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
-        ],
-        "missingRequiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
-        ]
+        ],
+        "missingRequiredSampleEntities": []
       },
-      "status": "missing",
+      "status": "semantic-mismatch",
       "severity": "blocking",
       "rulingStatus": "pending",
       "blockedBy": [
         "phase3:ruling-required",
-        "phase3:candidate-source-missing"
+        "phase3:semantic-equivalence-ruling-required"
       ],
-      "notes": "First sync is missing required approved-live nanoka candidate sample(s): nanoka-bangboo-sharkboo-live-54001."
+      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
     },
     {
       "entityType": "bangboo",
@@ -2595,7 +2607,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2608,7 +2622,9 @@
             "promotable": true,
             "rawAvailable": true,
             "sampleEntities": [
-              "nanoka-bangboo-plugboo-live-54008"
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
             ],
             "auditArtifact": null,
             "blockedBy": []
@@ -2631,7 +2647,9 @@
           "nanoka-bangboo-plugboo-live-54008"
         ],
         "availableSampleEntities": [
-          "nanoka-bangboo-plugboo-live-54008"
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
         ],
         "missingRequiredSampleEntities": []
       },

--- a/packages/data/scripts/nanoka-source.mjs
+++ b/packages/data/scripts/nanoka-source.mjs
@@ -89,6 +89,26 @@ function snapshotAssets(snapshot) {
       evidenceUse: "adrenaline-resonance-source-gate",
     },
     {
+      id: "character-nicole-1031",
+      url: `https://static.nanoka.cc/zzz/${snapshot}/zh/character/1031.json`,
+      path: "zh/character/1031.json",
+      entityType: "character",
+      language: "zh",
+      entityId: 1031,
+      approvedForCleanedOutput: true,
+      evidenceUse: "phase3-g22-passive-candidate-gate",
+    },
+    {
+      id: "character-yanagi-1221",
+      url: `https://static.nanoka.cc/zzz/${snapshot}/zh/character/1221.json`,
+      path: "zh/character/1221.json",
+      entityType: "character",
+      language: "zh",
+      entityId: 1221,
+      approvedForCleanedOutput: true,
+      evidenceUse: "phase3-g23-passive-candidate-gate",
+    },
+    {
       id: "boss-69036",
       url: `https://static.nanoka.cc/zzz/${snapshot}/zh/boss/69036.json`,
       path: "zh/boss/69036.json",
@@ -179,6 +199,26 @@ function snapshotAssets(snapshot) {
       evidenceUse: "bangboo-panel-skill-source-gate",
     },
     {
+      id: "bangboo-penguinboo-53001",
+      url: `https://static.nanoka.cc/zzz/${snapshot}/zh/bangboo/53001.json`,
+      path: "zh/bangboo/53001.json",
+      entityType: "bangboo",
+      language: "zh",
+      entityId: 53001,
+      approvedForCleanedOutput: true,
+      evidenceUse: "phase3-g24-bangboo-candidate-gate",
+    },
+    {
+      id: "bangboo-sharkboo-54001",
+      url: `https://static.nanoka.cc/zzz/${snapshot}/zh/bangboo/54001.json`,
+      path: "zh/bangboo/54001.json",
+      entityType: "bangboo",
+      language: "zh",
+      entityId: 54001,
+      approvedForCleanedOutput: true,
+      evidenceUse: "phase3-g25-bangboo-candidate-gate",
+    },
+    {
       id: "weapon-yixuan-signature-14137",
       url: `https://static.nanoka.cc/zzz/${snapshot}/zh/weapon/14137.json`,
       path: "zh/weapon/14137.json",
@@ -229,6 +269,8 @@ function summarizeSnapshot(snapshot, assets) {
   const bossIndex = readJson(join(sourceRoot, snapshot, "boss.json"))
   const character = readJson(join(sourceRoot, snapshot, "zh/character/1021.json"))
   const sentinelCharacter = readJson(join(sourceRoot, snapshot, "zh/character/1371.json"))
+  const nicoleCharacter = readJson(join(sourceRoot, snapshot, "zh/character/1031.json"))
+  const yanagiCharacter = readJson(join(sourceRoot, snapshot, "zh/character/1221.json"))
   const boss = readJson(join(sourceRoot, snapshot, "zh/boss/69036.json"))
   const monsterSamples = [
     {
@@ -293,6 +335,8 @@ function summarizeSnapshot(snapshot, assets) {
     }
   })
   const bangboo = readJson(join(sourceRoot, snapshot, "zh/bangboo/54008.json"))
+  const penguinboo = readJson(join(sourceRoot, snapshot, "zh/bangboo/53001.json"))
+  const sharkboo = readJson(join(sourceRoot, snapshot, "zh/bangboo/54001.json"))
   const weapon = readJson(join(sourceRoot, snapshot, "zh/weapon/14137.json"))
   const equipment = readJson(join(sourceRoot, snapshot, "zh/equipment/31000.json"))
 
@@ -306,10 +350,18 @@ function summarizeSnapshot(snapshot, assets) {
     throw new Error("character sample id drifted")
   if (sentinelCharacter.id !== 1371)
     throw new Error("sentinel character sample id drifted")
+  if (nicoleCharacter.id !== 1031)
+    throw new Error("Nicole character sample id drifted")
+  if (yanagiCharacter.id !== 1221)
+    throw new Error("Yanagi character sample id drifted")
   if (boss.id !== 69036)
     throw new Error("boss sample id drifted")
   if (bangboo.id !== 54008)
     throw new Error("bangboo sample id drifted")
+  if (penguinboo.id !== 53001)
+    throw new Error("Penguinboo sample id drifted")
+  if (sharkboo.id !== 54001)
+    throw new Error("Sharkboo sample id drifted")
   if (weapon.id !== 14137)
     throw new Error("weapon sample id drifted")
   if (equipment.id !== 31000)
@@ -348,6 +400,20 @@ function summarizeSnapshot(snapshot, assets) {
         "/skill/basic/description/4/param/0/param/1371001/rp_recovery",
       ],
     },
+    passiveCharacterSamples: [
+      {
+        id: nicoleCharacter.id,
+        codeName: nicoleCharacter.code_name,
+        hasStats: nicoleCharacter.stats !== undefined,
+        skillKeys: Object.keys(nicoleCharacter.skill ?? {}),
+      },
+      {
+        id: yanagiCharacter.id,
+        codeName: yanagiCharacter.code_name,
+        hasStats: yanagiCharacter.stats !== undefined,
+        skillKeys: Object.keys(yanagiCharacter.skill ?? {}),
+      },
+    ],
     deadlyAssaultSample: {
       id: boss.id,
       zoneCount: Object.keys(boss.zone ?? {}).length,
@@ -370,6 +436,20 @@ function summarizeSnapshot(snapshot, assets) {
       hasStats: bangboo.stats !== undefined,
       hasSkillProp: bangboo.skill_prop !== undefined,
     },
+    bangbooCandidateSamples: [
+      {
+        id: penguinboo.id,
+        codeName: penguinboo.code_name,
+        hasStats: penguinboo.stats !== undefined,
+        hasSkillProp: penguinboo.skill_prop !== undefined,
+      },
+      {
+        id: sharkboo.id,
+        codeName: sharkboo.code_name,
+        hasStats: sharkboo.stats !== undefined,
+        hasSkillProp: sharkboo.skill_prop !== undefined,
+      },
+    ],
     wEngineSample: {
       id: weapon.id,
       codeName: weapon.code_name,

--- a/packages/data/scripts/sync-cleaned.mjs
+++ b/packages/data/scripts/sync-cleaned.mjs
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs"
 import { dirname, extname, join, relative } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -6,6 +6,7 @@ const packageDir = fileURLToPath(new URL("..", import.meta.url))
 const repoRoot = join(packageDir, "../..")
 const sourceDir = join(repoRoot, "data/cleaned")
 const targetDir = join(packageDir, "cleaned")
+const checkOnly = process.argv.includes("--check")
 
 function listJsonFiles(dir, baseDir = dir) {
   if (!existsSync(dir))
@@ -19,6 +20,40 @@ function listJsonFiles(dir, baseDir = dir) {
       return [relative(baseDir, path)]
     return []
   })
+}
+
+function assertMirrorsMatch() {
+  const sourceFiles = listJsonFiles(sourceDir).sort()
+  const targetFiles = listJsonFiles(targetDir).sort()
+  const targetFileSet = new Set(targetFiles)
+  const sourceFileSet = new Set(sourceFiles)
+  const missingInTarget = sourceFiles.filter(relativePath => !targetFileSet.has(relativePath))
+  const extraInTarget = targetFiles.filter(relativePath => !sourceFileSet.has(relativePath))
+  const mismatched = sourceFiles.filter((relativePath) => {
+    if (!targetFileSet.has(relativePath))
+      return false
+
+    return !readFileSync(join(sourceDir, relativePath)).equals(
+      readFileSync(join(targetDir, relativePath)),
+    )
+  })
+
+  if (missingInTarget.length || extraInTarget.length || mismatched.length) {
+    const details = [
+      missingInTarget.length ? `missing in package cleaned mirror: ${missingInTarget.join(", ")}` : "",
+      extraInTarget.length ? `extra in package cleaned mirror: ${extraInTarget.join(", ")}` : "",
+      mismatched.length ? `mismatched cleaned mirror files: ${mismatched.join(", ")}` : "",
+    ].filter(Boolean).join("\n")
+
+    throw new Error(`cleaned mirror check failed\n${details}`)
+  }
+
+  console.log(`cleaned mirror check passed (${sourceFiles.length} JSON files)`)
+}
+
+if (checkOnly) {
+  assertMirrorsMatch()
+  process.exit(0)
 }
 
 mkdirSync(targetDir, { recursive: true })

--- a/packages/data/scripts/verify-source-registry.mjs
+++ b/packages/data/scripts/verify-source-registry.mjs
@@ -195,6 +195,38 @@ function validateMatrixAgainstRegistry(matrix, registry) {
     assert(bangbooElementRow.rawFieldPaths?.includes(rawPath), `bangboos.element: missing raw path ${rawPath}`)
   }
 
+  const passiveModifierRow = resourceRows.get("agents.passiveModifiers")
+  assert(passiveModifierRow !== undefined, "agents.passiveModifiers: missing passive modifier row")
+  assert(passiveModifierRow.status === "verified-from-nanoka", "agents.passiveModifiers: row must stay verified after passive candidate fetch")
+  assert(passiveModifierRow.promotable === false, "agents.passiveModifiers: row must not become promotable before typed modifier template")
+  assert(passiveModifierRow.blockedBy?.includes("typed-modifier-template-required"), "agents.passiveModifiers: typed modifier blocker must remain until ruling/template work")
+  for (const sampleId of [
+    "nanoka-character-nicole-live-1031",
+    "nanoka-character-yanagi-live-1221",
+  ]) {
+    const sample = sampleById.get(sampleId)
+    assert(sample !== undefined, `agents.passiveModifiers: missing Phase 3 live sample ${sampleId}`)
+    assert(sample.approvedForCleanedOutput === true, `${sampleId}: passive supporting sample must be approved live evidence`)
+    assert(sample.version === nanoka.configuredLiveVersion, `${sampleId}: passive supporting sample must use configuredLiveVersion`)
+    assert(passiveModifierRow.supportingSampleEntities?.includes(sampleId), `agents.passiveModifiers: supporting samples must include ${sampleId}`)
+  }
+
+  for (const fieldId of ["bangboos.basePanel", "bangboos.skillSegments"]) {
+    const row = resourceRows.get(fieldId)
+    assert(row !== undefined, `${fieldId}: missing Bangboo candidate row`)
+    assert(row.status === "verified-from-nanoka", `${fieldId}: row must stay verified after Phase 3 candidate fetch`)
+    for (const sampleId of [
+      "nanoka-bangboo-penguinboo-live-53001",
+      "nanoka-bangboo-sharkboo-live-54001",
+    ]) {
+      const sample = sampleById.get(sampleId)
+      assert(sample !== undefined, `${fieldId}: missing Phase 3 live sample ${sampleId}`)
+      assert(sample.approvedForCleanedOutput === true, `${sampleId}: Bangboo supporting sample must be approved live evidence`)
+      assert(sample.version === nanoka.configuredLiveVersion, `${sampleId}: Bangboo supporting sample must use configuredLiveVersion`)
+      assert(row.supportingSampleEntities?.includes(sampleId), `${fieldId}: supporting samples must include ${sampleId}`)
+    }
+  }
+
   const driveDiscSlotRow = resourceRows.get("driveDiscs.slotAndSubstatTables")
   assert(driveDiscSlotRow !== undefined, "driveDiscs.slotAndSubstatTables: missing Drive Disc slot/stat row")
   assert(driveDiscSlotRow.status === "deferred", "driveDiscs.slotAndSubstatTables: row must be deferred after owner scope decision")

--- a/packages/data/source-registry.json
+++ b/packages/data/source-registry.json
@@ -24,8 +24,8 @@
         "versionedIndexUrls": "^https://static\\.nanoka\\.cc/zzz/(?:\\d[\\dA-Za-z.+-]*)/boss\\.json$",
         "localizedDetailUrls": "^https://static\\.nanoka\\.cc/zzz/(?:\\d[\\dA-Za-z.+-]*)/(?:zh|en|ja|ko)/[a-z]+/\\d+\\.json$"
       },
-      "fetchedAt": "2026-05-15T12:20:00+08:00",
-      "lastVerifiedAt": "2026-05-15T12:20:00+08:00",
+      "fetchedAt": "2026-05-15T17:15:00+08:00",
+      "lastVerifiedAt": "2026-05-15T17:15:00+08:00",
       "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d",
       "takedownPath": "docs/data-source/takedown-rollback.md#nanoka",
       "fallbackPlan": "archived Excel V0.0.4 snapshot + D-17 Mihoyo archived + D-12 buhflipexplode archived",

--- a/packages/data/src/governance.test.ts
+++ b/packages/data/src/governance.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process"
 import { createHash } from "node:crypto"
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
-import { dirname, join } from "node:path"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import type { SourceManifest } from "./types/source-manifest"
 
@@ -54,37 +54,21 @@ describe("S5 data governance", () => {
   })
 
   it("packs synced cleaned JSON while excluding retained source files", () => {
-    const sourceProbePath = join(repoRoot, "data/cleaned/qa-pack-probe.json")
-    const packageProbePath = join(dataPackageRoot, "cleaned/qa-pack-probe.json")
-    mkdirSync(dirname(sourceProbePath), { recursive: true })
-    writeFileSync(
-      sourceProbePath,
-      `${JSON.stringify({
-        kind: "sourceManifest",
-        schemaVersion: "pack-probe-v1",
-        generatedAt: "2026-05-05T12:31:10+08:00",
-      })}\n`,
-    )
+    const syncOutput = execFileSync("node", ["scripts/sync-cleaned.mjs", "--check"], {
+      cwd: dataPackageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const files = npmPackFiles()
 
-    try {
-      execFileSync("node", ["scripts/sync-cleaned.mjs"], {
-        cwd: dataPackageRoot,
-        stdio: ["ignore", "pipe", "pipe"],
-      })
-
-      const files = npmPackFiles()
-
-      expect(files).toContain("cleaned/qa-pack-probe.json")
-      expect(files).toContain("source-registry.json")
-      expect(files.some(file => file.startsWith("data/source/"))).toBe(false)
-      expect(files.some(file => file.startsWith("docs/reference/"))).toBe(false)
-      expect(files.some(file => file.endsWith(".xlsx"))).toBe(false)
-      expect(files.some(file => file.endsWith(".test.ts"))).toBe(false)
-    }
-    finally {
-      rmSync(sourceProbePath, { force: true })
-      rmSync(packageProbePath, { force: true })
-    }
+    expect(syncOutput).toContain("cleaned mirror check passed")
+    expect(files).toContain("cleaned/golden/v1-replay-report.json")
+    expect(files).toContain("cleaned/audit/nanoka-coverage-matrix.json")
+    expect(files).toContain("source-registry.json")
+    expect(files.some(file => file.startsWith("data/source/"))).toBe(false)
+    expect(files.some(file => file.startsWith("docs/reference/"))).toBe(false)
+    expect(files.some(file => file.endsWith(".xlsx"))).toBe(false)
+    expect(files.some(file => file.endsWith(".test.ts"))).toBe(false)
   })
 
   it("keeps the guide as reference material instead of formal cleaned data", () => {

--- a/packages/data/src/nanoka-adapter.test.ts
+++ b/packages/data/src/nanoka-adapter.test.ts
@@ -73,7 +73,11 @@ describe("nanoka raw snapshot adapter skeleton", () => {
         "data/source/raw/nanoka/zzz/2.8/boss.json",
         "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
         "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
         "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
       ]),
     )
     expect(descriptor.compliance.notes.join("\n")).toContain("manifest.zzz.live")

--- a/packages/data/src/nanoka-source-gate.test.ts
+++ b/packages/data/src/nanoka-source-gate.test.ts
@@ -16,6 +16,11 @@ type SourceRegistry = {
 
 type CoverageMatrix = {
   status: string
+  sampleSources: Array<{
+    id: string
+    version: string
+    approvedForCleanedOutput: boolean
+  }>
   rows: Array<{
     fieldId: string
     fieldClass?: string
@@ -185,6 +190,37 @@ describe("nanoka source gate", () => {
     ]))
     expect(row?.transformRule).toContain("colored damage phrase")
     expect(row?.transformRule).toContain("source /id to match the requested Bangboo id")
+  })
+
+  it("adds Phase 3 missing-anchor candidate samples without marking them exit-clean", () => {
+    const matrix = readJson<CoverageMatrix>("data/cleaned/audit/nanoka-coverage-matrix.json")
+    const samples = new Map(matrix.sampleSources.map(sample => [sample.id, sample]))
+    const rows = new Map(matrix.rows.map(row => [row.fieldId, row]))
+
+    for (const sampleId of [
+      "nanoka-character-nicole-live-1031",
+      "nanoka-character-yanagi-live-1221",
+      "nanoka-bangboo-penguinboo-live-53001",
+      "nanoka-bangboo-sharkboo-live-54001",
+    ]) {
+      expect(samples.get(sampleId)).toMatchObject({
+        version: "2.8",
+        approvedForCleanedOutput: true,
+      })
+    }
+
+    expect(rows.get("agents.passiveModifiers")?.supportingSampleEntities).toEqual(expect.arrayContaining([
+      "nanoka-character-nicole-live-1031",
+      "nanoka-character-yanagi-live-1221",
+    ]))
+    expect(rows.get("agents.passiveModifiers")?.blockedBy).toContain("typed-modifier-template-required")
+
+    for (const fieldId of ["bangboos.basePanel", "bangboos.skillSegments"]) {
+      expect(rows.get(fieldId)?.supportingSampleEntities).toEqual(expect.arrayContaining([
+        "nanoka-bangboo-penguinboo-live-53001",
+        "nanoka-bangboo-sharkboo-live-54001",
+      ]))
+    }
   })
 
   it("locks enemy variant mapping to approved live monster detail samples", () => {

--- a/packages/data/src/source-migration-drift.test.ts
+++ b/packages/data/src/source-migration-drift.test.ts
@@ -214,9 +214,9 @@ describe("Phase 3 source migration drift report foundation", () => {
       counts: {
         same: 0,
         changed: 0,
-        missing: 4,
+        missing: 0,
         new: 0,
-        "semantic-mismatch": 22,
+        "semantic-mismatch": 26,
       },
       unresolvedCount: 26,
     })
@@ -228,27 +228,35 @@ describe("Phase 3 source migration drift report foundation", () => {
       && row.blockedBy.includes("phase3:ruling-required"),
     )).toBe(true)
     expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor.startsWith("data/source/raw/nanoka/zzz/2.8/"))).toBe(true)
-    expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor === "data/cleaned/audit/nanoka-coverage-matrix.json")).toBe(true)
+    expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor.endsWith("nanoka-disorder-formula-audit.json"))).toBe(true)
     expect(report.rows.every(row => row.fieldId.endsWith(".nanokaCandidateCoverage"))).toBe(true)
     expect(report.rows.every(row => row.baselineValue !== "passed")).toBe(true)
     expect(report.rows.every(row => row.candidateValue.coverageStatus !== "passed")).toBe(true)
+    expect(report.rows.every(row => row.status === "semantic-mismatch")).toBe(true)
 
     const g22 = report.rows.find(row => row.entityId === "G22")
     const g24 = report.rows.find(row => row.entityId === "G24")
     const g26 = report.rows.find(row => row.entityId === "G26")
     expect(g22).toMatchObject({
-      status: "missing",
+      status: "semantic-mismatch",
       candidateValue: {
-        missingRequiredSampleEntities: ["nanoka-character-nicole-live-1031"],
+        missingRequiredSampleEntities: [],
+        requiredSampleEntities: ["nanoka-character-nicole-live-1031"],
       },
       candidateSourceRef: {
-        sourceAnchor: "data/cleaned/audit/nanoka-coverage-matrix.json",
+        sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        dataPath: "/stats",
       },
     })
     expect(g24).toMatchObject({
-      status: "missing",
+      status: "semantic-mismatch",
       candidateValue: {
-        missingRequiredSampleEntities: ["nanoka-bangboo-penguinboo-live-53001"],
+        missingRequiredSampleEntities: [],
+        requiredSampleEntities: ["nanoka-bangboo-penguinboo-live-53001"],
+      },
+      candidateSourceRef: {
+        sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        dataPath: "/stats",
       },
     })
     expect(g26).toMatchObject({

--- a/packages/data/src/sources.ts
+++ b/packages/data/src/sources.ts
@@ -55,6 +55,7 @@ export const dataSourceDescriptors = [
       "Deadly Assault period / zone / buff / boss detail raw fields",
       "Adrenaline and Resonance recovery raw fields",
       "enemy monster_info variant mapping raw fields",
+      "Phase 3 Nicole/Yanagi/Penguinboo/Sharkboo candidate coverage",
       "approved-live snapshot diff inputs",
     ],
     sourceVersionStrategy:
@@ -65,6 +66,8 @@ export const dataSourceDescriptors = [
       "data/source/raw/nanoka/zzz/2.8/boss.json",
       "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
       "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+      "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+      "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
       "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
       "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
       "data/source/raw/nanoka/zzz/2.8/zh/monster/30004.json",
@@ -73,6 +76,8 @@ export const dataSourceDescriptors = [
       "data/source/raw/nanoka/zzz/2.8/zh/monster/200034.json",
       "data/source/raw/nanoka/zzz/2.8/zh/monster/30033.json",
       "data/source/raw/nanoka/zzz/2.8/zh/monster/300211.json",
+      "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+      "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
     ],
     fetchPolicy: {
       mode: "httpGet",


### PR DESCRIPTION
## Summary

- retain approved-live nanoka raw samples for the four first-sync missing anchors:
  - G22 Nicole passive candidate: `zh/character/1031.json`
  - G23 Yanagi passive candidate: `zh/character/1221.json`
  - G24 Penguinboo candidate: `zh/bangboo/53001.json`
  - G25 Sharkboo candidate: `zh/bangboo/54001.json`
- update the nanoka fetch manifest, source manifest, source registry timestamps, and root/package coverage-matrix mirrors
- wire the new samples into `agents.passiveModifiers`, `bangboos.basePanel`, and `bangboos.skillSegments` supporting sample evidence without promoting unresolved typed modifier semantics
- regenerate `phase3-sync-001-g01-g26`: the first sync is now `missing=0`, `semantic-mismatch=26`, `unresolvedCount=26`, still not exit-clean and still no runtime cutover

## Scope boundaries

- no runtime cleaned-data cutover
- no numeric equality ruling yet; this only moves G22-G25 from missing-source to candidate-covered semantic-mismatch
- no G27/G28 anchors yet
- no typed modifier template promotion for Nicole/Yanagi passive rows

## Verification

- `pnpm --filter @randomplay/data fetch:nanoka --snapshot 2.8 --generated-at 2026-05-15T17:15:00+08:00`
- `pnpm --filter @randomplay/data audit:source-migration --sync-id phase3-sync-001-g01-g26 --generated-at 2026-05-15T17:25:00+08:00`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:source-migration --sync-id phase3-sync-000-foundation`
- `pnpm --filter @randomplay/data verify:source-migration --sync-id phase3-sync-001-g01-g26`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data test -- nanoka-source-gate.test.ts nanoka-adapter.test.ts source-migration-drift.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `npm pack --dry-run --json` in `packages/data` + drift artifact inclusion and raw/xlsx exclusion check
- `git diff --check`
