### PR TITLE
feat(data): add Phase 3 semantic rulings

### DIFF
--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
@@ -26,6 +26,7 @@
   ],
   "matrixStatus": "phase-3-drift-foundation-gate",
   "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": false,
   "counts": {
     "same": 0,
     "changed": 0,

--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-drift-report/v0.1",
   "syncId": "phase3-sync-001-g01-g26",
-  "generatedAt": "2026-05-15T17:25:00+08:00",
+  "generatedAt": "2026-05-15T17:45:00+08:00",
   "candidate": {
     "sourceId": "nanoka-zzz",
     "sourceVersion": "2.8",
@@ -26,6 +26,7 @@
   ],
   "matrixStatus": "phase-3-drift-foundation-gate",
   "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": false,
   "counts": {
     "same": 0,
     "changed": 0,
@@ -152,18 +153,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r001",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r001-g01",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
     },
     {
       "entityType": "enemy",
@@ -283,18 +282,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r002",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r002-g02",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
     },
     {
       "entityType": "agent",
@@ -355,16 +352,16 @@
         "availableSampleEntities": [
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r003",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r003-g03",
+      "blockedBy": [],
+      "notes": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
     },
     {
       "entityType": "rules",
@@ -435,17 +432,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r004",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r004-g04",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
     },
     {
       "entityType": "agent",
@@ -546,19 +542,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-boss-live-69036"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required",
-        "implementation-owned-runtime-formula",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r005",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r005-g05",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
     },
     {
       "entityType": "agent",
@@ -659,19 +652,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-boss-live-69036"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required",
-        "implementation-owned-runtime-formula",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r006",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r006-g06",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
     },
     {
       "entityType": "rules",
@@ -728,17 +718,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r007",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r007-g07",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
     },
     {
       "entityType": "agent",
@@ -813,17 +802,16 @@
         "availableSampleEntities": [
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r008",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r008-g08",
+      "blockedBy": [],
+      "notes": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
     },
     {
       "entityType": "deadlyAssault",
@@ -921,18 +909,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r009",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r009-g09",
+      "blockedBy": [],
+      "notes": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
     },
     {
       "entityType": "agent",
@@ -1025,18 +1011,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:attribute-mapping-source-required",
-        "field:resistance-unit-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r010",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r010-g10",
+      "blockedBy": [],
+      "notes": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
     },
     {
       "entityType": "agent",
@@ -1115,18 +1099,16 @@
         "availableSampleEntities": [
           "nanoka-character-yixuan-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:attribute-mapping-source-required",
-        "field:stat-unit-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r011",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r011-g11",
+      "blockedBy": [],
+      "notes": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
     },
     {
       "entityType": "enemy",
@@ -1224,18 +1206,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:anomaly-threshold-rule-source-required",
-        "field:anomaly-threshold-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r012",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r012-g12",
+      "blockedBy": [],
+      "notes": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
     },
     {
       "entityType": "enemy",
@@ -1351,19 +1331,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:anomaly-threshold-rule-source-required",
-        "field:anomaly-threshold-mapping-required",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r013",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r013-g13",
+      "blockedBy": [],
+      "notes": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
     },
     {
       "entityType": "agent",
@@ -1442,17 +1419,16 @@
         "availableSampleEntities": [
           "nanoka-bangboo-plugboo-live-54008"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r014",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r014-g14",
+      "blockedBy": [],
+      "notes": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
     },
     {
       "entityType": "rules",
@@ -1509,17 +1485,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r015",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r015-g15",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
     },
     {
       "entityType": "rules",
@@ -1576,17 +1551,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r016",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r016-g16",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
     },
     {
       "entityType": "deadlyAssault",
@@ -1684,18 +1658,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r017",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r017-g17",
+      "blockedBy": [],
+      "notes": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
     },
     {
       "entityType": "enemy",
@@ -1820,19 +1792,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required",
-        "typed-modifier-template-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r018",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r018-g18",
+      "blockedBy": [],
+      "notes": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
     },
     {
       "entityType": "enemy",
@@ -1935,18 +1904,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:daze-recovery-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r019",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r019-g19",
+      "blockedBy": [],
+      "notes": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
     },
     {
       "entityType": "enemy",
@@ -2051,18 +2018,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:daze-recovery-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r020",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r020-g20",
+      "blockedBy": [],
+      "notes": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
     },
     {
       "entityType": "agent",
@@ -2140,17 +2105,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r021",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r021-g21",
+      "blockedBy": [],
+      "notes": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
     },
     {
       "entityType": "agent",
@@ -2218,17 +2182,16 @@
           "nanoka-character-yanagi-live-1221",
           "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "typed-modifier-template-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r022",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r022-g22",
+      "blockedBy": [],
+      "notes": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
     },
     {
       "entityType": "agent",
@@ -2323,18 +2286,16 @@
           "nanoka-character-yanagi-live-1221",
           "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "typed-modifier-template-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r023",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r023-g23",
+      "blockedBy": [],
+      "notes": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
     },
     {
       "entityType": "bangboo",
@@ -2429,16 +2390,16 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r024",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r024-g24",
+      "blockedBy": [],
+      "notes": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
     },
     {
       "entityType": "bangboo",
@@ -2533,16 +2494,16 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r025",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r025-g25",
+      "blockedBy": [],
+      "notes": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
     },
     {
       "entityType": "bangboo",
@@ -2651,22 +2612,22 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r026",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r026-g26",
+      "blockedBy": [],
+      "notes": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
     }
   ],
-  "unresolvedCount": 26,
+  "unresolvedCount": 0,
   "notes": [
     "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
-    "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+    "This sync has Product/TL rulings for G01-G26, but it does not count as an exit-clean sync because G27/G28 and the two-clean-sync exit condition are still pending.",
     "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
   ]
 }

--- a/docs/data-source/drift-reports/phase3-sync-000-foundation.md
+++ b/docs/data-source/drift-reports/phase3-sync-000-foundation.md
@@ -34,6 +34,10 @@ Unresolved blocking drift rows: **0**
 
 Runtime cutover ready: **false**
 
+Exit-clean sync eligible: **false**
+
+
+
 ## Boundary
 
 - This artifact does not compare production fields yet.

--- a/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
+++ b/docs/data-source/drift-reports/phase3-sync-001-g01-g26.md
@@ -1,9 +1,9 @@
 # Nanoka Drift Report: phase3-sync-001-g01-g26
 
 Status: Phase 3 drift audit first G01-G26 sync
-Generated: 2026-05-15T17:25:00+08:00
+Generated: 2026-05-15T17:45:00+08:00
 
-This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths. Full runtime cutover remains disabled.
+This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths and records Product/TL rulings. Full runtime cutover remains disabled.
 
 ## Candidate
 
@@ -29,40 +29,42 @@ This report compares archived G01-G26 replay baselines against nanoka candidate 
 | `new` | 0 |
 | `semantic-mismatch` | 26 |
 
-Unresolved blocking drift rows: **26**
+Unresolved blocking drift rows: **0**
 
 Runtime cutover ready: **false**
 
+Exit-clean sync eligible: **false**
+
 ## Drift Rows
 
-| Entity | Field | Status | Ruling | Notes |
-|---|---|---|---|---|
-| `G01` | `goldenAnchors.G01.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G02` | `goldenAnchors.G02.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G03` | `goldenAnchors.G03.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G04` | `goldenAnchors.G04.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G05` | `goldenAnchors.G05.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G06` | `goldenAnchors.G06.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G07` | `goldenAnchors.G07.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G08` | `goldenAnchors.G08.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G09` | `goldenAnchors.G09.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G10` | `goldenAnchors.G10.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G11` | `goldenAnchors.G11.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G12` | `goldenAnchors.G12.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G13` | `goldenAnchors.G13.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G14` | `goldenAnchors.G14.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G15` | `goldenAnchors.G15.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G16` | `goldenAnchors.G16.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G17` | `goldenAnchors.G17.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G18` | `goldenAnchors.G18.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G19` | `goldenAnchors.G19.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G20` | `goldenAnchors.G20.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G21` | `goldenAnchors.G21.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
-| `G26` | `goldenAnchors.G26.nanokaCandidateCoverage` | `semantic-mismatch` | `pending` | First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline. |
+| Entity | Field | Status | Ruling | Ruling ID | Notes |
+|---|---|---|---|---|---|
+| `G01` | `goldenAnchors.G01.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r001` | Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover. |
+| `G02` | `goldenAnchors.G02.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r002` | Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only. |
+| `G03` | `goldenAnchors.G03.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r003` | Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned. |
+| `G04` | `goldenAnchors.G04.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r004` | Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor. |
+| `G05` | `goldenAnchors.G05.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r005` | Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands. |
+| `G06` | `goldenAnchors.G06.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r006` | Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned. |
+| `G07` | `goldenAnchors.G07.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r007` | Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior. |
+| `G08` | `goldenAnchors.G08.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r008` | Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior. |
+| `G09` | `goldenAnchors.G09.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r009` | Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned. |
+| `G10` | `goldenAnchors.G10.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r010` | Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned. |
+| `G11` | `goldenAnchors.G11.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r011` | Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields. |
+| `G12` | `goldenAnchors.G12.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r012` | Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned. |
+| `G13` | `goldenAnchors.G13.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r013` | Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor. |
+| `G14` | `goldenAnchors.G14.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r014` | Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned. |
+| `G15` | `goldenAnchors.G15.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r015` | Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof. |
+| `G16` | `goldenAnchors.G16.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r016` | Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof. |
+| `G17` | `goldenAnchors.G17.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r017` | Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule. |
+| `G18` | `goldenAnchors.G18.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r018` | Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4. |
+| `G19` | `goldenAnchors.G19.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r019` | Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula. |
+| `G20` | `goldenAnchors.G20.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r020` | Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula. |
+| `G21` | `goldenAnchors.G21.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r021` | Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied. |
+| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r022` | Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task. |
+| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r023` | Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later. |
+| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r024` | Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion. |
+| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r025` | Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion. |
+| `G26` | `goldenAnchors.G26.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r026` | Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence. |
 
 
 ## Boundary

--- a/docs/product/decisions/data-source-rulings.md
+++ b/docs/product/decisions/data-source-rulings.md
@@ -1,0 +1,142 @@
+# Phase 3 Data Source Rulings
+
+This log records Product + TL rulings for Phase 3 drift rows. These rulings resolve the G01-G26 first-sync queue for `phase3-sync-001-g01-g26`, but they do not make that sync exit-clean: G27/G28 and two consecutive clean syncs are still required before Phase 4 runtime cutover.
+
+Runtime cutover remains disabled. Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode data remain audit baselines only.
+
+## Summary
+
+| Ruling | Anchor | Status | Decision |
+|---|---|---|---|
+| `phase3-r001` | G01 | accepted | Accept nanoka DA boss context as the source replacement for the archived default-defense replay baseline. |
+| `phase3-r002` | G02 | accepted | Accept nanoka DA boss context for corrupted-shield defense replay; shield formula remains implementation-owned. |
+| `phase3-r003` | G03 | accepted | Accept deterministic nanoka character panel normalization; crit expected-value behavior remains formula-owned. |
+| `phase3-r004` | G04 | accepted | Accept implementation-owned penetration/damage formula boundary; nanoka is not expected to provide this formula table. |
+| `phase3-r005` | G05 | accepted | Accept nanoka Yixuan rupture raw fields and DA boss context; sheer semantics remain implementation-owned. |
+| `phase3-r006` | G06 | accepted | Accept nanoka source coverage for sheer-vs-default ratio replay with implementation-owned ratio semantics. |
+| `phase3-r007` | G07 | accepted | Accept implementation-owned rounding boundary. |
+| `phase3-r008` | G08 | accepted | Accept nanoka combat-panel raw fields plus implementation-owned anomaly mastery flooring behavior. |
+| `phase3-r009` | G09 | accepted | Accept nanoka DA daze-context evidence; display flooring remains implementation-owned. |
+| `phase3-r010` | G10 | accepted | Accept nanoka raw coverage plus implementation-owned Frost/Auric alias semantics. |
+| `phase3-r011` | G11 | accepted | Accept nanoka combat-panel raw coverage plus implementation-owned damage-bonus alias routing. |
+| `phase3-r012` | G12 | accepted | Accept nanoka enemy threshold raw coverage plus implementation-owned threshold formula constants. |
+| `phase3-r013` | G13 | accepted | Accept nanoka monster_info variant mapping plus implementation-owned threshold modifier constants. |
+| `phase3-r014` | G14 | accepted | Accept sourceRefs contract coverage plus implementation-owned virtual contribution behavior. |
+| `phase3-r015` | G15 | accepted | Accept failed-evidence ruling: Disorder formula remains implementation-owned. |
+| `phase3-r016` | G16 | accepted | Accept failed-evidence ruling: Disorder daze-level zone remains implementation-owned. |
+| `phase3-r017` | G17 | accepted | Accept nanoka DA boss max-HP context plus implementation-owned corrupted-shield cleanse true-damage rule. |
+| `phase3-r018` | G18 | accepted | Accept Greta monster_info variant source coverage plus implementation-owned part-break rule. |
+| `phase3-r019` | G19 | accepted | Accept Ruthless Fiend variant source coverage plus implementation-owned daze-recovery semantics. |
+| `phase3-r020` | G20 | accepted | Accept Hati/Armored Hati variant source coverage plus implementation-owned daze-recovery semantics. |
+| `phase3-r021` | G21 | accepted | Accept Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics. |
+| `phase3-r022` | G22 | accepted | Accept Nicole passive source coverage for the existing lo-user-approved defense-reduction replay. |
+| `phase3-r023` | G23 | accepted | Accept Yanagi passive source coverage for the existing lo-user-approved disorder boost and polarity-disorder replay. |
+| `phase3-r024` | G24 | accepted | Accept Penguinboo numeric parity from nanoka live panel and active skill raw values. |
+| `phase3-r025` | G25 | accepted | Accept Sharkboo numeric parity from nanoka live panel and active skill raw values. |
+| `phase3-r026` | G26 | accepted | Accept Plugboo numeric parity and electric element evidence from nanoka live panel, skill raw values, and skill text. |
+
+## Rulings
+
+### phase3-r001-g01
+
+Decision: accepted. Nanoka approved-live `2.8` DA period detail provides the boss context and `boss_adjust` evidence required to replace the archived buhflipexplode DA source for G01. The default-defense formula is owned by core and remains protected by golden replay; this ruling only accepts the source replacement boundary.
+
+### phase3-r002-g02
+
+Decision: accepted. G02 uses the same nanoka DA period/boss context as G01. The corrupted-shield multiplier is not a nanoka data field; it remains implementation-owned and golden-replay checked.
+
+### phase3-r003-g03
+
+Decision: accepted. Nanoka live character `stats` + `level` rows use the deterministic panel transform `stats[key] + level[promotionPhase][key] + stats[key_growth] * (level - 1) / 10000`. G03's crit expected-value calculation is formula-owned and is not sourced from nanoka.
+
+### phase3-r004-g04
+
+Decision: accepted. Nanoka does not expose a penetration/damage formula table. G04 remains implementation-owned with the retained guide anchor and executable golden replay as proof.
+
+### phase3-r005-g05
+
+Decision: accepted. Nanoka supplies Yixuan rupture raw fields and DA boss context, but the sheer defense-skip semantic mapping remains implementation-owned until the runtime mapper is promoted.
+
+### phase3-r006-g06
+
+Decision: accepted. Nanoka supplies the same Yixuan + DA source coverage as G05. The sheer-vs-default ratio remains a core formula/golden-replay proof, not a nanoka table.
+
+### phase3-r007-g07
+
+Decision: accepted. Per-segment rounding is an implementation-owned display/aggregation rule; no nanoka source table is expected.
+
+### phase3-r008-g08
+
+Decision: accepted. Nanoka supplies combat-panel raw fields such as anomaly mastery. The floor-before-buildup rule remains implementation-owned and golden-replay checked.
+
+### phase3-r009-g09
+
+Decision: accepted. Nanoka DA period detail supplies the boss/daze source context. Daze ratio display flooring remains implementation-owned.
+
+### phase3-r010-g10
+
+Decision: accepted. Nanoka supplies Yixuan and monster raw coverage. Frost-to-Ice and Auric-Ink-to-Ether alias semantics are implementation-owned mapping rules.
+
+### phase3-r011-g11
+
+Decision: accepted. Nanoka supplies combat-panel raw fields. Damage-bonus routing for Frost/Auric aliases remains implementation-owned.
+
+### phase3-r012-g12
+
+Decision: accepted. Nanoka monster details expose enemy anomaly-related raw coverage. Trigger-count and rank threshold constants remain implementation-owned.
+
+### phase3-r013-g13
+
+Decision: accepted. Nanoka `monster_info.*` variant mapping covers the relevant enemy identity boundary. The guide-sourced anomaly threshold modifiers remain implementation-owned golden replay evidence.
+
+### phase3-r014-g14
+
+Decision: accepted. Phase 2 promoted sourceRefs metadata emission. Virtual contribution inclusion/exclusion remains implementation-owned core behavior.
+
+### phase3-r015-g15
+
+Decision: accepted. Failed-evidence audit confirms nanoka has no Disorder formula endpoint/table. The Disorder formula remains implementation-owned with golden replay proof.
+
+### phase3-r016-g16
+
+Decision: accepted. Failed-evidence audit confirms nanoka has no Disorder daze-level zone endpoint/table. The daze-level zone formula remains implementation-owned with golden replay proof.
+
+### phase3-r017-g17
+
+Decision: accepted. Nanoka DA period detail supplies boss context and max-HP source evidence. The corrupted-shield cleanse true-damage rule remains implementation-owned.
+
+### phase3-r018-g18
+
+Decision: accepted. Nanoka `monster_info.*` covers Greta identity/variant mapping. The engineering-machine part-break rule remains guide/core-owned.
+
+### phase3-r019-g19
+
+Decision: accepted. Nanoka `monster_info.*` covers Ruthless Fiend identity/variant mapping. Daze-recovery composition remains guide/core-owned until a formal nanoka runtime mapper exists.
+
+### phase3-r020-g20
+
+Decision: accepted. Nanoka `monster_info.*` covers Hati and Armored Hati identity/variant mapping. Daze-recovery composition remains guide/core-owned until a formal nanoka runtime mapper exists.
+
+### phase3-r021-g21
+
+Decision: accepted. Nanoka supplies Yixuan panel and rupture raw coverage. Sheer defense-skip semantics remain implementation-owned and golden-replay checked.
+
+### phase3-r022-g22
+
+Decision: accepted. Nanoka approved-live Nicole detail supplies passive/source-text coverage for the existing lo-user-approved defense-reduction replay. Formal typed modifier template promotion remains a later transform task.
+
+### phase3-r023-g23
+
+Decision: accepted. Nanoka approved-live Yanagi detail supplies passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay. Formal typed modifier template promotion remains a later transform task.
+
+### phase3-r024-g24
+
+Decision: accepted. Nanoka approved-live Penguinboo panel and active skill raw values reproduce the archived Excel Path X numbers after unit conversion: attack `6198.0006`, active multiplier `4.62`, daze multiplier `2.7`, and anomaly buildup `346`.
+
+### phase3-r025-g25
+
+Decision: accepted. Nanoka approved-live Sharkboo panel and active skill raw values reproduce the archived Excel Path X numbers after unit conversion: attack `8057.0996`, active multiplier `3.84`, daze multiplier `1.4`, and anomaly buildup `180`.
+
+### phase3-r026-g26
+
+Decision: accepted. Nanoka approved-live Plugboo panel and active skill raw values reproduce the archived Excel Path X numbers after unit conversion: attack `8057.0996`, active multiplier `5.12`, daze multiplier `1.87`, and anomaly buildup `240`. Plugboo skill text also proves electric element evidence.

--- a/docs/product/decisions/index.md
+++ b/docs/product/decisions/index.md
@@ -33,6 +33,7 @@
 | **D-18** | V1 dogfooding gate（DD-003） | ✅ 锁定（2026-05-05） + 通过（2026-05-08 4/5） | V1 release gate 第 2 项从"3+ 社区试用"收窄为 lo-user 单人深度 dogfood + QA 回归；known limitations 显式标注未经社区广泛验证 + Day 3 跳过 | 高 |
 | **D-19** | V1 CLI 输出改革 | ✅ 锁定（2026-05-06） | `fairy calc` 默认 `--view brief` summary-first；完整 trace 通过 `--view verbose`；默认输出 `summary.lanes.nonCrit` / `summary.lanes.crit`，不使用期望伤害；`--result-mode expected` 保留为可选理论分析；其他二元输入差异通过 `fairy compare` | 中 |
 | **D-20** | 数据源迁移（Excel 永久停 → nanoka-exclusive）| ✅ 锁定（2026-05-15）| Path C nanoka-exclusive for ALL source-backed cleaned data（含 DA）；R1/R4/R6 final lock；Formal-Live Gate `manifest.zzz.live`（cleaned output 强制 live，latest 仅 research）；鸣徽 removed；Sentinel + patch history 进 V0.1.0 scope（R4.a snapshot-derived numeric diff）；D-17/D-12 archived audit baseline 保留到 Phase 4 cutover；V0.1.0 minor bump (schema breaking)；8 QA acceptance gates；45-row canonical-generated coverage matrix；Phase 0-4 plan ~3-4 周 sprint。详见 [`D-20-data-source-migration.md`](D-20-data-source-migration.md) | 中 |
+| **D-20-R** | Phase 3 drift rulings | 🟡 执行中 | G01-G26 first-sync rulings 记录在 [`data-source-rulings.md`](data-source-rulings.md)；ruling 只清除 pending queue，不代表 runtime cutover 或 exit-clean sync | 中 |
 | **D-1=D**（S2 节奏） | V1 推进顺序 | ✅ 锁定 | S2 双门槛：schema discovery + 并行 scraper 准备；S6 全量化最后；不允许 data 全量化阻塞 core 启动 | 中 |
 
 ---

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-000-foundation.json
@@ -26,6 +26,7 @@
   ],
   "matrixStatus": "phase-3-drift-foundation-gate",
   "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": false,
   "counts": {
     "same": 0,
     "changed": 0,

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-001-g01-g26.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "nanoka-drift-report/v0.1",
   "syncId": "phase3-sync-001-g01-g26",
-  "generatedAt": "2026-05-15T17:25:00+08:00",
+  "generatedAt": "2026-05-15T17:45:00+08:00",
   "candidate": {
     "sourceId": "nanoka-zzz",
     "sourceVersion": "2.8",
@@ -26,6 +26,7 @@
   ],
   "matrixStatus": "phase-3-drift-foundation-gate",
   "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": false,
   "counts": {
     "same": 0,
     "changed": 0,
@@ -152,18 +153,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r001",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r001-g01",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
     },
     {
       "entityType": "enemy",
@@ -283,18 +282,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r002",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r002-g02",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
     },
     {
       "entityType": "agent",
@@ -355,16 +352,16 @@
         "availableSampleEntities": [
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r003",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r003-g03",
+      "blockedBy": [],
+      "notes": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
     },
     {
       "entityType": "rules",
@@ -435,17 +432,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r004",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r004-g04",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
     },
     {
       "entityType": "agent",
@@ -546,19 +542,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-boss-live-69036"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required",
-        "implementation-owned-runtime-formula",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r005",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r005-g05",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
     },
     {
       "entityType": "agent",
@@ -659,19 +652,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-boss-live-69036"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required",
-        "implementation-owned-runtime-formula",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r006",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r006-g06",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
     },
     {
       "entityType": "rules",
@@ -728,17 +718,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r007",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r007-g07",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
     },
     {
       "entityType": "agent",
@@ -813,17 +802,16 @@
         "availableSampleEntities": [
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r008",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r008-g08",
+      "blockedBy": [],
+      "notes": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
     },
     {
       "entityType": "deadlyAssault",
@@ -921,18 +909,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r009",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r009-g09",
+      "blockedBy": [],
+      "notes": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
     },
     {
       "entityType": "agent",
@@ -1025,18 +1011,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:attribute-mapping-source-required",
-        "field:resistance-unit-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r010",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r010-g10",
+      "blockedBy": [],
+      "notes": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
     },
     {
       "entityType": "agent",
@@ -1115,18 +1099,16 @@
         "availableSampleEntities": [
           "nanoka-character-yixuan-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:attribute-mapping-source-required",
-        "field:stat-unit-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r011",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r011-g11",
+      "blockedBy": [],
+      "notes": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
     },
     {
       "entityType": "enemy",
@@ -1224,18 +1206,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:anomaly-threshold-rule-source-required",
-        "field:anomaly-threshold-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r012",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r012-g12",
+      "blockedBy": [],
+      "notes": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
     },
     {
       "entityType": "enemy",
@@ -1351,19 +1331,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:anomaly-threshold-rule-source-required",
-        "field:anomaly-threshold-mapping-required",
-        "field:runtime-cutover-drift-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r013",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r013-g13",
+      "blockedBy": [],
+      "notes": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
     },
     {
       "entityType": "agent",
@@ -1442,17 +1419,16 @@
         "availableSampleEntities": [
           "nanoka-bangboo-plugboo-live-54008"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r014",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r014-g14",
+      "blockedBy": [],
+      "notes": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
     },
     {
       "entityType": "rules",
@@ -1509,17 +1485,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r015",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r015-g15",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
     },
     {
       "entityType": "rules",
@@ -1576,17 +1551,16 @@
         ],
         "requiredSampleEntities": [],
         "availableSampleEntities": [],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r016",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r016-g16",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
     },
     {
       "entityType": "deadlyAssault",
@@ -1684,18 +1658,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r017",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r017-g17",
+      "blockedBy": [],
+      "notes": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
     },
     {
       "entityType": "enemy",
@@ -1820,19 +1792,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:enemy-level-formula-required",
-        "typed-modifier-template-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r018",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r018-g18",
+      "blockedBy": [],
+      "notes": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
     },
     {
       "entityType": "enemy",
@@ -1935,18 +1904,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:daze-recovery-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r019",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r019-g19",
+      "blockedBy": [],
+      "notes": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
     },
     {
       "entityType": "enemy",
@@ -2051,18 +2018,16 @@
           "nanoka-monster-miasma-priest-live-30033",
           "nanoka-monster-notorious-pompey-live-300211"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:runtime-cutover-drift-required",
-        "field:daze-recovery-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r020",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r020-g20",
+      "blockedBy": [],
+      "notes": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
     },
     {
       "entityType": "agent",
@@ -2140,17 +2105,16 @@
           "nanoka-character-yixuan-1371",
           "nanoka-character-nekomata-live-1021"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "field:rupture-semantic-mapping-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r021",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r021-g21",
+      "blockedBy": [],
+      "notes": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
     },
     {
       "entityType": "agent",
@@ -2218,17 +2182,16 @@
           "nanoka-character-yanagi-live-1221",
           "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "typed-modifier-template-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r022",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r022-g22",
+      "blockedBy": [],
+      "notes": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
     },
     {
       "entityType": "agent",
@@ -2323,18 +2286,16 @@
           "nanoka-character-yanagi-live-1221",
           "nanoka-character-yixuan-live-1371"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required",
-        "typed-modifier-template-required",
-        "implementation-owned-runtime-formula"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r023",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r023-g23",
+      "blockedBy": [],
+      "notes": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
     },
     {
       "entityType": "bangboo",
@@ -2429,16 +2390,16 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r024",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r024-g24",
+      "blockedBy": [],
+      "notes": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
     },
     {
       "entityType": "bangboo",
@@ -2533,16 +2494,16 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r025",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r025-g25",
+      "blockedBy": [],
+      "notes": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
     },
     {
       "entityType": "bangboo",
@@ -2651,22 +2612,22 @@
           "nanoka-bangboo-penguinboo-live-53001",
           "nanoka-bangboo-sharkboo-live-54001"
         ],
-        "missingRequiredSampleEntities": []
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
       },
       "status": "semantic-mismatch",
-      "severity": "blocking",
-      "rulingStatus": "pending",
-      "blockedBy": [
-        "phase3:ruling-required",
-        "phase3:semantic-equivalence-ruling-required"
-      ],
-      "notes": "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline."
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r026",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r026-g26",
+      "blockedBy": [],
+      "notes": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
     }
   ],
-  "unresolvedCount": 26,
+  "unresolvedCount": 0,
   "notes": [
     "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
-    "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+    "This sync has Product/TL rulings for G01-G26, but it does not count as an exit-clean sync because G27/G28 and the two-clean-sync exit condition are still pending.",
     "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
   ]
 }

--- a/packages/data/scripts/source-migration-drift.mjs
+++ b/packages/data/scripts/source-migration-drift.mjs
@@ -17,6 +17,7 @@ const schemaVersion = "nanoka-drift-report/v0.1"
 const defaultSyncId = "phase3-sync-000-foundation"
 const firstSyncId = "phase3-sync-001-g01-g26"
 const defaultGeneratedAt = "2026-05-15T16:20:00+08:00"
+const rulingDecisionLogPath = "docs/product/decisions/data-source-rulings.md"
 const driftStatuses = ["same", "changed", "missing", "new", "semantic-mismatch"]
 const entityTypes = ["agent", "bangboo", "enemy", "wEngine", "driveDisc", "deadlyAssault", "metadata", "rules"]
 const severities = ["info", "blocking"]
@@ -124,6 +125,7 @@ function reportHeader({ syncId, generatedAt }) {
     baselines: requiredBaselineIds.map(sourceId => baselineFromRegistry(registry, sourceId)),
     matrixStatus: matrix.status,
     runtimeCutoverReady: false,
+    exitCleanSyncEligible: false,
   }
 }
 
@@ -291,6 +293,113 @@ const anchorCandidateSpecs = {
     fieldIds: ["bangboos.basePanel", "bangboos.skillSegments", "bangboos.element"],
     requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
     expectedCandidate: "Plugboo panel, skill numeric, and element source coverage.",
+  },
+}
+
+const phase3Rulings = {
+  G01: {
+    rulingId: "phase3-r001",
+    summary: "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover.",
+  },
+  G02: {
+    rulingId: "phase3-r002",
+    summary: "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only.",
+  },
+  G03: {
+    rulingId: "phase3-r003",
+    summary: "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned.",
+  },
+  G04: {
+    rulingId: "phase3-r004",
+    summary: "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor.",
+  },
+  G05: {
+    rulingId: "phase3-r005",
+    summary: "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands.",
+  },
+  G06: {
+    rulingId: "phase3-r006",
+    summary: "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned.",
+  },
+  G07: {
+    rulingId: "phase3-r007",
+    summary: "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior.",
+  },
+  G08: {
+    rulingId: "phase3-r008",
+    summary: "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior.",
+  },
+  G09: {
+    rulingId: "phase3-r009",
+    summary: "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned.",
+  },
+  G10: {
+    rulingId: "phase3-r010",
+    summary: "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned.",
+  },
+  G11: {
+    rulingId: "phase3-r011",
+    summary: "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields.",
+  },
+  G12: {
+    rulingId: "phase3-r012",
+    summary: "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned.",
+  },
+  G13: {
+    rulingId: "phase3-r013",
+    summary: "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor.",
+  },
+  G14: {
+    rulingId: "phase3-r014",
+    summary: "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned.",
+  },
+  G15: {
+    rulingId: "phase3-r015",
+    summary: "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof.",
+  },
+  G16: {
+    rulingId: "phase3-r016",
+    summary: "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof.",
+  },
+  G17: {
+    rulingId: "phase3-r017",
+    summary: "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule.",
+  },
+  G18: {
+    rulingId: "phase3-r018",
+    summary: "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4.",
+  },
+  G19: {
+    rulingId: "phase3-r019",
+    summary: "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula.",
+  },
+  G20: {
+    rulingId: "phase3-r020",
+    summary: "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula.",
+  },
+  G21: {
+    rulingId: "phase3-r021",
+    summary: "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied.",
+  },
+  G22: {
+    rulingId: "phase3-r022",
+    summary: "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task.",
+  },
+  G23: {
+    rulingId: "phase3-r023",
+    summary: "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later.",
+  },
+  G24: {
+    rulingId: "phase3-r024",
+    summary: "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion.",
+  },
+  G25: {
+    rulingId: "phase3-r025",
+    summary: "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion.",
+  },
+  G26: {
+    rulingId: "phase3-r026",
+    summary: "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence.",
   },
 }
 
@@ -477,11 +586,15 @@ function buildG01G26Report({ syncId, generatedAt }) {
     const requiredSampleEntities = spec.requiredSampleEntities ?? []
     const missingRequiredSampleEntities = requiredSampleEntities.filter(sample => !availableSampleEntities.includes(sample))
     const status = missingRequiredSampleEntities.length > 0 ? "missing" : "semantic-mismatch"
-    const blockedBy = unique([
-      "phase3:ruling-required",
-      status === "missing" ? "phase3:candidate-source-missing" : "phase3:semantic-equivalence-ruling-required",
-      ...matrixRows.flatMap(({ row }) => rowBlockers(row)),
-    ])
+    const ruling = status === "semantic-mismatch" ? phase3Rulings[anchorId] : undefined
+    const rulingStatus = ruling === undefined ? "pending" : "accepted"
+    const blockedBy = rulingStatus === "pending"
+      ? unique([
+          "phase3:ruling-required",
+          status === "missing" ? "phase3:candidate-source-missing" : "phase3:semantic-equivalence-ruling-required",
+          ...matrixRows.flatMap(({ row }) => rowBlockers(row)),
+        ])
+      : []
 
     return {
       entityType: spec.entityType,
@@ -509,14 +622,21 @@ function buildG01G26Report({ syncId, generatedAt }) {
         requiredSampleEntities,
         availableSampleEntities,
         missingRequiredSampleEntities,
+        rulingSummary: ruling?.summary,
       },
       status,
-      severity: "blocking",
-      rulingStatus: "pending",
+      severity: rulingStatus === "pending" ? "blocking" : "info",
+      rulingStatus,
+      ...(ruling === undefined
+        ? {}
+        : {
+            rulingId: ruling.rulingId,
+            rulingDecisionLog: `${rulingDecisionLogPath}#${ruling.rulingId}-${anchorId.toLowerCase()}`,
+          }),
       blockedBy,
       notes: status === "missing"
         ? `First sync is missing required approved-live nanoka candidate sample(s): ${missingRequiredSampleEntities.join(", ")}.`
-        : "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline.",
+        : ruling?.summary ?? "First sync has nanoka candidate coverage, but Phase 3 has not ruled semantic equivalence against the archived golden replay baseline.",
     }
   })
 
@@ -524,10 +644,10 @@ function buildG01G26Report({ syncId, generatedAt }) {
     ...header,
     counts: countsForRows(rows),
     rows,
-    unresolvedCount: rows.length,
+    unresolvedCount: rows.filter(row => row.rulingStatus === "pending" || row.rulingStatus === "owner-required").length,
     notes: [
       "Phase 3 first sync compares G01-G26 archived golden replay baselines against real nanoka candidate coverage/status/source paths.",
-      "This sync intentionally exposes unresolved missing/semantic drift rows; it does not count as an exit-clean sync until Product/TL rulings clear the queue.",
+      "This sync has Product/TL rulings for G01-G26, but it does not count as an exit-clean sync because G27/G28 and the two-clean-sync exit condition are still pending.",
       "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs.",
     ],
   }
@@ -551,12 +671,12 @@ function renderMarkdown(report) {
   const hasRows = report.rows.length > 0
   const statusLine = hasRows ? "Phase 3 drift audit first G01-G26 sync" : "Phase 3 drift audit foundation fixture"
   const intro = hasRows
-    ? "This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths. Full runtime cutover remains disabled."
+    ? "This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths and records Product/TL rulings. Full runtime cutover remains disabled."
     : `This report is a schema/verifier fixture. It intentionally contains no field
 comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.`
   const driftRows = hasRows
     ? report.rows
-        .map(row => `| \`${row.entityId}\` | \`${row.fieldId}\` | \`${row.status}\` | \`${row.rulingStatus}\` | ${row.notes} |`)
+        .map(row => `| \`${row.entityId}\` | \`${row.fieldId}\` | \`${row.status}\` | \`${row.rulingStatus}\` | ${row.rulingId === undefined ? "" : `\`${row.rulingId}\``} | ${row.notes} |`)
         .join("\n")
     : ""
 
@@ -589,11 +709,13 @@ Unresolved blocking drift rows: **${report.unresolvedCount}**
 
 Runtime cutover ready: **${report.runtimeCutoverReady}**
 
+Exit-clean sync eligible: **${report.exitCleanSyncEligible}**
+
 ${hasRows
   ? `## Drift Rows
 
-| Entity | Field | Status | Ruling | Notes |
-|---|---|---|---|---|
+| Entity | Field | Status | Ruling | Ruling ID | Notes |
+|---|---|---|---|---|---|
 ${driftRows}
 `
   : ""}
@@ -645,19 +767,44 @@ function validateRows(report) {
       assert(JSON.stringify(row.baselineValue) === JSON.stringify(row.candidateValue), `${label}: same rows must have equal normalized values`)
     }
     else {
-      assert(row.severity === "blocking", `${label}: non-same drift rows are blocking until ruled`)
       assert(row.rulingStatus !== "not-required", `${label}: non-same rows require explicit ruling queue status`)
       if (row.rulingStatus === "pending" || row.rulingStatus === "owner-required") {
+        assert(row.severity === "blocking", `${label}: unresolved non-same rows must be blocking`)
+        assert(row.blockedBy.length > 0, `${label}: unresolved non-same rows must carry blockers`)
         unresolvedCount += 1
       }
       else {
+        assert(row.severity === "info", `${label}: resolved non-same rows must be informational`)
+        assert(row.blockedBy.length === 0, `${label}: resolved non-same rows must not carry blockers`)
         assert(typeof row.rulingId === "string" && row.rulingId.length > 0, `${label}: resolved non-same rows require rulingId`)
+        assert(typeof row.rulingDecisionLog === "string" && row.rulingDecisionLog.length > 0, `${label}: resolved non-same rows require rulingDecisionLog`)
+        const [decisionLogPath] = row.rulingDecisionLog.split("#")
+        assert(decisionLogPath === rulingDecisionLogPath, `${label}: rulingDecisionLog must point to ${rulingDecisionLogPath}`)
+        const decisionLogText = readFileSync(join(repoRoot, decisionLogPath), "utf8")
+        assert(decisionLogText.includes(row.rulingId), `${label}: rulingDecisionLog must contain ${row.rulingId}`)
       }
     }
   }
 
   assert(JSON.stringify(report.counts) === JSON.stringify(actualCounts), "counts must equal row status totals")
   assert(report.unresolvedCount === unresolvedCount, "unresolvedCount must equal pending/owner-required blocking rows")
+}
+
+function validateExitCleanEligibility(report, { syncId }) {
+  if (!report.exitCleanSyncEligible)
+    return
+
+  assert(syncId !== defaultSyncId, `${syncId}: foundation sync cannot be exit-clean eligible`)
+  assert(syncId !== firstSyncId, `${syncId}: first G01-G26 sync cannot be exit-clean eligible before G27/G28 and two clean sync evidence`)
+  assert(report.runtimeCutoverReady === false, "exit-clean drift sync must still not cut runtime over")
+  assert(report.unresolvedCount === 0, "exit-clean drift sync cannot have unresolved rows")
+
+  const evidence = report.exitGateEvidence
+  assert(evidence !== null && typeof evidence === "object" && !Array.isArray(evidence), "exitCleanSyncEligible requires exitGateEvidence")
+  assert(Array.isArray(evidence.cleanSyncIds) && evidence.cleanSyncIds.length >= 2, "exitGateEvidence.cleanSyncIds must include at least two clean syncs")
+  assert(evidence.cleanSyncIds.includes(syncId), "exitGateEvidence.cleanSyncIds must include the current syncId")
+  assert(Array.isArray(evidence.anchorIds) && evidence.anchorIds.includes("G27") && evidence.anchorIds.includes("G28"), "exitGateEvidence.anchorIds must include G27 and G28")
+  assert(evidence.goldenReplayStatus === "passed", "exitGateEvidence.goldenReplayStatus must be passed")
 }
 
 function validateReportShape(report, { registry, matrix, syncId }) {
@@ -672,6 +819,8 @@ function validateReportShape(report, { registry, matrix, syncId }) {
   assert(report.candidate.sourceVersion !== nanoka.latestResearchVersion, "candidate must not use latest research version")
   assert(report.matrixStatus === matrix.status, "matrixStatus must match current nanoka coverage matrix")
   assert(report.runtimeCutoverReady === false, "Phase 3 drift reports must not imply runtime cutover")
+  assert(typeof report.exitCleanSyncEligible === "boolean", "exitCleanSyncEligible is required")
+  validateExitCleanEligibility(report, { syncId })
 
   assert(Array.isArray(report.baselines), "baselines must be an array")
   for (const sourceId of requiredBaselineIds) {

--- a/packages/data/src/source-migration-drift.test.ts
+++ b/packages/data/src/source-migration-drift.test.ts
@@ -24,6 +24,7 @@ type DriftReport = {
   }>
   matrixStatus: string
   runtimeCutoverReady: boolean
+  exitCleanSyncEligible: boolean
   counts: Record<"same" | "changed" | "missing" | "new" | "semantic-mismatch", number>
   rows: Array<{
     entityType: string
@@ -42,13 +43,21 @@ type DriftReport = {
       requiredSampleEntities: string[]
       availableSampleEntities: string[]
       missingRequiredSampleEntities: string[]
+      rulingSummary?: string
     }
     status: string
     severity: string
     rulingStatus: string
+    rulingId?: string
+    rulingDecisionLog?: string
     blockedBy: string[]
   }>
   unresolvedCount: number
+  exitGateEvidence?: {
+    cleanSyncIds: string[]
+    anchorIds: string[]
+    goldenReplayStatus: string
+  }
 }
 
 function readJson<T>(path: string): T {
@@ -95,6 +104,7 @@ describe("Phase 3 source migration drift report foundation", () => {
       },
       matrixStatus: "phase-3-drift-foundation-gate",
       runtimeCutoverReady: false,
+      exitCleanSyncEligible: false,
       counts: {
         same: 0,
         changed: 0,
@@ -185,6 +195,62 @@ describe("Phase 3 source migration drift report foundation", () => {
     }
   })
 
+  it("rejects resolved non-same drift rows without decision-log backlinks", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const fixturePath = join(tempDir, "missing-ruling-log-report.json")
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${firstSyncId}.json`)
+    const missingBacklinkReport = {
+      ...report,
+      rows: report.rows.map((row, index) => {
+        if (index !== 0)
+          return row
+        const withoutBacklink = { ...row }
+        delete withoutBacklink.rulingDecisionLog
+        return withoutBacklink
+      }),
+    }
+
+    try {
+      writeFileSync(fixturePath, `${JSON.stringify(missingBacklinkReport, null, 2)}\n`)
+
+      expect(() =>
+        execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", firstSyncId, "--report", fixturePath], {
+          cwd: dataPackageRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).toThrow("resolved non-same rows require rulingDecisionLog")
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("rejects first-sync reports that claim exit-clean eligibility before G27/G28 and two clean syncs", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const fixturePath = join(tempDir, "premature-exit-clean-report.json")
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${firstSyncId}.json`)
+    const prematureExitCleanReport = {
+      ...report,
+      exitCleanSyncEligible: true,
+    }
+
+    try {
+      writeFileSync(fixturePath, `${JSON.stringify(prematureExitCleanReport, null, 2)}\n`)
+
+      expect(() =>
+        execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", firstSyncId, "--report", fixturePath], {
+          cwd: dataPackageRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).toThrow("first G01-G26 sync cannot be exit-clean eligible before G27/G28 and two clean sync evidence")
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it("documents the no-runtime-fallback boundary in the human report", () => {
     const report = readFileSync(join(repoRoot, `docs/data-source/drift-reports/${syncId}.md`), "utf8")
 
@@ -211,6 +277,7 @@ describe("Phase 3 source migration drift report foundation", () => {
         sourceVersion: "2.8",
       },
       runtimeCutoverReady: false,
+      exitCleanSyncEligible: false,
       counts: {
         same: 0,
         changed: 0,
@@ -218,14 +285,16 @@ describe("Phase 3 source migration drift report foundation", () => {
         new: 0,
         "semantic-mismatch": 26,
       },
-      unresolvedCount: 26,
+      unresolvedCount: 0,
     })
     expect(report.rows).toHaveLength(26)
     expect(report.rows.map(row => row.entityId)).toEqual(Array.from({ length: 26 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`))
     expect(report.rows.every(row =>
-      row.severity === "blocking"
-      && row.rulingStatus === "pending"
-      && row.blockedBy.includes("phase3:ruling-required"),
+      row.severity === "info"
+      && row.rulingStatus === "accepted"
+      && row.rulingId?.startsWith("phase3-r")
+      && row.rulingDecisionLog?.startsWith("docs/product/decisions/data-source-rulings.md#phase3-r")
+      && row.blockedBy.length === 0,
     )).toBe(true)
     expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor.startsWith("data/source/raw/nanoka/zzz/2.8/"))).toBe(true)
     expect(report.rows.some(row => row.candidateSourceRef.sourceAnchor.endsWith("nanoka-disorder-formula-audit.json"))).toBe(true)
@@ -233,12 +302,15 @@ describe("Phase 3 source migration drift report foundation", () => {
     expect(report.rows.every(row => row.baselineValue !== "passed")).toBe(true)
     expect(report.rows.every(row => row.candidateValue.coverageStatus !== "passed")).toBe(true)
     expect(report.rows.every(row => row.status === "semantic-mismatch")).toBe(true)
+    expect(report.rows.every(row => row.candidateValue.rulingSummary !== undefined)).toBe(true)
 
     const g22 = report.rows.find(row => row.entityId === "G22")
     const g24 = report.rows.find(row => row.entityId === "G24")
     const g26 = report.rows.find(row => row.entityId === "G26")
     expect(g22).toMatchObject({
       status: "semantic-mismatch",
+      rulingStatus: "accepted",
+      rulingId: "phase3-r022",
       candidateValue: {
         missingRequiredSampleEntities: [],
         requiredSampleEntities: ["nanoka-character-nicole-live-1031"],
@@ -250,6 +322,8 @@ describe("Phase 3 source migration drift report foundation", () => {
     })
     expect(g24).toMatchObject({
       status: "semantic-mismatch",
+      rulingStatus: "accepted",
+      rulingId: "phase3-r024",
       candidateValue: {
         missingRequiredSampleEntities: [],
         requiredSampleEntities: ["nanoka-bangboo-penguinboo-live-53001"],
@@ -261,6 +335,8 @@ describe("Phase 3 source migration drift report foundation", () => {
     })
     expect(g26).toMatchObject({
       status: "semantic-mismatch",
+      rulingStatus: "accepted",
+      rulingId: "phase3-r026",
       candidateSourceRef: {
         sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
         dataPath: "/stats",
@@ -280,7 +356,9 @@ describe("Phase 3 source migration drift report foundation", () => {
     const report = readFileSync(join(repoRoot, `docs/data-source/drift-reports/${firstSyncId}.md`), "utf8")
     expect(report).toContain(`# Nanoka Drift Report: ${firstSyncId}`)
     expect(report).toContain("Phase 3 drift audit first G01-G26 sync")
-    expect(report).toContain("Unresolved blocking drift rows: **26**")
+    expect(report).toContain("Unresolved blocking drift rows: **0**")
+    expect(report).toContain("Exit-clean sync eligible: **false**")
+    expect(report).toContain("`phase3-r026`")
     expect(report).toContain("`goldenAnchors.G26.nanokaCandidateCoverage`")
     expect(report).toContain("Runtime cutover ready: **false**")
   })


### PR DESCRIPTION
## Slock Context

Owner: @TechLead
Task: task #167
Reviewers: @Product first, then @QA
Related decisions: D-20, D-20-R
Runtime cutover: no

## Summary

- Adds `docs/product/decisions/data-source-rulings.md` with 26 Product/TL draft rulings for G01-G26 first-sync semantic mismatches.
- Updates `phase3-sync-001-g01-g26` so all 26 rows remain `semantic-mismatch` but have `rulingStatus=accepted`, explicit `phase3-r###` IDs, and decision-log backlinks.
- Keeps `unresolvedCount=0`, `runtimeCutoverReady=false`, and `exitCleanSyncEligible=false`; this is not a clean sync and does not count toward Phase 3 exit.
- Extends the verifier so resolved non-`same` rows require `rulingId` + decision-log backlink; pending/owner-required rows are the only unresolved rows.

## Verification

- `pnpm --filter @randomplay/data audit:source-migration -- --sync-id phase3-sync-001-g01-g26 --generated-at 2026-05-15T17:45:00+08:00`
- `pnpm --filter @randomplay/data audit:source-migration -- --sync-id phase3-sync-000-foundation --generated-at 2026-05-15T16:20:00+08:00`
- `pnpm --filter @randomplay/data verify:source-migration`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-000-foundation`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-001-g01-g26`
- `pnpm --filter @randomplay/data test -- source-migration-drift.test.ts`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `node scripts/sync-cleaned.mjs --check` from `packages/data`
- data package `npm pack --dry-run --json` inclusion/exclusion check
- `git diff --check`

## Review Focus

Product: confirm whether the 26 draft rulings are acceptable or whether any row should move to `owner-required` / escalation.
QA: after Product confirms, verify Gate 8 semantics: no `not-required` bypass, backlink enforcement, correct unresolved count, no exit-clean claim, no runtime cutover.