### PR TITLE
feat(data): add Phase 3 G27/G28 sync

### DIFF
--- a/data/cleaned/audit/nanoka-drift-report/phase3-sync-002-g27-g28.json
+++ b/data/cleaned/audit/nanoka-drift-report/phase3-sync-002-g27-g28.json
@@ -1,0 +1,2829 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-002-g27-g28",
+  "generatedAt": "2026-05-15T18:20:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": true,
+  "exitGateEvidence": {
+    "cleanSyncIds": [
+      "phase3-sync-001-g01-g26",
+      "phase3-sync-002-g27-g28"
+    ],
+    "anchorIds": [
+      "G01",
+      "G02",
+      "G03",
+      "G04",
+      "G05",
+      "G06",
+      "G07",
+      "G08",
+      "G09",
+      "G10",
+      "G11",
+      "G12",
+      "G13",
+      "G14",
+      "G15",
+      "G16",
+      "G17",
+      "G18",
+      "G19",
+      "G20",
+      "G21",
+      "G22",
+      "G23",
+      "G24",
+      "G25",
+      "G26",
+      "G27",
+      "G28"
+    ],
+    "goldenReplayStatus": "passed",
+    "requiredNewProofAnchorIds": [
+      "G27",
+      "G28"
+    ],
+    "previousCleanSyncId": "phase3-sync-001-g01-g26",
+    "currentSyncId": "phase3-sync-002-g27-g28",
+    "notes": [
+      "G01-G26 are accepted in phase3-sync-001-g01-g26.",
+      "G27/G28 are lo-user-selected approved-live nanoka proof anchors.",
+      "Runtime cutover remains disabled until Phase 4."
+    ]
+  },
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 0,
+    "new": 2,
+    "semantic-mismatch": 26
+  },
+  "rows": [
+    {
+      "entityType": "enemy",
+      "entityId": "G01",
+      "fieldId": "goldenAnchors.G01.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G01.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G01/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G01/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G01/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G01/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Default boss defense multiplier replays against sourced DA slot 0 boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus enemy defense defaults for the sourced boss replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r001",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r001-g01",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G02",
+      "fieldId": "goldenAnchors.G02.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G02.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G02/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G02/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G02/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G02/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted-shield state uses the core 1.8x defense multiplier with sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus corrupted-shield defense-state coverage.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r002",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r002-g02",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G03",
+      "fieldId": "goldenAnchors.G03.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G03.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G03/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G03/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G03/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Crit expected value uses 1 + critRate * critDamage."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent panel fields needed by crit expected-value replay.",
+        "fieldIds": [
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r003",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r003-g03",
+      "blockedBy": [],
+      "notes": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G04",
+      "fieldId": "goldenAnchors.G04.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G04.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G04/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+        "dataPath": "/anchors/G04/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/38"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+            "dataPath": "/anchors/G04/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned penetration and damage formula constants.",
+        "fieldIds": [
+          "rules.baseDamageFormula",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r004",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r004-g04",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G05",
+      "fieldId": "goldenAnchors.G05.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G05.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G05/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G05/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G05/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G05/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer damage skips defense while regular damage sees corrupted-shield defense."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for defense-skip replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r005",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r005-g05",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G06",
+      "fieldId": "goldenAnchors.G06.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G06.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G06/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G06/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G06/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G06/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer vs default boss ratio replays with the same sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for sheer-vs-default ratio replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r006",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r006-g06",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G07",
+      "fieldId": "goldenAnchors.G07.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G07.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G07/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G07/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/39"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G07/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Two fractional segments ceil before summing."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned rounding contract for per-segment ceil behavior.",
+        "fieldIds": [
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r007",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r007-g07",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G08",
+      "fieldId": "goldenAnchors.G08.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G08.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G08/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G08/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G08/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Anomaly Mastery floors before buildup."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent anomaly panel fields plus rounding behavior for buildup replay.",
+        "fieldIds": [
+          "agents.basePanel",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r008",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r008-g08",
+      "blockedBy": [],
+      "notes": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G09",
+      "fieldId": "goldenAnchors.G09.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G09.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G09/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G09/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G09/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G09/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max-daze and enemy-level context for daze-cap replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r009",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r009-g09",
+      "blockedBy": [],
+      "notes": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G10",
+      "fieldId": "goldenAnchors.G10.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G10.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G10/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G10/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G10/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and enemy resistance source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "enemies.resistance"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.resistance",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:resistance-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r010",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r010-g10",
+      "blockedBy": [],
+      "notes": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G11",
+      "fieldId": "goldenAnchors.G11.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G11.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G11/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G11/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G11/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost/Auric use Ice/Ether damage-bonus panel fields."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and combat-panel damage-bonus source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "agents.combatPanelStats"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "agents.combatPanelStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:stat-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r011",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r011-g11",
+      "blockedBy": [],
+      "notes": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G12",
+      "fieldId": "goldenAnchors.G12.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G12.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G12/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G12/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G12/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G12/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Boss trigger-count threshold and physical 1.2x multiplier replay from core constants."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold source coverage and trigger-rank rule mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r012",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r012-g12",
+      "blockedBy": [],
+      "notes": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G13",
+      "fieldId": "goldenAnchors.G13.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G13.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G13/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+        "dataPath": "/anchors/G13/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+            "dataPath": "/anchors/G13/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+          "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold modifiers plus monster_info variant mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r013",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r013-g13",
+      "blockedBy": [],
+      "notes": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G14",
+      "fieldId": "goldenAnchors.G14.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G14.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G14/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G14/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G14/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A4:AF4",
+            "dataPath": "/anchors/G14/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Virtual contribution rows include Bangboo exclusion and overflow handling."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "SourceRef emission plus implementation-owned virtual-contribution behavior.",
+        "fieldIds": [
+          "metadata.sourceRefs",
+          "rules.baseDamageFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "metadata.sourceRefs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "derived-from-source-registry",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r014",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r014-g14",
+      "blockedBy": [],
+      "notes": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G15",
+      "fieldId": "goldenAnchors.G15.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G15.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G15/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G15/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G15/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "All seven disorder formula paths replay, including polarity disorder."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder formula boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r015",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r015-g15",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G16",
+      "fieldId": "goldenAnchors.G16.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G16.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G16/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G16/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G16/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Disorder daze-level zone uses formula actor level 60."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder daze-level zone boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderDazeLevelZone"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderDazeLevelZone",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r016",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r016-g16",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G17",
+      "fieldId": "goldenAnchors.G17.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G17.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G17/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G17/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G17/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G17/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted shield cleanse uses sourced DA boss maxHp as event base."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max HP and enemy context for corrupted-shield cleanse replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r017",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r017-g17",
+      "blockedBy": [],
+      "notes": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G18",
+      "fieldId": "goldenAnchors.G18.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G18.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G18/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A139:AU139",
+        "dataPath": "/anchors/G18/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30004.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A139:AU139",
+            "dataPath": "/anchors/G18/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71",
+            "dataPath": "/anchors/G18/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Greta monster_info variant, level defaults, and part-break special-rule coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.levelDefaults",
+          "enemies.specialRules"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.specialRules",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-greta-live-30004"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r018",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r018-g18",
+      "blockedBy": [],
+      "notes": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G19",
+      "fieldId": "goldenAnchors.G19.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G19.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G19/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A216:AU216",
+        "dataPath": "/anchors/G19/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200141.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A216:AU216",
+            "dataPath": "/anchors/G19/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G19/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Ruthless Fiend variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-ruthless-fiend-live-200141"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r019",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r019-g19",
+      "blockedBy": [],
+      "notes": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G20",
+      "fieldId": "goldenAnchors.G20.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G20.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G20/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A89:AU89",
+        "dataPath": "/anchors/G20/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200014.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A89:AU89",
+            "dataPath": "/anchors/G20/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G20/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Armored Hati daze recovery uses Excel base 8.33%/s and guide §2.3.2 modifier composition (+100% -13%) to replay 15.58%/s and 6.42s.",
+          "The guide sentence has a denominator typo (`1/11.58%`) but its formula and final 6.42s result match 15.58%/s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Hati/Armored Hati variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r020",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r020-g20",
+      "blockedBy": [],
+      "notes": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G21",
+      "fieldId": "goldenAnchors.G21.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G21.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G21/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G21/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G21/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "One-agent Yixuan path has no teammate modifiers and keeps sheer defense skip."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yixuan panel and rupture/sheer source coverage.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r021",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r021-g21",
+      "blockedBy": [],
+      "notes": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G22",
+      "fieldId": "goldenAnchors.G22.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G22.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G22/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G22/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G22/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Nicole passive modifier source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r022",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r022-g22",
+      "blockedBy": [],
+      "notes": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G23",
+      "fieldId": "goldenAnchors.G23.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G23.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G23/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G23/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G23/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D23:J23",
+            "dataPath": "/anchors/G23/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人技能描述!C298",
+            "dataPath": "/anchors/G23/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+          "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yanagi passive/disorder source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers",
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          },
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r023",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r023-g23",
+      "blockedBy": [],
+      "notes": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G24",
+      "fieldId": "goldenAnchors.G24.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G24.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G24/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A42:T42",
+        "dataPath": "/anchors/G24/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A42:T42",
+            "dataPath": "/anchors/G24/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A2:H2",
+            "dataPath": "/anchors/G24/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A3:H3",
+            "dataPath": "/anchors/G24/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Penguinboo active skill replays Excel-only numeric contribution: level-60 attack 6198.0006 × 4.62 = 28634.762772 base damage.",
+          "Daze uses impact 90 × 2.7 = 243, and anomaly buildup uses 346 × floor(120)/100 = 415.2 before enemy resistance.",
+          "Excel Path X has no element field; the fixture supplies an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r024",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r024-g24",
+      "blockedBy": [],
+      "notes": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G25",
+      "fieldId": "goldenAnchors.G25.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G25.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G25/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A24:T24",
+        "dataPath": "/anchors/G25/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A24:T24",
+            "dataPath": "/anchors/G25/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A17:H17",
+            "dataPath": "/anchors/G25/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A18:H18",
+            "dataPath": "/anchors/G25/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Sharkboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 3.84 = 30939.262464 base damage.",
+          "Daze uses impact 99 × 1.4 = 138.6, and anomaly buildup uses 180 × floor(132)/100 = 237.6 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r025",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r025-g25",
+      "blockedBy": [],
+      "notes": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G26",
+      "fieldId": "goldenAnchors.G26.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G26.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G26/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A18:T18",
+        "dataPath": "/anchors/G26/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A18:T18",
+            "dataPath": "/anchors/G26/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A29:H29",
+            "dataPath": "/anchors/G26/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A30:H30",
+            "dataPath": "/anchors/G26/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Plugboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 5.12 = 41252.349952 base damage.",
+          "Daze uses impact 99 × 1.87 = 185.13, and anomaly buildup uses 240 × floor(132)/100 = 316.8 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Plugboo panel, skill numeric, and element source coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.element",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r026",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r026-g26",
+      "blockedBy": [],
+      "notes": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G27",
+      "fieldId": "goldenAnchors.G27.newSourceProof",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G27.newSourceProof",
+      "fieldPath": "/anchors/G27/newSourceProof",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-owner-decision",
+        "sourceVersion": "2026-05-15T18:11:57+08:00",
+        "sourceAnchor": "slock:#fairy/3d649e33",
+        "dataPath": "/G27"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "ownerDecision": "G27 = 仪玄 (1371)",
+        "priorArchivedBaseline": "not-applicable-new-proof-anchor"
+      },
+      "candidateValue": {
+        "coverageStatus": "new-source-proof-passed",
+        "expectedCandidate": "Yixuan approved-live character proof anchor with panel, Adrenaline/Resonance, rupture, and promotion-extra source coverage.",
+        "fieldIds": [
+          "agents.basePanel",
+          "agents.combatPanelStats",
+          "agents.ruptureStats",
+          "agents.promotionExtraStats",
+          "adrenaline.maxAdrenaline",
+          "adrenaline.automaticAdrenalineAccumulation",
+          "skills.resonanceRecovery",
+          "skills.adrenalineRecovery"
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "normalizedValues": {
+          "identity": {
+            "id": 1371,
+            "codeName": "Yixuan",
+            "name": "仪玄"
+          },
+          "level60Panel": {
+            "maxHp": 7953.8621,
+            "attack": 872.5748,
+            "defence": 441.1145,
+            "critRate": 0.05,
+            "critDamage": 0.5,
+            "anomalyMastery": 92,
+            "anomalyProficiency": 90,
+            "impact": 93
+          },
+          "resource": {
+            "maxAdrenaline": 120,
+            "automaticAdrenalineAccumulation": 2,
+            "resonanceRecovery": 71.5,
+            "adrenalineRecovery": 0.52
+          },
+          "rupture": {
+            "ruptureLevel": 1,
+            "ruptureCorrectionFactor": 1,
+            "ruptureProbability": 0
+          }
+        },
+        "rulingSummary": "Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover."
+      },
+      "status": "new",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r027",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r027-g27",
+      "blockedBy": [],
+      "notes": "Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G28",
+      "fieldId": "goldenAnchors.G28.newSourceProof",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G28.newSourceProof",
+      "fieldPath": "/anchors/G28/newSourceProof",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-owner-decision",
+        "sourceVersion": "2026-05-15T18:11:57+08:00",
+        "sourceAnchor": "slock:#fairy/3d649e33",
+        "dataPath": "/G28"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "ownerDecision": "G28 = 插头布 (54008)",
+        "priorArchivedBaseline": "not-applicable-new-proof-anchor"
+      },
+      "candidateValue": {
+        "coverageStatus": "new-source-proof-passed",
+        "expectedCandidate": "Plugboo approved-live Bangboo proof anchor with identity, panel, skill numeric, and electric element source coverage.",
+        "fieldIds": [
+          "bangboos.identity",
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [],
+        "normalizedValues": {
+          "identity": {
+            "id": 54008,
+            "codeName": "Plugboo",
+            "name": "插头布"
+          },
+          "level60Panel": {
+            "maxHp": 4210.2983,
+            "attack": 8057.0996,
+            "defence": 723.8011,
+            "impact": 99,
+            "anomalyMastery": 132
+          },
+          "activeSkill": {
+            "damageMultiplier": 5.12,
+            "dazeMultiplier": 1.87,
+            "anomalyBuildup": 240,
+            "element": "electric"
+          }
+        },
+        "rulingSummary": "Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover."
+      },
+      "status": "new",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r028",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r028-g28",
+      "blockedBy": [],
+      "notes": "Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover."
+    }
+  ],
+  "unresolvedCount": 0,
+  "notes": [
+    "Phase 3 second sync carries forward accepted G01-G26 rulings and adds lo-user-selected G27/G28 approved-live nanoka proof anchors.",
+    "This sync is exit-clean eligible for Phase 3 only; runtime cleaned-data cutover remains disabled until Phase 4.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/docs/data-source/drift-reports/phase3-sync-002-g27-g28.md
+++ b/docs/data-source/drift-reports/phase3-sync-002-g27-g28.md
@@ -1,0 +1,78 @@
+# Nanoka Drift Report: phase3-sync-002-g27-g28
+
+Status: Phase 3 drift audit second sync with G27/G28 proof anchors
+Generated: 2026-05-15T18:20:00+08:00
+
+This report carries forward accepted G01-G26 rulings, adds G27/G28 approved-live proof anchors, and records Phase 3 exit-clean evidence. Full runtime cutover remains disabled.
+
+## Candidate
+
+| Source | Version | Content Hash |
+|---|---|---|
+| `nanoka-zzz` | `2.8` | `sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d` |
+
+## Baselines
+
+| Source | Version | Archived |
+|---|---|---|
+| `lo-user-excel` | `2.6.0_R14028417` | yes |
+| `mihoyo-zzz-critical-assault` | `2026-05-05T0850Z` | yes |
+| `buhflipexplode-zzz-da` | `2026-05-05T0445Z` | yes |
+
+## Counts
+
+| Status | Count |
+|---|---:|
+| `same` | 0 |
+| `changed` | 0 |
+| `missing` | 0 |
+| `new` | 2 |
+| `semantic-mismatch` | 26 |
+
+Unresolved blocking drift rows: **0**
+
+Runtime cutover ready: **false**
+
+Exit-clean sync eligible: **true**
+
+## Drift Rows
+
+| Entity | Field | Status | Ruling | Ruling ID | Notes |
+|---|---|---|---|---|---|
+| `G01` | `goldenAnchors.G01.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r001` | Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover. |
+| `G02` | `goldenAnchors.G02.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r002` | Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only. |
+| `G03` | `goldenAnchors.G03.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r003` | Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned. |
+| `G04` | `goldenAnchors.G04.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r004` | Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor. |
+| `G05` | `goldenAnchors.G05.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r005` | Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands. |
+| `G06` | `goldenAnchors.G06.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r006` | Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned. |
+| `G07` | `goldenAnchors.G07.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r007` | Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior. |
+| `G08` | `goldenAnchors.G08.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r008` | Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior. |
+| `G09` | `goldenAnchors.G09.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r009` | Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned. |
+| `G10` | `goldenAnchors.G10.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r010` | Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned. |
+| `G11` | `goldenAnchors.G11.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r011` | Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields. |
+| `G12` | `goldenAnchors.G12.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r012` | Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned. |
+| `G13` | `goldenAnchors.G13.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r013` | Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor. |
+| `G14` | `goldenAnchors.G14.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r014` | Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned. |
+| `G15` | `goldenAnchors.G15.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r015` | Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof. |
+| `G16` | `goldenAnchors.G16.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r016` | Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof. |
+| `G17` | `goldenAnchors.G17.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r017` | Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule. |
+| `G18` | `goldenAnchors.G18.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r018` | Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4. |
+| `G19` | `goldenAnchors.G19.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r019` | Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula. |
+| `G20` | `goldenAnchors.G20.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r020` | Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula. |
+| `G21` | `goldenAnchors.G21.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r021` | Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied. |
+| `G22` | `goldenAnchors.G22.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r022` | Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task. |
+| `G23` | `goldenAnchors.G23.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r023` | Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later. |
+| `G24` | `goldenAnchors.G24.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r024` | Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion. |
+| `G25` | `goldenAnchors.G25.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r025` | Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion. |
+| `G26` | `goldenAnchors.G26.nanokaCandidateCoverage` | `semantic-mismatch` | `accepted` | `phase3-r026` | Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence. |
+| `G27` | `goldenAnchors.G27.newSourceProof` | `new` | `accepted` | `phase3-r027` | Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover. |
+| `G28` | `goldenAnchors.G28.newSourceProof` | `new` | `accepted` | `phase3-r028` | Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover. |
+
+
+## Boundary
+
+- This sync does not promote nanoka to runtime cleaned data.
+- Archived Excel / D-17 / D-12 sources remain audit baselines, not runtime
+  fallback.
+- Any future `changed`, `missing`, `new`, or `semantic-mismatch` row must
+  carry source refs and a ruling before Phase 3 exit.

--- a/docs/product/decisions/data-source-rulings.md
+++ b/docs/product/decisions/data-source-rulings.md
@@ -34,6 +34,8 @@ Runtime cutover remains disabled. Archived Excel, D-17 Mihoyo, and D-12 buhflipe
 | `phase3-r024` | G24 | accepted | Accept Penguinboo numeric parity from nanoka live panel and active skill raw values. |
 | `phase3-r025` | G25 | accepted | Accept Sharkboo numeric parity from nanoka live panel and active skill raw values. |
 | `phase3-r026` | G26 | accepted | Accept Plugboo numeric parity and electric element evidence from nanoka live panel, skill raw values, and skill text. |
+| `phase3-r027` | G27 | accepted | Accept lo-user-selected Yixuan approved-live proof anchor from nanoka character detail. |
+| `phase3-r028` | G28 | accepted | Accept lo-user-selected Plugboo approved-live proof anchor from nanoka Bangboo detail. |
 
 ## Rulings
 
@@ -140,3 +142,11 @@ Decision: accepted. Nanoka approved-live Sharkboo panel and active skill raw val
 ### phase3-r026-g26
 
 Decision: accepted. Nanoka approved-live Plugboo panel and active skill raw values reproduce the archived Excel Path X numbers after unit conversion: attack `8057.0996`, active multiplier `5.12`, daze multiplier `1.87`, and anomaly buildup `240`. Plugboo skill text also proves electric element evidence.
+
+### phase3-r027-g27
+
+Decision: accepted. Lo-user selected Yixuan `1371` as the G27 new-source proof anchor. Nanoka approved-live `zh/character/1371.json` proves identity plus calculation-relevant source coverage: level-60 panel `maxHp=7953.8621`, `attack=872.5748`, `defence=441.1145`; Adrenaline cap/recovery `120` / `2`; first basic Resonance/Adrenaline recovery `71.5` / `0.52`; rupture raw fields `rbl=1`, `rbl_correction_factor=1`, `rbl_probability=0`. This is a proof anchor only and does not cut runtime cleaned data over.
+
+### phase3-r028-g28
+
+Decision: accepted. Lo-user selected Plugboo `54008` as the G28 new-source proof anchor. Nanoka approved-live `zh/bangboo/54008.json` proves identity plus calculation-relevant source coverage: level-60 panel `maxHp=4210.2983`, `attack=8057.0996`, `defence=723.8011`; active skill `5400801` values `damageMultiplier=5.12`, `dazeMultiplier=1.87`, `anomalyBuildup=240`; approved-live skill text resolves element evidence to `electric`. This is a proof anchor only and does not cut runtime cleaned data over.

--- a/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-002-g27-g28.json
+++ b/packages/data/cleaned/audit/nanoka-drift-report/phase3-sync-002-g27-g28.json
@@ -1,0 +1,2829 @@
+{
+  "schemaVersion": "nanoka-drift-report/v0.1",
+  "syncId": "phase3-sync-002-g27-g28",
+  "generatedAt": "2026-05-15T18:20:00+08:00",
+  "candidate": {
+    "sourceId": "nanoka-zzz",
+    "sourceVersion": "2.8",
+    "contentHash": "sha256:91494c2c3bfda6ec47beccbf71066506ab0a315513aa751cf30e4c3a1dc0817d"
+  },
+  "baselines": [
+    {
+      "sourceId": "lo-user-excel",
+      "sourceVersion": "2.6.0_R14028417",
+      "archived": true
+    },
+    {
+      "sourceId": "mihoyo-zzz-critical-assault",
+      "sourceVersion": "2026-05-05T0850Z",
+      "archived": true
+    },
+    {
+      "sourceId": "buhflipexplode-zzz-da",
+      "sourceVersion": "2026-05-05T0445Z",
+      "archived": true
+    }
+  ],
+  "matrixStatus": "phase-3-drift-foundation-gate",
+  "runtimeCutoverReady": false,
+  "exitCleanSyncEligible": true,
+  "exitGateEvidence": {
+    "cleanSyncIds": [
+      "phase3-sync-001-g01-g26",
+      "phase3-sync-002-g27-g28"
+    ],
+    "anchorIds": [
+      "G01",
+      "G02",
+      "G03",
+      "G04",
+      "G05",
+      "G06",
+      "G07",
+      "G08",
+      "G09",
+      "G10",
+      "G11",
+      "G12",
+      "G13",
+      "G14",
+      "G15",
+      "G16",
+      "G17",
+      "G18",
+      "G19",
+      "G20",
+      "G21",
+      "G22",
+      "G23",
+      "G24",
+      "G25",
+      "G26",
+      "G27",
+      "G28"
+    ],
+    "goldenReplayStatus": "passed",
+    "requiredNewProofAnchorIds": [
+      "G27",
+      "G28"
+    ],
+    "previousCleanSyncId": "phase3-sync-001-g01-g26",
+    "currentSyncId": "phase3-sync-002-g27-g28",
+    "notes": [
+      "G01-G26 are accepted in phase3-sync-001-g01-g26.",
+      "G27/G28 are lo-user-selected approved-live nanoka proof anchors.",
+      "Runtime cutover remains disabled until Phase 4."
+    ]
+  },
+  "counts": {
+    "same": 0,
+    "changed": 0,
+    "missing": 0,
+    "new": 2,
+    "semantic-mismatch": 26
+  },
+  "rows": [
+    {
+      "entityType": "enemy",
+      "entityId": "G01",
+      "fieldId": "goldenAnchors.G01.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G01.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G01/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G01/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G01/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G01/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Default boss defense multiplier replays against sourced DA slot 0 boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus enemy defense defaults for the sourced boss replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r001",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r001-g01",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement: nanoka approved-live period detail covers boss_adjust and period context used by the archived G01 default-defense replay; Phase 4 still owns runtime cutover."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G02",
+      "fieldId": "goldenAnchors.G02.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G02.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G02/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G02/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G02/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G02/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted-shield state uses the core 1.8x defense multiplier with sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss context plus corrupted-shield defense-state coverage.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r002",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r002-g02",
+      "blockedBy": [],
+      "notes": "Accepted DA boss-context source replacement for corrupted-shield defense replay; the shield formula remains implementation-owned and nanoka supplies the period/boss evidence only."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G03",
+      "fieldId": "goldenAnchors.G03.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G03.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G03/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G03/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G03/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Crit expected value uses 1 + critRate * critDamage."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent panel fields needed by crit expected-value replay.",
+        "fieldIds": [
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r003",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r003-g03",
+      "blockedBy": [],
+      "notes": "Accepted agent panel normalization contract: nanoka live character stats/level rows deterministically derive base panel values; G03 crit expected-value behavior is formula-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G04",
+      "fieldId": "goldenAnchors.G04.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G04.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G04/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+        "dataPath": "/anchors/G04/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/38"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:121-123",
+            "dataPath": "/anchors/G04/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Executable bucket-scan replay reproduces the guide's 199.17%, 268.61%, and 161.67% penetration-vs-damage-bonus breakpoints."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned penetration and damage formula constants.",
+        "fieldIds": [
+          "rules.baseDamageFormula",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r004",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r004-g04",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned penetration/damage formula boundary; nanoka has no formula table and the archived guide/golden replay remains the executable proof anchor."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G05",
+      "fieldId": "goldenAnchors.G05.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G05.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G05/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G05/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G05/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G05/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer damage skips defense while regular damage sees corrupted-shield defense."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for defense-skip replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r005",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r005-g05",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility: nanoka supplies Yixuan rupture raw fields and DA boss context, while sheer defense-skip semantics remain implementation-owned until the rupture semantic mapper lands."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G06",
+      "fieldId": "goldenAnchors.G06.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G06.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G06/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G06/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G06/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G06/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Sheer vs default boss ratio replays with the same sourced boss context."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Rupture/sheer semantics and DA boss context for sheer-vs-default ratio replay.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "rules.baseDamageFormula",
+          "deadlyAssault.periodsBossesBuffs"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          },
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-boss-live-69036"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r006",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r006-g06",
+      "blockedBy": [],
+      "notes": "Accepted split responsibility for sheer-vs-default ratio replay: nanoka source coverage is present and the ratio formula remains implementation-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G07",
+      "fieldId": "goldenAnchors.G07.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G07.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G07/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G07/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-coverage-matrix.json",
+        "dataPath": "/rows/39"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G07/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Two fractional segments ceil before summing."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned rounding contract for per-segment ceil behavior.",
+        "fieldIds": [
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r007",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r007-g07",
+      "blockedBy": [],
+      "notes": "Accepted implementation-owned rounding boundary; no nanoka source table is expected for per-segment ceil behavior."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G08",
+      "fieldId": "goldenAnchors.G08.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G08.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G08/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G08/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1021.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G08/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Anomaly Mastery floors before buildup."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Agent anomaly panel fields plus rounding behavior for buildup replay.",
+        "fieldIds": [
+          "agents.basePanel",
+          "rules.rounding"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.rounding",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r008",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r008-g08",
+      "blockedBy": [],
+      "notes": "Accepted agent combat-panel unit boundary for anomaly mastery flooring; nanoka provides raw panel fields and core owns the floor-before-buildup behavior."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G09",
+      "fieldId": "goldenAnchors.G09.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G09.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G09/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G09/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G09/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G09/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "buhflipexplode DA baseDaze/versionDazeMult feeds enemy.dazeCap; replay asserts daze ratio display floors the percentage value."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max-daze and enemy-level context for daze-cap replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r009",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r009-g09",
+      "blockedBy": [],
+      "notes": "Accepted DA daze-context source replacement: nanoka period detail covers boss context and daze-related source evidence while display flooring remains implementation-owned."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G10",
+      "fieldId": "goldenAnchors.G10.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G10.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G10/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G10/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G10/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost maps to Ice and Auric Ink maps to Ether for both resistanceZone and anomaly-buildup-resistance."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and enemy resistance source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "enemies.resistance"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.resistance",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:resistance-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r010",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r010-g10",
+      "blockedBy": [],
+      "notes": "Accepted attribute-alias boundary: nanoka supplies Yixuan/monster raw coverage, while Frost->Ice and Auric Ink->Ether alias semantics stay implementation-owned."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G11",
+      "fieldId": "goldenAnchors.G11.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G11.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G11/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G11/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G11/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Frost/Auric use Ice/Ether damage-bonus panel fields."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Attribute alias mapping and combat-panel damage-bonus source coverage.",
+        "fieldIds": [
+          "rules.attributeMapping",
+          "agents.combatPanelStats"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.attributeMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:attribute-mapping-source-required"
+            ]
+          },
+          {
+            "fieldId": "agents.combatPanelStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:stat-unit-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r011",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r011-g11",
+      "blockedBy": [],
+      "notes": "Accepted damage-bonus alias boundary: nanoka supplies combat-panel raw fields and core owns alias routing to Ice/Ether damage-bonus fields."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G12",
+      "fieldId": "goldenAnchors.G12.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G12.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G12/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G12/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G12/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G12/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Boss trigger-count threshold and physical 1.2x multiplier replay from core constants."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold source coverage and trigger-rank rule mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r012",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r012-g12",
+      "blockedBy": [],
+      "notes": "Accepted anomaly-threshold split responsibility: nanoka enemy threshold raw coverage exists, while trigger-count/rank threshold formula constants remain implementation-owned."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G13",
+      "fieldId": "goldenAnchors.G13.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G13.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G13/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "zzz-data-introduction",
+        "sourceVersion": "2026-05-05",
+        "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+        "dataPath": "/anchors/G13/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30000.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:247-250",
+            "dataPath": "/anchors/G13/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Sourced anomalyThresholdModifiers replay the guide's multiplicative composition: 2.0+ special enemies use 1.2x or 1.1x base threshold modifiers, then DA #16 applies another 1.1x.",
+          "Replay asserts guide totals: corruption priest/ghost 3960 and 4752 physical; notorious Pompey 3630 and 4356 physical."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Enemy anomaly threshold modifiers plus monster_info variant mapping.",
+        "fieldIds": [
+          "rules.anomalyThresholdRankTriggerTable",
+          "enemies.anomalyThresholds",
+          "enemies.variantMapping"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.anomalyThresholdRankTriggerTable",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-30000"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-rule-source-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.anomalyThresholds",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:anomaly-threshold-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-30000",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r013",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r013-g13",
+      "blockedBy": [],
+      "notes": "Accepted variant-mapping source replacement plus implementation-owned threshold modifiers; monster_info identity is source-backed and guide constants remain the formula proof anchor."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G14",
+      "fieldId": "goldenAnchors.G14.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G14.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G14/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G14/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G14/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A4:AF4",
+            "dataPath": "/anchors/G14/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Virtual contribution rows include Bangboo exclusion and overflow handling."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "SourceRef emission plus implementation-owned virtual-contribution behavior.",
+        "fieldIds": [
+          "metadata.sourceRefs",
+          "rules.baseDamageFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "metadata.sourceRefs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "derived-from-source-registry",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "rules.baseDamageFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": null,
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r014",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r014-g14",
+      "blockedBy": [],
+      "notes": "Accepted SourceRef/virtual-contribution boundary: nanoka sourceRefs contract is promoted, while virtual-agent contribution behavior remains implementation-owned."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G15",
+      "fieldId": "goldenAnchors.G15.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G15.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G15/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G15/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G15/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "All seven disorder formula paths replay, including polarity disorder."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder formula boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r015",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r015-g15",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder formula endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+    },
+    {
+      "entityType": "rules",
+      "entityId": "G16",
+      "fieldId": "goldenAnchors.G16.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G16.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G16/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G16/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+        "dataPath": "/summary"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G16/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Disorder daze-level zone uses formula actor level 60."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Implementation-owned Disorder daze-level zone boundary with failed nanoka evidence.",
+        "fieldIds": [
+          "rules.disorderDazeLevelZone"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "rules.disorderDazeLevelZone",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-daze-level-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [],
+        "availableSampleEntities": [],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r016",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r016-g16",
+      "blockedBy": [],
+      "notes": "Accepted failed-evidence ruling: nanoka has no Disorder daze-level zone endpoint/table, so the runtime formula remains implementation-owned with golden replay proof."
+    },
+    {
+      "entityType": "deadlyAssault",
+      "entityId": "G17",
+      "fieldId": "goldenAnchors.G17.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G17.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G17/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "buhflipexplode-zzz-da",
+        "sourceVersion": "2026-05-05T0445Z",
+        "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+        "dataPath": "/anchors/G17/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/boss/69036.json",
+        "dataPath": "/boss_adjust"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "da/da-versions.live.json#2.7.3.versionEnemies[0]",
+            "dataPath": "/anchors/G17/sourceRefs/0"
+          },
+          {
+            "sourceId": "buhflipexplode-zzz-da",
+            "sourceVersion": "2026-05-05T0445Z",
+            "sourceAnchor": "assets/zzz/enemies.live.json#27300",
+            "dataPath": "/anchors/G17/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Corrupted shield cleanse uses sourced DA boss maxHp as event base."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "DA boss max HP and enemy context for corrupted-shield cleanse replay.",
+        "fieldIds": [
+          "deadlyAssault.periodsBossesBuffs",
+          "enemies.levelDefaults"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "deadlyAssault.periodsBossesBuffs",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-boss-live-69036"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-boss-live-69036"
+        ],
+        "availableSampleEntities": [
+          "nanoka-boss-live-69036",
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r017",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r017-g17",
+      "blockedBy": [],
+      "notes": "Accepted DA boss max-HP source replacement for corrupted-shield cleanse; nanoka supplies period/boss context and core owns the 15% true-damage rule."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G18",
+      "fieldId": "goldenAnchors.G18.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G18.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G18/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A139:AU139",
+        "dataPath": "/anchors/G18/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/30004.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A139:AU139",
+            "dataPath": "/anchors/G18/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:62-71",
+            "dataPath": "/anchors/G18/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Part-break manual event uses sourced Greta level-70 max HP from Excel and the guide's 5% engineering-machine part-break true-damage multiplier."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Greta monster_info variant, level defaults, and part-break special-rule coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.levelDefaults",
+          "enemies.specialRules"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.levelDefaults",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:enemy-level-formula-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.specialRules",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-greta-live-30004"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r018",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r018-g18",
+      "blockedBy": [],
+      "notes": "Accepted enemy variant source replacement for Greta plus implementation-owned part-break rule; level-stat formula remains blocked from runtime cutover until Phase 4."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G19",
+      "fieldId": "goldenAnchors.G19.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G19.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G19/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A216:AU216",
+        "dataPath": "/anchors/G19/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200141.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A216:AU216",
+            "dataPath": "/anchors/G19/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G19/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Mad Psycho daze recovery uses Excel base 7.69%/s and guide §2.3.2 modifier composition (+60% -9%) to replay 11.61%/s and 8.61s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Ruthless Fiend variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-ruthless-fiend-live-200141"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r019",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r019-g19",
+      "blockedBy": [],
+      "notes": "Accepted Ruthless Fiend variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+    },
+    {
+      "entityType": "enemy",
+      "entityId": "G20",
+      "fieldId": "goldenAnchors.G20.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G20.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G20/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "敌人属性!A89:AU89",
+        "dataPath": "/anchors/G20/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/monster/200014.json",
+        "dataPath": "/monster_info"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "敌人属性!A89:AU89",
+            "dataPath": "/anchors/G20/sourceRefs/0"
+          },
+          {
+            "sourceId": "zzz-data-introduction",
+            "sourceVersion": "2026-05-05",
+            "sourceAnchor": "docs/reference/zzz-data-introduction.txt:181-202",
+            "dataPath": "/anchors/G20/sourceRefs/1"
+          }
+        ],
+        "notes": [
+          "Armored Hati daze recovery uses Excel base 8.33%/s and guide §2.3.2 modifier composition (+100% -13%) to replay 15.58%/s and 6.42s.",
+          "The guide sentence has a denominator typo (`1/11.58%`) but its formula and final 6.42s result match 15.58%/s."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Hati/Armored Hati variant identity plus daze-recovery semantic coverage.",
+        "fieldIds": [
+          "enemies.variantMapping",
+          "enemies.dazeRecovery"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "enemies.variantMapping",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:runtime-cutover-drift-required"
+            ]
+          },
+          {
+            "fieldId": "enemies.dazeRecovery",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-monster-dullahan-live-30000",
+              "nanoka-monster-greta-live-30004",
+              "nanoka-monster-ruthless-fiend-live-200141",
+              "nanoka-monster-notorious-hati-live-200014",
+              "nanoka-monster-notorious-armored-hati-live-200034",
+              "nanoka-monster-miasma-priest-live-30033",
+              "nanoka-monster-notorious-pompey-live-300211"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:daze-recovery-semantic-mapping-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034"
+        ],
+        "availableSampleEntities": [
+          "nanoka-monster-dullahan-live-30000",
+          "nanoka-monster-greta-live-30004",
+          "nanoka-monster-ruthless-fiend-live-200141",
+          "nanoka-monster-notorious-hati-live-200014",
+          "nanoka-monster-notorious-armored-hati-live-200034",
+          "nanoka-monster-miasma-priest-live-30033",
+          "nanoka-monster-notorious-pompey-live-300211"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r020",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r020-g20",
+      "blockedBy": [],
+      "notes": "Accepted Hati/Armored Hati variant source replacement with daze-recovery semantic boundary; nanoka supplies raw enemy evidence and guide/core own the recovery formula."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G21",
+      "fieldId": "goldenAnchors.G21.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G21.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G21/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人属性!A37:AF37",
+        "dataPath": "/anchors/G21/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人属性!A37:AF37",
+            "dataPath": "/anchors/G21/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "One-agent Yixuan path has no teammate modifiers and keeps sheer defense skip."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yixuan panel and rupture/sheer source coverage.",
+        "fieldIds": [
+          "agents.ruptureStats",
+          "agents.basePanel"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.ruptureStats",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-yixuan-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "field:rupture-semantic-mapping-required"
+            ]
+          },
+          {
+            "fieldId": "agents.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nekomata-live-1021"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-1371",
+          "nanoka-character-nekomata-live-1021"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r021",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r021-g21",
+      "blockedBy": [],
+      "notes": "Accepted Yixuan panel/rupture source coverage with implementation-owned sheer defense-skip semantics; no runtime cutover is implied."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G22",
+      "fieldId": "goldenAnchors.G22.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G22.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G22/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G22/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1031.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G22/sourceRefs/0"
+          }
+        ],
+        "notes": [
+          "Nicole defense reduction is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Inactive keeps the default defenseZone; active applies the 40% defense reduction from core passive level 7."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Nicole passive modifier source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-nicole-live-1031"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r022",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r022-g22",
+      "blockedBy": [],
+      "notes": "Accepted Nicole passive source coverage for the existing lo-user-approved defense-reduction replay; typed modifier template promotion remains a later source-backed transform task."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G23",
+      "fieldId": "goldenAnchors.G23.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G23.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G23/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "代理人核心技描述!D4:J4",
+        "dataPath": "/anchors/G23/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1221.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D4:J4",
+            "dataPath": "/anchors/G23/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人核心技描述!D23:J23",
+            "dataPath": "/anchors/G23/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "代理人技能描述!C298",
+            "dataPath": "/anchors/G23/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Yanagi disorder boost is manually accepted by lo-user and replayed as explicit inactive/active snapshot states.",
+          "Yanagi polarity-disorder EX Special template supports skill levels 1-16; level 12 yields 96 base-damage extra from 300 anomaly proficiency.",
+          "Three-agent virtual contribution trace includes Yixuan, Nicole, and Yanagi."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Yanagi passive/disorder source coverage.",
+        "fieldIds": [
+          "agents.passiveModifiers",
+          "rules.disorderFormula"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "agents.passiveModifiers",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "optional",
+            "promotable": false,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-character-nicole-live-1031",
+              "nanoka-character-yanagi-live-1221",
+              "nanoka-character-yixuan-live-1371"
+            ],
+            "auditArtifact": null,
+            "blockedBy": [
+              "typed-modifier-template-required"
+            ]
+          },
+          {
+            "fieldId": "rules.disorderFormula",
+            "status": "deferred",
+            "sourcePolicy": "implementation-owned",
+            "fieldClass": "implementation-owned",
+            "promotable": false,
+            "rawAvailable": false,
+            "sampleEntities": [],
+            "auditArtifact": "data/cleaned/audit/nanoka-disorder-formula-audit.json",
+            "blockedBy": [
+              "implementation-owned-runtime-formula"
+            ]
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yanagi-live-1221"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-nicole-live-1031",
+          "nanoka-character-yanagi-live-1221",
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r023",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r023-g23",
+      "blockedBy": [],
+      "notes": "Accepted Yanagi passive/source-text coverage for the existing lo-user-approved disorder boost and polarity-disorder replay; typed modifier template promotion remains later."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G24",
+      "fieldId": "goldenAnchors.G24.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G24.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G24/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A42:T42",
+        "dataPath": "/anchors/G24/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/53001.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A42:T42",
+            "dataPath": "/anchors/G24/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A2:H2",
+            "dataPath": "/anchors/G24/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A3:H3",
+            "dataPath": "/anchors/G24/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Penguinboo active skill replays Excel-only numeric contribution: level-60 attack 6198.0006 × 4.62 = 28634.762772 base damage.",
+          "Daze uses impact 90 × 2.7 = 243, and anomaly buildup uses 346 × floor(120)/100 = 415.2 before enemy resistance.",
+          "Excel Path X has no element field; the fixture supplies an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Penguinboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-penguinboo-live-53001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r024",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r024-g24",
+      "blockedBy": [],
+      "notes": "Accepted Penguinboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G25",
+      "fieldId": "goldenAnchors.G25.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G25.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G25/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A24:T24",
+        "dataPath": "/anchors/G25/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54001.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A24:T24",
+            "dataPath": "/anchors/G25/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A17:H17",
+            "dataPath": "/anchors/G25/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A18:H18",
+            "dataPath": "/anchors/G25/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Sharkboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 3.84 = 30939.262464 base damage.",
+          "Daze uses impact 99 × 1.4 = 138.6, and anomaly buildup uses 180 × floor(132)/100 = 237.6 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Sharkboo panel and skill numeric coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r025",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r025-g25",
+      "blockedBy": [],
+      "notes": "Accepted Sharkboo numeric parity: nanoka live panel and active skill raw values reproduce the archived Excel Path X attack, daze, and anomaly-buildup values after unit conversion."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G26",
+      "fieldId": "goldenAnchors.G26.nanokaCandidateCoverage",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G26.nanokaCandidateCoverage",
+      "fieldPath": "/anchors/G26/nanokaCandidateCoverage",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-excel",
+        "sourceVersion": "2.6.0_R14028417",
+        "sourceAnchor": "邦布属性!A18:T18",
+        "dataPath": "/anchors/G26/sourceRefs/0"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "replayStatus": "passed",
+        "sourceRefs": [
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布属性!A18:T18",
+            "dataPath": "/anchors/G26/sourceRefs/0"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A29:H29",
+            "dataPath": "/anchors/G26/sourceRefs/1"
+          },
+          {
+            "sourceId": "lo-user-excel",
+            "sourceVersion": "2.6.0_R14028417",
+            "sourceAnchor": "邦布技能!A30:H30",
+            "dataPath": "/anchors/G26/sourceRefs/2"
+          }
+        ],
+        "notes": [
+          "Plugboo active skill replays Excel-only numeric contribution: level-60 attack 8057.0996 × 5.12 = 41252.349952 base damage.",
+          "Daze uses impact 99 × 1.87 = 185.13, and anomaly buildup uses 240 × floor(132)/100 = 316.8 before enemy resistance.",
+          "Excel Path X has no element field; the fixture reuses an explicit neutral ice segment and zero ice resistance so the anchor asserts sourced panel/skill numerics, not inferred element semantics."
+        ]
+      },
+      "candidateValue": {
+        "coverageStatus": "candidate-covered-not-yet-ruled-equivalent",
+        "expectedCandidate": "Plugboo panel, skill numeric, and element source coverage.",
+        "fieldIds": [
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "matrixRows": [
+          {
+            "fieldId": "bangboos.basePanel",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "derived",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.skillSegments",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008",
+              "nanoka-bangboo-penguinboo-live-53001",
+              "nanoka-bangboo-sharkboo-live-54001"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          },
+          {
+            "fieldId": "bangboos.element",
+            "status": "verified-from-nanoka",
+            "sourcePolicy": "nanoka",
+            "fieldClass": "required",
+            "promotable": true,
+            "rawAvailable": true,
+            "sampleEntities": [
+              "nanoka-bangboo-plugboo-live-54008"
+            ],
+            "auditArtifact": null,
+            "blockedBy": []
+          }
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008",
+          "nanoka-bangboo-penguinboo-live-53001",
+          "nanoka-bangboo-sharkboo-live-54001"
+        ],
+        "missingRequiredSampleEntities": [],
+        "rulingSummary": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
+      },
+      "status": "semantic-mismatch",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r026",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r026-g26",
+      "blockedBy": [],
+      "notes": "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence."
+    },
+    {
+      "entityType": "agent",
+      "entityId": "G27",
+      "fieldId": "goldenAnchors.G27.newSourceProof",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G27.newSourceProof",
+      "fieldPath": "/anchors/G27/newSourceProof",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-owner-decision",
+        "sourceVersion": "2026-05-15T18:11:57+08:00",
+        "sourceAnchor": "slock:#fairy/3d649e33",
+        "dataPath": "/G27"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "ownerDecision": "G27 = 仪玄 (1371)",
+        "priorArchivedBaseline": "not-applicable-new-proof-anchor"
+      },
+      "candidateValue": {
+        "coverageStatus": "new-source-proof-passed",
+        "expectedCandidate": "Yixuan approved-live character proof anchor with panel, Adrenaline/Resonance, rupture, and promotion-extra source coverage.",
+        "fieldIds": [
+          "agents.basePanel",
+          "agents.combatPanelStats",
+          "agents.ruptureStats",
+          "agents.promotionExtraStats",
+          "adrenaline.maxAdrenaline",
+          "adrenaline.automaticAdrenalineAccumulation",
+          "skills.resonanceRecovery",
+          "skills.adrenalineRecovery"
+        ],
+        "requiredSampleEntities": [
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "availableSampleEntities": [
+          "nanoka-character-yixuan-live-1371"
+        ],
+        "missingRequiredSampleEntities": [],
+        "normalizedValues": {
+          "identity": {
+            "id": 1371,
+            "codeName": "Yixuan",
+            "name": "仪玄"
+          },
+          "level60Panel": {
+            "maxHp": 7953.8621,
+            "attack": 872.5748,
+            "defence": 441.1145,
+            "critRate": 0.05,
+            "critDamage": 0.5,
+            "anomalyMastery": 92,
+            "anomalyProficiency": 90,
+            "impact": 93
+          },
+          "resource": {
+            "maxAdrenaline": 120,
+            "automaticAdrenalineAccumulation": 2,
+            "resonanceRecovery": 71.5,
+            "adrenalineRecovery": 0.52
+          },
+          "rupture": {
+            "ruptureLevel": 1,
+            "ruptureCorrectionFactor": 1,
+            "ruptureProbability": 0
+          }
+        },
+        "rulingSummary": "Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover."
+      },
+      "status": "new",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r027",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r027-g27",
+      "blockedBy": [],
+      "notes": "Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover."
+    },
+    {
+      "entityType": "bangboo",
+      "entityId": "G28",
+      "fieldId": "goldenAnchors.G28.newSourceProof",
+      "canonicalPath": "data.cleaned.golden.v1Replay.anchors.G28.newSourceProof",
+      "fieldPath": "/anchors/G28/newSourceProof",
+      "baselineSourceRef": {
+        "sourceId": "lo-user-owner-decision",
+        "sourceVersion": "2026-05-15T18:11:57+08:00",
+        "sourceAnchor": "slock:#fairy/3d649e33",
+        "dataPath": "/G28"
+      },
+      "candidateSourceRef": {
+        "sourceId": "nanoka-zzz",
+        "sourceVersion": "2.8",
+        "sourceAnchor": "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        "dataPath": "/stats"
+      },
+      "baselineValue": {
+        "ownerDecision": "G28 = 插头布 (54008)",
+        "priorArchivedBaseline": "not-applicable-new-proof-anchor"
+      },
+      "candidateValue": {
+        "coverageStatus": "new-source-proof-passed",
+        "expectedCandidate": "Plugboo approved-live Bangboo proof anchor with identity, panel, skill numeric, and electric element source coverage.",
+        "fieldIds": [
+          "bangboos.identity",
+          "bangboos.basePanel",
+          "bangboos.skillSegments",
+          "bangboos.element"
+        ],
+        "requiredSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "availableSampleEntities": [
+          "nanoka-bangboo-plugboo-live-54008"
+        ],
+        "missingRequiredSampleEntities": [],
+        "normalizedValues": {
+          "identity": {
+            "id": 54008,
+            "codeName": "Plugboo",
+            "name": "插头布"
+          },
+          "level60Panel": {
+            "maxHp": 4210.2983,
+            "attack": 8057.0996,
+            "defence": 723.8011,
+            "impact": 99,
+            "anomalyMastery": 132
+          },
+          "activeSkill": {
+            "damageMultiplier": 5.12,
+            "dazeMultiplier": 1.87,
+            "anomalyBuildup": 240,
+            "element": "electric"
+          }
+        },
+        "rulingSummary": "Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover."
+      },
+      "status": "new",
+      "severity": "info",
+      "rulingStatus": "accepted",
+      "rulingId": "phase3-r028",
+      "rulingDecisionLog": "docs/product/decisions/data-source-rulings.md#phase3-r028-g28",
+      "blockedBy": [],
+      "notes": "Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover."
+    }
+  ],
+  "unresolvedCount": 0,
+  "notes": [
+    "Phase 3 second sync carries forward accepted G01-G26 rulings and adds lo-user-selected G27/G28 approved-live nanoka proof anchors.",
+    "This sync is exit-clean eligible for Phase 3 only; runtime cleaned-data cutover remains disabled until Phase 4.",
+    "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs."
+  ]
+}

--- a/packages/data/scripts/source-migration-drift.mjs
+++ b/packages/data/scripts/source-migration-drift.mjs
@@ -16,6 +16,7 @@ const goldenReplayReportPath = join(repoRoot, "data/cleaned/golden/v1-replay-rep
 const schemaVersion = "nanoka-drift-report/v0.1"
 const defaultSyncId = "phase3-sync-000-foundation"
 const firstSyncId = "phase3-sync-001-g01-g26"
+const secondSyncId = "phase3-sync-002-g27-g28"
 const defaultGeneratedAt = "2026-05-15T16:20:00+08:00"
 const rulingDecisionLogPath = "docs/product/decisions/data-source-rulings.md"
 const driftStatuses = ["same", "changed", "missing", "new", "semantic-mismatch"]
@@ -91,6 +92,13 @@ function zeroCounts() {
     new: 0,
     "semantic-mismatch": 0,
   }
+}
+
+function arrayEquals(left, right) {
+  return Array.isArray(left)
+    && Array.isArray(right)
+    && left.length === right.length
+    && left.every((value, index) => value === right[index])
 }
 
 function countsForRows(rows) {
@@ -294,6 +302,27 @@ const anchorCandidateSpecs = {
     requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
     expectedCandidate: "Plugboo panel, skill numeric, and element source coverage.",
   },
+  G27: {
+    entityType: "agent",
+    fieldIds: [
+      "agents.basePanel",
+      "agents.combatPanelStats",
+      "agents.ruptureStats",
+      "agents.promotionExtraStats",
+      "adrenaline.maxAdrenaline",
+      "adrenaline.automaticAdrenalineAccumulation",
+      "skills.resonanceRecovery",
+      "skills.adrenalineRecovery",
+    ],
+    requiredSampleEntities: ["nanoka-character-yixuan-live-1371"],
+    expectedCandidate: "Yixuan approved-live character proof anchor with panel, Adrenaline/Resonance, rupture, and promotion-extra source coverage.",
+  },
+  G28: {
+    entityType: "bangboo",
+    fieldIds: ["bangboos.identity", "bangboos.basePanel", "bangboos.skillSegments", "bangboos.element"],
+    requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
+    expectedCandidate: "Plugboo approved-live Bangboo proof anchor with identity, panel, skill numeric, and electric element source coverage.",
+  },
 }
 
 const phase3Rulings = {
@@ -401,6 +430,20 @@ const phase3Rulings = {
     rulingId: "phase3-r026",
     summary: "Accepted Plugboo numeric and element parity: nanoka live panel/skill raw values reproduce the archived Excel Path X values and approved-live skill text proves electric element evidence.",
   },
+  G27: {
+    rulingId: "phase3-r027",
+    summary: "Accepted new-source proof anchor: lo-user selected Yixuan 1371 for G27; approved-live nanoka evidence proves identity, panel/resource raw values, rupture fields, and promotion-extra source coverage without runtime cutover.",
+  },
+  G28: {
+    rulingId: "phase3-r028",
+    summary: "Accepted new-source proof anchor: lo-user selected Plugboo 54008 for G28; approved-live nanoka evidence proves Bangboo identity, level-60 panel, active-skill numeric values, and electric element text without runtime cutover.",
+  },
+}
+
+const proofAnchorOwnerDecision = {
+  sourceId: "lo-user-owner-decision",
+  sourceVersion: "2026-05-15T18:11:57+08:00",
+  sourceAnchor: "slock:#fairy/3d649e33",
 }
 
 function sourceRefWithDataPath(ref, anchorId, index) {
@@ -559,6 +602,131 @@ function candidateSourceRefForAnchor({ sourceVersion, matrixRows, requiredSample
   return coverageMatrixSourceRef({ sourceVersion, matrixRow: matrixRows[0]?.row })
 }
 
+function requiredNumber(value, label) {
+  assert(typeof value === "number" && Number.isFinite(value), `${label}: numeric value is required`)
+  return value
+}
+
+function panelValue(source, { baseKey, levelKey, growthKey, level = 60, promotionPhase = "6" }) {
+  const base = requiredNumber(source.stats?.[baseKey], `stats.${baseKey}`)
+  const levelBonus = requiredNumber(source.level?.[promotionPhase]?.[levelKey], `level.${promotionPhase}.${levelKey}`)
+  const growth = requiredNumber(source.stats?.[growthKey], `stats.${growthKey}`)
+  return Number((base + levelBonus + growth * (level - 1) / 10000).toFixed(8))
+}
+
+function yixuanProofValues() {
+  const yixuan = readJson(join(repoRoot, "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json"))
+  assert(yixuan.id === 1371, "G27 Yixuan proof source id drifted")
+  const firstBasic = yixuan.skill?.basic?.description?.[4]?.param?.[0]?.param?.["1371001"]
+  assert(firstBasic !== undefined, "G27 Yixuan proof skill param 1371001 is missing")
+
+  return {
+    identity: {
+      id: yixuan.id,
+      codeName: yixuan.code_name,
+      name: yixuan.name,
+    },
+    level60Panel: {
+      maxHp: panelValue(yixuan, { baseKey: "hp_max", levelKey: "hp_max", growthKey: "hp_growth" }),
+      attack: panelValue(yixuan, { baseKey: "attack", levelKey: "attack", growthKey: "attack_growth" }),
+      defence: panelValue(yixuan, { baseKey: "defence", levelKey: "defence", growthKey: "defence_growth" }),
+      critRate: requiredNumber(yixuan.stats?.crit, "stats.crit") / 10000,
+      critDamage: requiredNumber(yixuan.stats?.crit_damage, "stats.crit_damage") / 10000,
+      anomalyMastery: requiredNumber(yixuan.stats?.element_abnormal_power, "stats.element_abnormal_power"),
+      anomalyProficiency: requiredNumber(yixuan.stats?.element_mystery, "stats.element_mystery"),
+      impact: requiredNumber(yixuan.stats?.break_stun, "stats.break_stun"),
+    },
+    resource: {
+      maxAdrenaline: requiredNumber(yixuan.stats?.rp_max, "stats.rp_max"),
+      automaticAdrenalineAccumulation: requiredNumber(yixuan.stats?.rp_recover, "stats.rp_recover") / 100,
+      resonanceRecovery: requiredNumber(firstBasic.fever_recovery, "skill.basic.description.4.param.0.param.1371001.fever_recovery") / 1000,
+      adrenalineRecovery: requiredNumber(firstBasic.rp_recovery, "skill.basic.description.4.param.0.param.1371001.rp_recovery") / 10000,
+    },
+    rupture: {
+      ruptureLevel: requiredNumber(yixuan.stats?.rbl, "stats.rbl"),
+      ruptureCorrectionFactor: requiredNumber(yixuan.stats?.rbl_correction_factor, "stats.rbl_correction_factor") / 10000,
+      ruptureProbability: requiredNumber(yixuan.stats?.rbl_probability, "stats.rbl_probability") / 10000,
+    },
+  }
+}
+
+function plugbooProofValues() {
+  const plugboo = readJson(join(repoRoot, "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json"))
+  assert(plugboo.id === 54008, "G28 Plugboo proof source id drifted")
+  const active = plugboo.skill_prop?.["5400801"]
+  assert(active !== undefined, "G28 Plugboo proof active skill prop 5400801 is missing")
+
+  return {
+    identity: {
+      id: plugboo.id,
+      codeName: plugboo.code_name,
+      name: plugboo.name,
+    },
+    level60Panel: {
+      maxHp: panelValue(plugboo, { baseKey: "hp_max", levelKey: "hp_max", growthKey: "hpupgrade" }),
+      attack: panelValue(plugboo, { baseKey: "attack", levelKey: "attack", growthKey: "attack_upgrade" }),
+      defence: panelValue(plugboo, { baseKey: "defence", levelKey: "defence", growthKey: "def_upgrade" }),
+      impact: requiredNumber(plugboo.stats?.break_stun, "stats.break_stun"),
+      anomalyMastery: requiredNumber(plugboo.stats?.element_abnormal_power, "stats.element_abnormal_power"),
+    },
+    activeSkill: {
+      damageMultiplier: requiredNumber(active["1001"]?.main, "skill_prop.5400801.1001.main") / 10000,
+      dazeMultiplier: requiredNumber(active["1002"]?.main, "skill_prop.5400801.1002.main") / 10000,
+      anomalyBuildup: requiredNumber(active.element_accumulation_value, "skill_prop.5400801.element_accumulation_value") / 100,
+      element: "electric",
+    },
+  }
+}
+
+function proofAnchorRow({ header, anchorId, values }) {
+  const spec = anchorCandidateSpecs[anchorId]
+  const ruling = phase3Rulings[anchorId]
+  assert(spec !== undefined, `${anchorId}: proof anchor spec is missing`)
+  assert(ruling !== undefined, `${anchorId}: proof anchor ruling is missing`)
+  const sampleEntity = spec.requiredSampleEntities[0]
+  const sourceAnchor = rawAnchorForSample(sampleEntity, header.candidate.sourceVersion)
+  assert(sourceAnchor !== null, `${anchorId}: proof anchor source fixture is missing for ${sampleEntity}`)
+
+  return {
+    entityType: spec.entityType,
+    entityId: anchorId,
+    fieldId: `goldenAnchors.${anchorId}.newSourceProof`,
+    canonicalPath: `data.cleaned.golden.v1Replay.anchors.${anchorId}.newSourceProof`,
+    fieldPath: `/anchors/${anchorId}/newSourceProof`,
+    baselineSourceRef: {
+      ...proofAnchorOwnerDecision,
+      dataPath: `/${anchorId}`,
+    },
+    candidateSourceRef: {
+      sourceId: "nanoka-zzz",
+      sourceVersion: header.candidate.sourceVersion,
+      sourceAnchor,
+      dataPath: dataPathForSample(sampleEntity),
+    },
+    baselineValue: {
+      ownerDecision: `${anchorId} = ${values.identity.name} (${values.identity.id})`,
+      priorArchivedBaseline: "not-applicable-new-proof-anchor",
+    },
+    candidateValue: {
+      coverageStatus: "new-source-proof-passed",
+      expectedCandidate: spec.expectedCandidate,
+      fieldIds: spec.fieldIds,
+      requiredSampleEntities: spec.requiredSampleEntities,
+      availableSampleEntities: spec.requiredSampleEntities,
+      missingRequiredSampleEntities: [],
+      normalizedValues: values,
+      rulingSummary: ruling.summary,
+    },
+    status: "new",
+    severity: "info",
+    rulingStatus: "accepted",
+    rulingId: ruling.rulingId,
+    rulingDecisionLog: `${rulingDecisionLogPath}#${ruling.rulingId}-${anchorId.toLowerCase()}`,
+    blockedBy: [],
+    notes: ruling.summary,
+  }
+}
+
 function buildG01G26Report({ syncId, generatedAt }) {
   const header = reportHeader({ syncId, generatedAt })
   const matrix = readJson(matrixPath)
@@ -653,11 +821,49 @@ function buildG01G26Report({ syncId, generatedAt }) {
   }
 }
 
+function buildG27G28Report({ syncId, generatedAt }) {
+  const header = reportHeader({ syncId, generatedAt })
+  const previousRows = buildG01G26Report({ syncId: firstSyncId, generatedAt }).rows
+  const rows = [
+    ...previousRows,
+    proofAnchorRow({ header, anchorId: "G27", values: yixuanProofValues() }),
+    proofAnchorRow({ header, anchorId: "G28", values: plugbooProofValues() }),
+  ]
+
+  return {
+    ...header,
+    exitCleanSyncEligible: true,
+    exitGateEvidence: {
+      cleanSyncIds: [firstSyncId, syncId],
+      anchorIds: Array.from({ length: 28 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`),
+      goldenReplayStatus: "passed",
+      requiredNewProofAnchorIds: ["G27", "G28"],
+      previousCleanSyncId: firstSyncId,
+      currentSyncId: syncId,
+      notes: [
+        "G01-G26 are accepted in phase3-sync-001-g01-g26.",
+        "G27/G28 are lo-user-selected approved-live nanoka proof anchors.",
+        "Runtime cutover remains disabled until Phase 4.",
+      ],
+    },
+    counts: countsForRows(rows),
+    rows,
+    unresolvedCount: rows.filter(row => row.rulingStatus === "pending" || row.rulingStatus === "owner-required").length,
+    notes: [
+      "Phase 3 second sync carries forward accepted G01-G26 rulings and adds lo-user-selected G27/G28 approved-live nanoka proof anchors.",
+      "This sync is exit-clean eligible for Phase 3 only; runtime cleaned-data cutover remains disabled until Phase 4.",
+      "Archived Excel, D-17 Mihoyo, and D-12 buhflipexplode sources are audit baselines only; they are not runtime fallback inputs.",
+    ],
+  }
+}
+
 function buildReport({ syncId, generatedAt }) {
   if (syncId === defaultSyncId)
     return buildFoundationReport({ syncId, generatedAt })
   if (syncId === firstSyncId)
     return buildG01G26Report({ syncId, generatedAt })
+  if (syncId === secondSyncId)
+    return buildG27G28Report({ syncId, generatedAt })
   throw new Error(`Unsupported source migration drift syncId: ${syncId}`)
 }
 
@@ -669,8 +875,12 @@ function renderMarkdown(report) {
     .map(baseline => `| \`${baseline.sourceId}\` | \`${baseline.sourceVersion}\` | ${baseline.archived ? "yes" : "no"} |`)
     .join("\n")
   const hasRows = report.rows.length > 0
-  const statusLine = hasRows ? "Phase 3 drift audit first G01-G26 sync" : "Phase 3 drift audit foundation fixture"
-  const intro = hasRows
+  const statusLine = report.exitCleanSyncEligible
+    ? "Phase 3 drift audit second sync with G27/G28 proof anchors"
+    : hasRows ? "Phase 3 drift audit first G01-G26 sync" : "Phase 3 drift audit foundation fixture"
+  const intro = report.exitCleanSyncEligible
+    ? "This report carries forward accepted G01-G26 rulings, adds G27/G28 approved-live proof anchors, and records Phase 3 exit-clean evidence. Full runtime cutover remains disabled."
+    : hasRows
     ? "This report compares archived G01-G26 replay baselines against nanoka candidate coverage/status/source paths and records Product/TL rulings. Full runtime cutover remains disabled."
     : `This report is a schema/verifier fixture. It intentionally contains no field
 comparison rows; full G01-G26 comparison begins in the next Phase 3 slice.`
@@ -800,11 +1010,48 @@ function validateExitCleanEligibility(report, { syncId }) {
   assert(report.unresolvedCount === 0, "exit-clean drift sync cannot have unresolved rows")
 
   const evidence = report.exitGateEvidence
+  const expectedAnchorIds = Array.from({ length: 28 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`)
+  const expectedProofAnchorIds = ["G27", "G28"]
   assert(evidence !== null && typeof evidence === "object" && !Array.isArray(evidence), "exitCleanSyncEligible requires exitGateEvidence")
-  assert(Array.isArray(evidence.cleanSyncIds) && evidence.cleanSyncIds.length >= 2, "exitGateEvidence.cleanSyncIds must include at least two clean syncs")
-  assert(evidence.cleanSyncIds.includes(syncId), "exitGateEvidence.cleanSyncIds must include the current syncId")
-  assert(Array.isArray(evidence.anchorIds) && evidence.anchorIds.includes("G27") && evidence.anchorIds.includes("G28"), "exitGateEvidence.anchorIds must include G27 and G28")
+  assert(typeof evidence.previousCleanSyncId === "string" && evidence.previousCleanSyncId.length > 0, "exitGateEvidence.previousCleanSyncId is required")
+  assert(typeof evidence.currentSyncId === "string" && evidence.currentSyncId.length > 0, "exitGateEvidence.currentSyncId is required")
+  assert(evidence.currentSyncId === syncId, "exitGateEvidence.currentSyncId must equal the verified syncId")
+  assert(evidence.previousCleanSyncId !== syncId, "exitGateEvidence.previousCleanSyncId must be distinct from the current syncId")
+  assert(evidence.previousCleanSyncId !== defaultSyncId, "foundation sync cannot count as clean sync evidence")
+  assert(Array.isArray(evidence.cleanSyncIds), "exitGateEvidence.cleanSyncIds must be an array")
+  assert(evidence.cleanSyncIds.length === new Set(evidence.cleanSyncIds).size, "exitGateEvidence.cleanSyncIds must be unique")
+  assert(arrayEquals(evidence.cleanSyncIds, [evidence.previousCleanSyncId, evidence.currentSyncId]), "exitGateEvidence.cleanSyncIds must equal previous/current clean sync ids")
+  assert(!evidence.cleanSyncIds.includes(defaultSyncId), "foundation sync cannot count as clean sync evidence")
+  assert(arrayEquals(evidence.anchorIds, expectedAnchorIds), "exitGateEvidence.anchorIds must equal the complete G01-G28 anchor set")
+  assert(arrayEquals(evidence.requiredNewProofAnchorIds, expectedProofAnchorIds), "exitGateEvidence.requiredNewProofAnchorIds must equal G27/G28")
   assert(evidence.goldenReplayStatus === "passed", "exitGateEvidence.goldenReplayStatus must be passed")
+  const rowByEntityId = new Map(report.rows.map(row => [row.entityId, row]))
+  for (const anchorId of expectedAnchorIds) {
+    const row = rowByEntityId.get(anchorId)
+    assert(row !== undefined, `exit-clean drift sync requires ${anchorId} row evidence`)
+    assert(row.rulingStatus === "accepted", `exit-clean drift sync requires ${anchorId} accepted ruling`)
+  }
+  for (const anchorId of ["G27", "G28"]) {
+    const row = rowByEntityId.get(anchorId)
+    assert(row.status === "new", `exit-clean drift sync requires ${anchorId} new-source proof row`)
+    assert(row.candidateValue?.coverageStatus === "new-source-proof-passed", `exit-clean drift sync requires ${anchorId} passed proof coverage`)
+  }
+  validateProofAnchorValues(rowByEntityId.get("G27"), yixuanProofValues(), "G27")
+  validateProofAnchorValues(rowByEntityId.get("G28"), plugbooProofValues(), "G28")
+  for (const cleanSyncId of evidence.cleanSyncIds) {
+    const cleanReport = cleanSyncId === syncId
+      ? report
+      : readJson(reportPaths(cleanSyncId).rootJson)
+    assert(cleanReport.unresolvedCount === 0, `${cleanSyncId}: clean sync evidence cannot have unresolved rows`)
+    assert(cleanReport.runtimeCutoverReady === false, `${cleanSyncId}: clean sync evidence must not cut runtime over`)
+  }
+}
+
+function validateProofAnchorValues(row, expectedValues, anchorId) {
+  assert(row !== undefined, `${anchorId}: proof anchor row is required`)
+  const actualValues = row.candidateValue?.normalizedValues
+  assert(actualValues !== undefined, `${anchorId}: normalizedValues are required`)
+  assert(JSON.stringify(actualValues) === JSON.stringify(expectedValues), `${anchorId}: proof anchor normalizedValues must match approved-live nanoka raw evidence`)
 }
 
 function validateReportShape(report, { registry, matrix, syncId }) {

--- a/packages/data/src/source-migration-drift.test.ts
+++ b/packages/data/src/source-migration-drift.test.ts
@@ -8,6 +8,7 @@ const repoRoot = join(import.meta.dirname, "../../..")
 const dataPackageRoot = join(repoRoot, "packages/data")
 const syncId = "phase3-sync-000-foundation"
 const firstSyncId = "phase3-sync-001-g01-g26"
+const secondSyncId = "phase3-sync-002-g27-g28"
 
 type DriftReport = {
   schemaVersion: string
@@ -44,6 +45,7 @@ type DriftReport = {
       availableSampleEntities: string[]
       missingRequiredSampleEntities: string[]
       rulingSummary?: string
+      normalizedValues?: unknown
     }
     status: string
     severity: string
@@ -57,6 +59,9 @@ type DriftReport = {
     cleanSyncIds: string[]
     anchorIds: string[]
     goldenReplayStatus: string
+    requiredNewProofAnchorIds?: string[]
+    previousCleanSyncId?: string
+    currentSyncId?: string
   }
 }
 
@@ -363,11 +368,237 @@ describe("Phase 3 source migration drift report foundation", () => {
     expect(report).toContain("Runtime cutover ready: **false**")
   })
 
+  it("verifies the second G27/G28 sync report and exit-clean evidence", () => {
+    const output = execFileSync("node", ["scripts/source-migration-drift.mjs", "verify", "--sync-id", secondSyncId], {
+      cwd: dataPackageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${secondSyncId}.json`)
+
+    expect(output).toContain(`source migration drift verification passed for ${secondSyncId}`)
+    expect(report).toMatchObject({
+      schemaVersion: "nanoka-drift-report/v0.1",
+      syncId: secondSyncId,
+      candidate: {
+        sourceId: "nanoka-zzz",
+        sourceVersion: "2.8",
+      },
+      runtimeCutoverReady: false,
+      exitCleanSyncEligible: true,
+      counts: {
+        same: 0,
+        changed: 0,
+        missing: 0,
+        new: 2,
+        "semantic-mismatch": 26,
+      },
+      unresolvedCount: 0,
+      exitGateEvidence: {
+        cleanSyncIds: [firstSyncId, secondSyncId],
+        requiredNewProofAnchorIds: ["G27", "G28"],
+        previousCleanSyncId: firstSyncId,
+        currentSyncId: secondSyncId,
+        goldenReplayStatus: "passed",
+      },
+    })
+    expect(report.exitGateEvidence?.anchorIds).toEqual(Array.from({ length: 28 }, (_, index) => `G${String(index + 1).padStart(2, "0")}`))
+    expect(report.rows).toHaveLength(28)
+    expect(report.rows.slice(0, 26).every(row => row.status === "semantic-mismatch" && row.rulingStatus === "accepted")).toBe(true)
+
+    const g27 = report.rows.find(row => row.entityId === "G27")
+    const g28 = report.rows.find(row => row.entityId === "G28")
+    expect(g27).toMatchObject({
+      status: "new",
+      rulingStatus: "accepted",
+      rulingId: "phase3-r027",
+      candidateSourceRef: {
+        sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/character/1371.json",
+        dataPath: "/stats",
+      },
+      candidateValue: {
+        coverageStatus: "new-source-proof-passed",
+        requiredSampleEntities: ["nanoka-character-yixuan-live-1371"],
+        normalizedValues: {
+          identity: {
+            id: 1371,
+            codeName: "Yixuan",
+            name: "仪玄",
+          },
+          level60Panel: {
+            maxHp: 7953.8621,
+            attack: 872.5748,
+            defence: 441.1145,
+          },
+          resource: {
+            maxAdrenaline: 120,
+            automaticAdrenalineAccumulation: 2,
+            resonanceRecovery: 71.5,
+            adrenalineRecovery: 0.52,
+          },
+          rupture: {
+            ruptureLevel: 1,
+            ruptureCorrectionFactor: 1,
+            ruptureProbability: 0,
+          },
+        },
+      },
+    })
+    expect(g28).toMatchObject({
+      status: "new",
+      rulingStatus: "accepted",
+      rulingId: "phase3-r028",
+      candidateSourceRef: {
+        sourceAnchor: "data/source/raw/nanoka/zzz/2.8/zh/bangboo/54008.json",
+        dataPath: "/stats",
+      },
+      candidateValue: {
+        coverageStatus: "new-source-proof-passed",
+        requiredSampleEntities: ["nanoka-bangboo-plugboo-live-54008"],
+        normalizedValues: {
+          identity: {
+            id: 54008,
+            codeName: "Plugboo",
+            name: "插头布",
+          },
+          level60Panel: {
+            maxHp: 4210.2983,
+            attack: 8057.0996,
+            defence: 723.8011,
+          },
+          activeSkill: {
+            damageMultiplier: 5.12,
+            dazeMultiplier: 1.87,
+            anomalyBuildup: 240,
+            element: "electric",
+          },
+        },
+      },
+    })
+  })
+
+  it("rejects exit-clean reports without G27/G28 proof rows", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const fixturePath = join(tempDir, "missing-g28-proof-report.json")
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${secondSyncId}.json`)
+    const missingG28Report = {
+      ...report,
+      rows: report.rows.filter(row => row.entityId !== "G28"),
+      counts: {
+        ...report.counts,
+        new: 1,
+      },
+    }
+
+    try {
+      writeFileSync(fixturePath, `${JSON.stringify(missingG28Report, null, 2)}\n`)
+
+      expect(() =>
+        execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", secondSyncId, "--report", fixturePath], {
+          cwd: dataPackageRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).toThrow("exit-clean drift sync requires G28 row evidence")
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("rejects exit-clean reports whose G27/G28 proof values drift from approved-live raw evidence", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const fixturePath = join(tempDir, "mutated-proof-values-report.json")
+    const report = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${secondSyncId}.json`)
+    const mutatedReport = structuredClone(report)
+    const g27 = mutatedReport.rows.find(row => row.entityId === "G27")!
+    const g28 = mutatedReport.rows.find(row => row.entityId === "G28")!
+    const g27Values = g27.candidateValue.normalizedValues as { resource: { adrenalineRecovery: number } }
+    const g28Values = g28.candidateValue.normalizedValues as { activeSkill: { damageMultiplier: number, element: string } }
+    g27Values.resource.adrenalineRecovery = 0.53
+    g28Values.activeSkill.damageMultiplier = 5.13
+    g28Values.activeSkill.element = "fire"
+
+    try {
+      writeFileSync(fixturePath, `${JSON.stringify(mutatedReport, null, 2)}\n`)
+
+      expect(() =>
+        execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", secondSyncId, "--report", fixturePath], {
+          cwd: dataPackageRoot,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ).toThrow("G27: proof anchor normalizedValues must match approved-live nanoka raw evidence")
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it("rejects forged exit-clean evidence for the second sync", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "fairy-drift-report-"))
+    const baseReport = readJson<DriftReport>(`data/cleaned/audit/nanoka-drift-report/${secondSyncId}.json`)
+    const tamperedReports = [
+      {
+        name: "foundation-current-clean-syncs",
+        mutate(report: DriftReport) {
+          report.exitGateEvidence!.cleanSyncIds = [syncId, secondSyncId]
+        },
+      },
+      {
+        name: "duplicate-current-clean-syncs",
+        mutate(report: DriftReport) {
+          report.exitGateEvidence!.cleanSyncIds = [secondSyncId, secondSyncId]
+        },
+      },
+      {
+        name: "truncated-anchor-set",
+        mutate(report: DriftReport) {
+          report.exitGateEvidence!.anchorIds = ["G27", "G28"]
+        },
+      },
+      {
+        name: "mismatched-current-sync-id",
+        mutate(report: DriftReport) {
+          report.exitGateEvidence!.currentSyncId = firstSyncId
+        },
+      },
+      {
+        name: "foundation-previous-sync-id",
+        mutate(report: DriftReport) {
+          report.exitGateEvidence!.previousCleanSyncId = syncId
+          report.exitGateEvidence!.cleanSyncIds = [syncId, secondSyncId]
+        },
+      },
+    ]
+
+    try {
+      for (const tampered of tamperedReports) {
+        const fixturePath = join(tempDir, `${tampered.name}.json`)
+        const report = structuredClone(baseReport)
+        tampered.mutate(report)
+        writeFileSync(fixturePath, `${JSON.stringify(report, null, 2)}\n`)
+
+        expect(() =>
+          execFileSync("node", ["scripts/source-migration-drift.mjs", "verify-fixture", "--sync-id", secondSyncId, "--report", fixturePath], {
+            cwd: dataPackageRoot,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        ).toThrow(/exitGateEvidence|foundation sync/)
+      }
+    }
+    finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it("packs the drift report artifact without raw source archives", () => {
     const files = npmPackFiles()
 
     expect(files).toContain(`cleaned/audit/nanoka-drift-report/${syncId}.json`)
     expect(files).toContain(`cleaned/audit/nanoka-drift-report/${firstSyncId}.json`)
+    expect(files).toContain(`cleaned/audit/nanoka-drift-report/${secondSyncId}.json`)
     expect(files.some(file => file.startsWith("source/raw/"))).toBe(false)
     expect(files.some(file => file.endsWith(".xlsx"))).toBe(false)
   })


### PR DESCRIPTION
## Summary

- add Phase 3 `phase3-sync-002-g27-g28` drift report carrying forward accepted G01-G26 rulings plus lo-user-selected G27/G28 proof anchors
- record G27 Yixuan (1371) and G28 Plugboo (54008) accepted rulings in the source ruling log
- add executable exit-clean evidence checks: two clean sync IDs, current sync membership, G27/G28 row proof, accepted G01-G28 rulings, golden replay passed, and `runtimeCutoverReady=false`

## Drift state

- `counts`: `same=0`, `changed=0`, `missing=0`, `new=2`, `semantic-mismatch=26`
- `unresolvedCount=0`
- `exitCleanSyncEligible=true`
- `runtimeCutoverReady=false`
- `exitGateEvidence.cleanSyncIds=[phase3-sync-001-g01-g26, phase3-sync-002-g27-g28]`
- G27 proof values: Yixuan `maxHp=7953.8621`, `attack=872.5748`, `defence=441.1145`, Adrenaline `120/2`, Resonance/Adrenaline recovery `71.5/0.52`
- G28 proof values: Plugboo `attack=8057.0996`, active skill `5.12x`, daze `1.87x`, buildup `240`, element `electric`

## Runtime boundary

This PR does not promote nanoka to runtime cleaned data. `runtimeCutoverReady` remains false; Phase 4 still owns the runtime cutover.

## Verification

- `pnpm --filter @randomplay/data audit:source-migration -- --sync-id phase3-sync-002-g27-g28 --generated-at 2026-05-15T18:20:00+08:00`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-002-g27-g28`
- `pnpm --filter @randomplay/data test -- source-migration-drift.test.ts`
- `node scripts/sync-cleaned.mjs --check` (from `packages/data`)
- `pnpm --filter @randomplay/data verify:source-migration`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-001-g01-g26`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data verify:golden-v1`
- data pack dry-run artifact inclusion / raw-source exclusion check
- `git diff --check`
- `pnpm check`
- `pnpm build`
- `pnpm test`
