### PR TITLE
docs(data): plan nanoka full data batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Fairy are documented in this file.
 ### Added
 
 - Batch import the approved-live nanoka 2.8 Bangboo catalog into runtime cleaned data without a package version bump.
+- Record the V1.2.x full-data batch import discovery and PR sequence without a package version bump.
 
 ## 0.1.0 - 2026-05-15
 

--- a/data/cleaned/audit/nanoka-full-data-batch-discovery.json
+++ b/data/cleaned/audit/nanoka-full-data-batch-discovery.json
@@ -1,0 +1,255 @@
+{
+  "kind": "nanokaFullDataBatchDiscovery",
+  "schemaVersion": "nanoka-full-data-batch-discovery/v0.1",
+  "sourceId": "nanoka-zzz",
+  "configuredLiveVersion": "2.8",
+  "generatedAt": "2026-05-15T23:17:00+08:00",
+  "runtimeCutoverReady": true,
+  "decisionContext": {
+    "task": "task #179",
+    "scope": "Batch import all nanoka-backed data used by fairy after V0.1.0 and V1.2.1",
+    "decisions": {
+      "batchOrder": "sequential-per-domain",
+      "enemyScope": "all-current-live-monster-index-records",
+      "deadlyAssaultScope": "current-live-plus-historical-periods-in-a-dedicated-historicalDAPeriods-bucket",
+      "versionBumpPolicy": "do-not-bump-until-batch-work-is-complete",
+      "goldenAnchorPolicy": "do-not-add-new-golden-anchors",
+      "sourceConsistencyPolicy": "nanoka-self-consistency"
+    },
+    "excludedOrDeferred": [
+      {
+        "field": "resonium",
+        "reason": "removed from cleaned scope by R4"
+      },
+      {
+        "field": "driveDiscs.slotAndSubstatTables",
+        "reason": "out-of-scope by prior lo-user decision; user snapshots provide final Agent panel"
+      },
+      {
+        "field": "formula-owned anomaly/disorder/daze constants",
+        "reason": "implementation-owned by Phase 3 rulings, not batch-imported source data"
+      }
+    ]
+  },
+  "domains": [
+    {
+      "domain": "characters",
+      "index": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "currentLiveIndexCount": 53,
+      "currentLiveDetailAccessibleCount": 53,
+      "retainedRawDetailCount": 4,
+      "runtimeRecordCount": 1,
+      "missingRawDetailCount": 49,
+      "missingRuntimeRecordCount": 52,
+      "targetRuntimeBucket": "GameData.agents",
+      "schemaFit": "existing-bucket",
+      "promotableCurrentFields": [
+        "identity",
+        "attribute",
+        "agentSpecialty",
+        "baseStatsByLevel.60",
+        "resource stats embedded in Agent/Skill artifacts where present",
+        "promotion extra stat audit rows"
+      ],
+      "implementationNotes": [
+        "Character skill/passive typed modifiers require per-template promotion and should fail loud when text is not mapped.",
+        "Sentinel/Adrenaline fields remain character-detail-derived and stay in current live runtime only."
+      ],
+      "recommendedPr": "PR-A characters batch"
+    },
+    {
+      "domain": "wEngines",
+      "index": "https://static.nanoka.cc/zzz/2.8/weapon.json",
+      "currentLiveIndexCount": 89,
+      "currentLiveDetailAccessibleCount": 89,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 88,
+      "missingRuntimeRecordCount": 89,
+      "targetRuntimeBucket": "GameData.wEngines",
+      "schemaFit": "existing-bucket",
+      "promotableCurrentFields": [
+        "identity",
+        "baseStatsByLevel",
+        "base_property",
+        "rand_property"
+      ],
+      "implementationNotes": [
+        "Weapon passive text/talents must be audited before typed modifier promotion.",
+        "Numeric base/substat promotion can proceed with source refs and unit normalization first."
+      ],
+      "recommendedPr": "PR-B wEngines batch"
+    },
+    {
+      "domain": "driveDiscs",
+      "index": "https://static.nanoka.cc/zzz/2.8/equipment.json",
+      "currentLiveIndexCount": 26,
+      "currentLiveDetailAccessibleCount": 26,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 25,
+      "missingRuntimeRecordCount": 26,
+      "targetRuntimeBucket": "GameData.driveDiscs",
+      "schemaFit": "existing-bucket-for-set-effects-only",
+      "promotableCurrentFields": [
+        "identity",
+        "desc2",
+        "desc4"
+      ],
+      "implementationNotes": [
+        "Set-effect text can be retained and audited for typed promotion.",
+        "Slot/main/substat tables remain excluded and must not appear in runtime until a separate product decision changes that scope."
+      ],
+      "recommendedPr": "PR-C drive disc set batch"
+    },
+    {
+      "domain": "enemies",
+      "index": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "currentLiveIndexCount": 269,
+      "currentLiveDetailAccessibleCount": 269,
+      "currentLiveMonsterInfoVariantCount": 573,
+      "retainedRawDetailCount": 7,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 262,
+      "missingRuntimeRecordCount": 269,
+      "targetRuntimeBucket": "GameData.enemies",
+      "schemaFit": "existing-bucket-with-variant-selection-risk",
+      "promotableCurrentFields": [
+        "identity",
+        "rank",
+        "variant mapping",
+        "selected monster_info stats",
+        "element/resistance profile"
+      ],
+      "implementationNotes": [
+        "Each monster detail can contain multiple monster_info variants; current batch should retain all current-live details and explicitly document selection rules.",
+        "Runtime import should start from the detail.monster_id selected variant, with audit rows for skipped variants."
+      ],
+      "recommendedPr": "PR-D enemies batch"
+    },
+    {
+      "domain": "deadlyAssaultCurrent",
+      "index": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "currentLiveIndexCount": 38,
+      "currentLiveDetailAccessibleCount": 38,
+      "currentLiveZoneCount": 114,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 37,
+      "targetRuntimeBucket": "GameData.deadlyAssaultPeriods or equivalent DA bucket",
+      "schemaFit": "schema-additive",
+      "promotableCurrentFields": [
+        "period identity",
+        "begin/end",
+        "zones",
+        "layer/selectable buffs",
+        "rooms",
+        "monsters",
+        "boss adjustments"
+      ],
+      "implementationNotes": [
+        "Current-live DA periods can be modeled separately from historical DA periods while preserving nanoka-only runtime source refs.",
+        "Any new runtime DA bucket is schema-additive and must be treated as a release-boundary change before npm publication."
+      ],
+      "recommendedPr": "PR-E DA current periods"
+    },
+    {
+      "domain": "bangboos",
+      "index": "https://static.nanoka.cc/zzz/2.8/bangboo.json",
+      "currentLiveIndexCount": 39,
+      "currentLiveDetailAccessibleCount": 39,
+      "retainedRawDetailCount": 39,
+      "runtimeRecordCount": 39,
+      "runtimeSkillCount": 63,
+      "missingRawDetailCount": 0,
+      "missingRuntimeRecordCount": 0,
+      "targetRuntimeBucket": "GameData.bangboos and GameData.bangbooSkills",
+      "schemaFit": "completed-in-V1.2.1",
+      "implementationNotes": [
+        "No further V1.2.x batch work required unless configuredLiveVersion changes."
+      ],
+      "recommendedPr": "done-in-PR-77"
+    }
+  ],
+  "historicalDeadlyAssault": {
+    "targetBucket": "historicalDAPeriods",
+    "policy": "historical periods must not be mixed into configured-live runtime records",
+    "schemaImpact": "schema-additive; release version to be decided after V1.2.x batch completion",
+    "snapshots": [
+      {
+        "snapshot": "2.8",
+        "bossIndexCount": 38,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "69038"
+      },
+      {
+        "snapshot": "2.8.12",
+        "bossIndexCount": 46,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690381"
+      },
+      {
+        "snapshot": "3.0.1+15348292",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15370273",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15377279",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15390262",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15596677",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15597809",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15599986",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15602810",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15625449",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      }
+    ]
+  },
+  "recommendedPrSequence": [
+    "PR-A: retain and batch-promote all current-live characters",
+    "PR-B: retain and batch-promote all current-live W-Engines",
+    "PR-C: retain and batch-promote current-live Drive Disc set identity/effect text; keep slot/main/substat excluded",
+    "PR-D: retain all current-live monster details and batch-promote selected enemy variants with skipped-variant audit",
+    "PR-E: add current DA period bucket if needed and retain/promote all 2.8 DA periods",
+    "PR-F: add historicalDAPeriods schema bucket and retain/promote historical DA periods across manifest.available snapshots"
+  ]
+}

--- a/docs/data-source/README.md
+++ b/docs/data-source/README.md
@@ -1,6 +1,6 @@
 # Data Source Ingestion
 
-Status: V0.1.0 nanoka runtime cutover baseline + V1.2.1 Bangboo batch import
+Status: V0.1.0 nanoka runtime cutover baseline + V1.2.1 Bangboo batch import + V1.2.x full-data batch discovery
 Owner: @TechLead
 Inputs: CONFIRM-4, CONFIRM-11, D-20, Phase 2 nanoka adapter, Phase 3 drift audit, Phase 4 runtime cutover
 
@@ -27,6 +27,9 @@ nanoka 2.8 entries without adding a package version bump.
   runtime cleaned artifacts.
 - `data/cleaned/audit/nanoka-bangboo-batch-audit.json` records the V1.2.1
   per-entry Bangboo panel/skill/element audit.
+- `data/cleaned/audit/nanoka-full-data-batch-discovery.json` records the
+  V1.2.x full-data batch counts, exclusions, historical DA boundary, and PR
+  sequence.
 - Raw source archives are retained for audit and are not distributed in npm
   package payloads.
 
@@ -54,6 +57,7 @@ Source-specific notes:
 - [Source migration candidates](source-migration-candidates.md)
 - [Source decision recommendation](source-decision-recommendation.md)
 - [Nanoka coverage matrix](nanoka-coverage-matrix.md)
+- [Nanoka full-data batch plan](nanoka-full-data-batch-plan.md)
 - [Nanoka DA / Sentinel / patch history feasibility](da-sentinel-patch-nanoka-feasibility.md)
 - [Takedown and rollback runbook](takedown-rollback.md)
 

--- a/docs/data-source/nanoka-full-data-batch-plan.md
+++ b/docs/data-source/nanoka-full-data-batch-plan.md
@@ -1,0 +1,72 @@
+# Nanoka Full-Data Batch Plan
+
+Status: V1.2.x discovery locked for task #179.
+
+This plan extends the V1.2.1 Bangboo batch import into the rest of the nanoka-backed data that fairy can use. It records the implementation boundary before the larger domain PRs land.
+
+## Locked Decisions
+
+| Decision | Value |
+|---|---|
+| Batch order | Sequential per domain |
+| Enemy scope | All current-live monster index records |
+| Deadly Assault scope | Current live plus historical periods, with historical data in a dedicated `historicalDAPeriods` bucket |
+| Version bump | Do not bump until the full V1.2.x batch work is complete |
+| Golden anchors | Do not add new anchors for this batch |
+| Source consistency | Nanoka self-consistency is sufficient |
+
+## Current Live Counts
+
+Configured live version remains `manifest.zzz.live = 2.8`.
+
+| Domain | Current live index | Details accessible | Runtime today | Gap |
+|---|---:|---:|---:|---:|
+| Characters | 53 | 53 | 1 | 52 runtime records |
+| W-Engines | 89 | 89 | 0 | 89 runtime records |
+| Drive Disc sets | 26 | 26 | 0 | 26 runtime records |
+| Enemies | 269 | 269 | 0 | 269 runtime records |
+| Deadly Assault current periods | 38 | 38 | 0 | schema/runtime bucket required |
+| Bangboos | 39 | 39 | 39 | complete in PR #77 |
+
+Enemy details contain 573 `monster_info` variants. The first enemy batch should promote the selected `detail.monster_id -> monster_info[monster_id]` variant and audit skipped variants rather than silently dropping them.
+
+## Historical DA Boundary
+
+Historical DA periods are intentionally not mixed into configured-live runtime records. Product and lo-user selected a dedicated `historicalDAPeriods` bucket so old DA periods can be queried without weakening the Formal-Live Gate for current cleaned output.
+
+The currently visible nanoka ZZZ snapshots are:
+
+| Snapshot | Boss index count |
+|---|---:|
+| `2.8` | 38 |
+| `2.8.12` | 46 |
+| `3.0.1+15348292` | 53 |
+| `3.0.1+15370273` | 53 |
+| `3.0.1+15377279` | 53 |
+| `3.0.1+15390262` | 50 |
+| `3.0.2+15596677` | 50 |
+| `3.0.2+15597809` | 50 |
+| `3.0.2+15599986` | 50 |
+| `3.0.2+15602810` | 50 |
+| `3.0.2+15625449` | 50 |
+
+The schema addition is release-significant. The version bump is deferred until the full V1.2.x batch is complete.
+
+## Exclusions
+
+| Field | Reason |
+|---|---|
+| Resonium | Removed from cleaned scope by R4 |
+| Drive Disc slot/main/substat tables | Out of scope by prior lo-user decision; user snapshots provide the final Agent panel |
+| Formula-owned anomaly/disorder/daze constants | Implementation-owned by Phase 3 rulings, not batch-imported source data |
+
+## PR Sequence
+
+1. Characters: retain and batch-promote all current-live characters.
+2. W-Engines: retain and batch-promote all current-live W-Engines.
+3. Drive Disc sets: retain and batch-promote current-live set identity/effect text; keep slot/main/substat excluded.
+4. Enemies: retain all current-live monster details and batch-promote selected enemy variants with skipped-variant audit.
+5. DA current: add a current DA period bucket if needed and retain/promote all 2.8 periods.
+6. DA historical: add `historicalDAPeriods` and retain/promote historical periods across `manifest.available`.
+
+Each implementation PR should keep the existing 28-anchor golden replay passing, avoid version bumps, avoid new golden anchors, and add per-domain fail-loud source/audit checks.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -17,6 +17,9 @@ Current state:
 - V1.2.1 Bangboo batch audit lives under
   `cleaned/audit/nanoka-bangboo-batch-audit.json` and verifies all 39
   approved-live nanoka 2.8 Bangboos;
+- V1.2.x full-data batch discovery lives under
+  `cleaned/audit/nanoka-full-data-batch-discovery.json` and locks the domain
+  counts, exclusions, historical DA boundary, and implementation PR sequence;
 - V1 golden source candidates, manual acceptance records, and the replay report
   are generated under repo-level `data/cleaned/`;
 - `pnpm --filter @randomplay/data sync-cleaned` mirrors repo-level cleaned JSON into

--- a/packages/data/cleaned/audit/nanoka-full-data-batch-discovery.json
+++ b/packages/data/cleaned/audit/nanoka-full-data-batch-discovery.json
@@ -1,0 +1,255 @@
+{
+  "kind": "nanokaFullDataBatchDiscovery",
+  "schemaVersion": "nanoka-full-data-batch-discovery/v0.1",
+  "sourceId": "nanoka-zzz",
+  "configuredLiveVersion": "2.8",
+  "generatedAt": "2026-05-15T23:17:00+08:00",
+  "runtimeCutoverReady": true,
+  "decisionContext": {
+    "task": "task #179",
+    "scope": "Batch import all nanoka-backed data used by fairy after V0.1.0 and V1.2.1",
+    "decisions": {
+      "batchOrder": "sequential-per-domain",
+      "enemyScope": "all-current-live-monster-index-records",
+      "deadlyAssaultScope": "current-live-plus-historical-periods-in-a-dedicated-historicalDAPeriods-bucket",
+      "versionBumpPolicy": "do-not-bump-until-batch-work-is-complete",
+      "goldenAnchorPolicy": "do-not-add-new-golden-anchors",
+      "sourceConsistencyPolicy": "nanoka-self-consistency"
+    },
+    "excludedOrDeferred": [
+      {
+        "field": "resonium",
+        "reason": "removed from cleaned scope by R4"
+      },
+      {
+        "field": "driveDiscs.slotAndSubstatTables",
+        "reason": "out-of-scope by prior lo-user decision; user snapshots provide final Agent panel"
+      },
+      {
+        "field": "formula-owned anomaly/disorder/daze constants",
+        "reason": "implementation-owned by Phase 3 rulings, not batch-imported source data"
+      }
+    ]
+  },
+  "domains": [
+    {
+      "domain": "characters",
+      "index": "https://static.nanoka.cc/zzz/2.8/character.json",
+      "currentLiveIndexCount": 53,
+      "currentLiveDetailAccessibleCount": 53,
+      "retainedRawDetailCount": 4,
+      "runtimeRecordCount": 1,
+      "missingRawDetailCount": 49,
+      "missingRuntimeRecordCount": 52,
+      "targetRuntimeBucket": "GameData.agents",
+      "schemaFit": "existing-bucket",
+      "promotableCurrentFields": [
+        "identity",
+        "attribute",
+        "agentSpecialty",
+        "baseStatsByLevel.60",
+        "resource stats embedded in Agent/Skill artifacts where present",
+        "promotion extra stat audit rows"
+      ],
+      "implementationNotes": [
+        "Character skill/passive typed modifiers require per-template promotion and should fail loud when text is not mapped.",
+        "Sentinel/Adrenaline fields remain character-detail-derived and stay in current live runtime only."
+      ],
+      "recommendedPr": "PR-A characters batch"
+    },
+    {
+      "domain": "wEngines",
+      "index": "https://static.nanoka.cc/zzz/2.8/weapon.json",
+      "currentLiveIndexCount": 89,
+      "currentLiveDetailAccessibleCount": 89,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 88,
+      "missingRuntimeRecordCount": 89,
+      "targetRuntimeBucket": "GameData.wEngines",
+      "schemaFit": "existing-bucket",
+      "promotableCurrentFields": [
+        "identity",
+        "baseStatsByLevel",
+        "base_property",
+        "rand_property"
+      ],
+      "implementationNotes": [
+        "Weapon passive text/talents must be audited before typed modifier promotion.",
+        "Numeric base/substat promotion can proceed with source refs and unit normalization first."
+      ],
+      "recommendedPr": "PR-B wEngines batch"
+    },
+    {
+      "domain": "driveDiscs",
+      "index": "https://static.nanoka.cc/zzz/2.8/equipment.json",
+      "currentLiveIndexCount": 26,
+      "currentLiveDetailAccessibleCount": 26,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 25,
+      "missingRuntimeRecordCount": 26,
+      "targetRuntimeBucket": "GameData.driveDiscs",
+      "schemaFit": "existing-bucket-for-set-effects-only",
+      "promotableCurrentFields": [
+        "identity",
+        "desc2",
+        "desc4"
+      ],
+      "implementationNotes": [
+        "Set-effect text can be retained and audited for typed promotion.",
+        "Slot/main/substat tables remain excluded and must not appear in runtime until a separate product decision changes that scope."
+      ],
+      "recommendedPr": "PR-C drive disc set batch"
+    },
+    {
+      "domain": "enemies",
+      "index": "https://static.nanoka.cc/zzz/2.8/monster.json",
+      "currentLiveIndexCount": 269,
+      "currentLiveDetailAccessibleCount": 269,
+      "currentLiveMonsterInfoVariantCount": 573,
+      "retainedRawDetailCount": 7,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 262,
+      "missingRuntimeRecordCount": 269,
+      "targetRuntimeBucket": "GameData.enemies",
+      "schemaFit": "existing-bucket-with-variant-selection-risk",
+      "promotableCurrentFields": [
+        "identity",
+        "rank",
+        "variant mapping",
+        "selected monster_info stats",
+        "element/resistance profile"
+      ],
+      "implementationNotes": [
+        "Each monster detail can contain multiple monster_info variants; current batch should retain all current-live details and explicitly document selection rules.",
+        "Runtime import should start from the detail.monster_id selected variant, with audit rows for skipped variants."
+      ],
+      "recommendedPr": "PR-D enemies batch"
+    },
+    {
+      "domain": "deadlyAssaultCurrent",
+      "index": "https://static.nanoka.cc/zzz/2.8/boss.json",
+      "currentLiveIndexCount": 38,
+      "currentLiveDetailAccessibleCount": 38,
+      "currentLiveZoneCount": 114,
+      "retainedRawDetailCount": 1,
+      "runtimeRecordCount": 0,
+      "missingRawDetailCount": 37,
+      "targetRuntimeBucket": "GameData.deadlyAssaultPeriods or equivalent DA bucket",
+      "schemaFit": "schema-additive",
+      "promotableCurrentFields": [
+        "period identity",
+        "begin/end",
+        "zones",
+        "layer/selectable buffs",
+        "rooms",
+        "monsters",
+        "boss adjustments"
+      ],
+      "implementationNotes": [
+        "Current-live DA periods can be modeled separately from historical DA periods while preserving nanoka-only runtime source refs.",
+        "Any new runtime DA bucket is schema-additive and must be treated as a release-boundary change before npm publication."
+      ],
+      "recommendedPr": "PR-E DA current periods"
+    },
+    {
+      "domain": "bangboos",
+      "index": "https://static.nanoka.cc/zzz/2.8/bangboo.json",
+      "currentLiveIndexCount": 39,
+      "currentLiveDetailAccessibleCount": 39,
+      "retainedRawDetailCount": 39,
+      "runtimeRecordCount": 39,
+      "runtimeSkillCount": 63,
+      "missingRawDetailCount": 0,
+      "missingRuntimeRecordCount": 0,
+      "targetRuntimeBucket": "GameData.bangboos and GameData.bangbooSkills",
+      "schemaFit": "completed-in-V1.2.1",
+      "implementationNotes": [
+        "No further V1.2.x batch work required unless configuredLiveVersion changes."
+      ],
+      "recommendedPr": "done-in-PR-77"
+    }
+  ],
+  "historicalDeadlyAssault": {
+    "targetBucket": "historicalDAPeriods",
+    "policy": "historical periods must not be mixed into configured-live runtime records",
+    "schemaImpact": "schema-additive; release version to be decided after V1.2.x batch completion",
+    "snapshots": [
+      {
+        "snapshot": "2.8",
+        "bossIndexCount": 38,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "69038"
+      },
+      {
+        "snapshot": "2.8.12",
+        "bossIndexCount": 46,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690381"
+      },
+      {
+        "snapshot": "3.0.1+15348292",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15370273",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15377279",
+        "bossIndexCount": 53,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.1+15390262",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15596677",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15597809",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15599986",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15602810",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      },
+      {
+        "snapshot": "3.0.2+15625449",
+        "bossIndexCount": 50,
+        "firstPeriodId": "69001",
+        "lastPeriodId": "690421"
+      }
+    ]
+  },
+  "recommendedPrSequence": [
+    "PR-A: retain and batch-promote all current-live characters",
+    "PR-B: retain and batch-promote all current-live W-Engines",
+    "PR-C: retain and batch-promote current-live Drive Disc set identity/effect text; keep slot/main/substat excluded",
+    "PR-D: retain all current-live monster details and batch-promote selected enemy variants with skipped-variant audit",
+    "PR-E: add current DA period bucket if needed and retain/promote all 2.8 DA periods",
+    "PR-F: add historicalDAPeriods schema bucket and retain/promote historical DA periods across manifest.available snapshots"
+  ]
+}

--- a/packages/data/src/nanoka-full-data-batch-discovery.test.ts
+++ b/packages/data/src/nanoka-full-data-batch-discovery.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = join(import.meta.dirname, "../../..")
+
+type Discovery = {
+  kind: string
+  configuredLiveVersion: string
+  decisionContext: {
+    decisions: Record<string, string>
+    excludedOrDeferred: Array<{ field: string }>
+  }
+  domains: Array<{
+    domain: string
+    currentLiveIndexCount: number
+    currentLiveDetailAccessibleCount: number
+    retainedRawDetailCount: number
+    runtimeRecordCount: number
+    missingRawDetailCount: number
+    missingRuntimeRecordCount?: number
+    targetRuntimeBucket: string
+    schemaFit: string
+  }>
+  historicalDeadlyAssault: {
+    targetBucket: string
+    policy: string
+    snapshots: Array<{
+      snapshot: string
+      bossIndexCount: number
+    }>
+  }
+  recommendedPrSequence: string[]
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8")) as T
+}
+
+describe("nanoka full-data batch discovery", () => {
+  it("keeps the root and package discovery mirrors byte-identical", () => {
+    expect(readFileSync(join(repoRoot, "packages/data/cleaned/audit/nanoka-full-data-batch-discovery.json"), "utf8")).toBe(
+      readFileSync(join(repoRoot, "data/cleaned/audit/nanoka-full-data-batch-discovery.json"), "utf8"),
+    )
+  })
+
+  it("locks the lo-user/Product batch decisions before implementation PRs", () => {
+    const discovery = readJson<Discovery>("data/cleaned/audit/nanoka-full-data-batch-discovery.json")
+
+    expect(discovery.kind).toBe("nanokaFullDataBatchDiscovery")
+    expect(discovery.configuredLiveVersion).toBe("2.8")
+    expect(discovery.decisionContext.decisions).toMatchObject({
+      batchOrder: "sequential-per-domain",
+      enemyScope: "all-current-live-monster-index-records",
+      deadlyAssaultScope: "current-live-plus-historical-periods-in-a-dedicated-historicalDAPeriods-bucket",
+      versionBumpPolicy: "do-not-bump-until-batch-work-is-complete",
+      goldenAnchorPolicy: "do-not-add-new-golden-anchors",
+      sourceConsistencyPolicy: "nanoka-self-consistency",
+    })
+    expect(discovery.decisionContext.excludedOrDeferred.map(item => item.field)).toEqual(expect.arrayContaining([
+      "resonium",
+      "driveDiscs.slotAndSubstatTables",
+      "formula-owned anomaly/disorder/daze constants",
+    ]))
+  })
+
+  it("records current-live domain counts and batch gaps", () => {
+    const discovery = readJson<Discovery>("data/cleaned/audit/nanoka-full-data-batch-discovery.json")
+    const rows = new Map(discovery.domains.map(row => [row.domain, row]))
+
+    expect(rows.get("characters")).toMatchObject({
+      currentLiveIndexCount: 53,
+      currentLiveDetailAccessibleCount: 53,
+      retainedRawDetailCount: 4,
+      runtimeRecordCount: 1,
+      missingRawDetailCount: 49,
+      missingRuntimeRecordCount: 52,
+      targetRuntimeBucket: "GameData.agents",
+    })
+    expect(rows.get("wEngines")).toMatchObject({
+      currentLiveIndexCount: 89,
+      currentLiveDetailAccessibleCount: 89,
+      runtimeRecordCount: 0,
+      targetRuntimeBucket: "GameData.wEngines",
+    })
+    expect(rows.get("driveDiscs")).toMatchObject({
+      currentLiveIndexCount: 26,
+      currentLiveDetailAccessibleCount: 26,
+      schemaFit: "existing-bucket-for-set-effects-only",
+    })
+    expect(rows.get("enemies")).toMatchObject({
+      currentLiveIndexCount: 269,
+      currentLiveDetailAccessibleCount: 269,
+      missingRuntimeRecordCount: 269,
+      targetRuntimeBucket: "GameData.enemies",
+    })
+    expect(rows.get("deadlyAssaultCurrent")).toMatchObject({
+      currentLiveIndexCount: 38,
+      currentLiveDetailAccessibleCount: 38,
+      schemaFit: "schema-additive",
+    })
+    expect(rows.get("bangboos")).toMatchObject({
+      currentLiveIndexCount: 39,
+      retainedRawDetailCount: 39,
+      runtimeRecordCount: 39,
+      missingRawDetailCount: 0,
+    })
+  })
+
+  it("keeps historical Deadly Assault separated from configured-live runtime data", () => {
+    const discovery = readJson<Discovery>("data/cleaned/audit/nanoka-full-data-batch-discovery.json")
+
+    expect(discovery.historicalDeadlyAssault.targetBucket).toBe("historicalDAPeriods")
+    expect(discovery.historicalDeadlyAssault.policy).toContain("must not be mixed into configured-live runtime records")
+    expect(discovery.historicalDeadlyAssault.snapshots).toHaveLength(11)
+    expect(discovery.historicalDeadlyAssault.snapshots.map(snapshot => snapshot.snapshot)).toEqual([
+      "2.8",
+      "2.8.12",
+      "3.0.1+15348292",
+      "3.0.1+15370273",
+      "3.0.1+15377279",
+      "3.0.1+15390262",
+      "3.0.2+15596677",
+      "3.0.2+15597809",
+      "3.0.2+15599986",
+      "3.0.2+15602810",
+      "3.0.2+15625449",
+    ])
+    expect(discovery.historicalDeadlyAssault.snapshots.at(0)).toMatchObject({ snapshot: "2.8", bossIndexCount: 38 })
+    expect(discovery.historicalDeadlyAssault.snapshots.at(-1)).toMatchObject({ snapshot: "3.0.2+15625449", bossIndexCount: 50 })
+  })
+
+  it("locks an implementation PR sequence that does not add golden anchors or release versions", () => {
+    const discovery = readJson<Discovery>("data/cleaned/audit/nanoka-full-data-batch-discovery.json")
+
+    expect(discovery.recommendedPrSequence).toEqual([
+      "PR-A: retain and batch-promote all current-live characters",
+      "PR-B: retain and batch-promote all current-live W-Engines",
+      "PR-C: retain and batch-promote current-live Drive Disc set identity/effect text; keep slot/main/substat excluded",
+      "PR-D: retain all current-live monster details and batch-promote selected enemy variants with skipped-variant audit",
+      "PR-E: add current DA period bucket if needed and retain/promote all 2.8 DA periods",
+      "PR-F: add historicalDAPeriods schema bucket and retain/promote historical DA periods across manifest.available snapshots",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- add the V1.2.x full-data batch discovery artifact and package mirror
- document the locked scope for characters, W-Engines, Drive Disc sets, enemies, current DA periods, and historical DA periods
- add executable tests for the discovery counts, exclusions, historical DA boundary, and implementation PR sequence

## Scope Notes

- no runtime data changes in this PR
- no package version bump
- no new golden anchors
- historical DA is explicitly separated into a future `historicalDAPeriods` bucket so it does not weaken the configured-live runtime gate

## Verification

- `jq empty data/cleaned/audit/nanoka-full-data-batch-discovery.json packages/data/cleaned/audit/nanoka-full-data-batch-discovery.json`
- `pnpm --filter @randomplay/data test -- nanoka-full-data-batch-discovery.test.ts`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:nanoka`
- `pnpm --filter @randomplay/data verify:nanoka-runtime`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-000-foundation`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-001-g01-g26`
- `pnpm --filter @randomplay/data verify:source-migration -- --sync-id phase3-sync-002-g27-g28`
- `pnpm --filter @randomplay/data sync-cleaned -- --check`
- `pnpm --filter @randomplay/data pack --dry-run`
- `pnpm build`
- `git diff --cached --check`
