### PR TITLE
fix(data): keep runtime JSON out of dist bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       - run: pnpm --filter @randomplay/data verify:excel
       - run: pnpm --filter @randomplay/data verify:nanoka
       - run: pnpm --filter @randomplay/data verify:nanoka-runtime
+      - run: pnpm --filter @randomplay/data verify:package-size
       - run: pnpm --filter @randomplay/data verify:source-registry
       - run: pnpm --filter @randomplay/data verify:source-migration
       - run: pnpm --silent fairy:s1 | jq empty

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -44,6 +44,9 @@ Current state:
   package-local `packages/data/cleaned/` for npm packaging;
 - package exports include TypeScript source/types plus package-local cleaned
   JSON, and exclude raw source archives.
+- package-size release guard is enforced by
+  `pnpm --filter @randomplay/data verify:package-size`; the root export loads
+  the packaged runtime JSON at runtime instead of bundling it into `dist`.
 
 Do not add hand-written formal game data to this package. Formal rows must be
 derived from source documents and preserve source metadata.
@@ -77,5 +80,6 @@ Useful source checks:
 - `pnpm --filter @randomplay/data verify:nanoka`
 - `pnpm --filter @randomplay/data verify:nanoka-da-history`
 - `pnpm --filter @randomplay/data verify:nanoka-runtime`
+- `pnpm --filter @randomplay/data verify:package-size`
 - `pnpm --filter @randomplay/data verify:source-registry`
 - `pnpm --filter @randomplay/data verify:source-migration`

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -52,6 +52,7 @@
     "verify:nanoka": "node scripts/nanoka-source.mjs verify --snapshot 2.8",
     "verify:nanoka-da-history": "node scripts/nanoka-da-history.mjs verify",
     "verify:nanoka-runtime": "node ../../scripts/ensure-core-build.mjs && tsx scripts/nanoka-runtime-game-data.ts verify",
+    "verify:package-size": "node scripts/verify-package-size.mjs",
     "verify:source-migration": "node scripts/source-migration-drift.mjs verify",
     "verify:source-registry": "node scripts/verify-source-registry.mjs"
   },

--- a/packages/data/scripts/verify-package-size.mjs
+++ b/packages/data/scripts/verify-package-size.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const packageDir = fileURLToPath(new URL("..", import.meta.url))
+
+const thresholds = {
+  packedBytes: 3 * 1024 * 1024,
+  unpackedBytes: 45 * 1024 * 1024,
+  distIndexBytes: 256 * 1024,
+  distTotalBytes: 512 * 1024,
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024)
+    return `${bytes} B`
+  if (bytes < 1024 * 1024)
+    return `${(bytes / 1024).toFixed(1)} KiB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
+}
+
+function assertWithin(label, actual, limit) {
+  if (actual > limit)
+    throw new Error(`${label} is ${formatBytes(actual)}, above ${formatBytes(limit)}`)
+}
+
+function packMetadata() {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  const result = JSON.parse(output)
+  const metadata = result[0]
+  if (!metadata)
+    throw new Error("npm pack --dry-run returned no package metadata")
+  return metadata
+}
+
+const metadata = packMetadata()
+const files = metadata.files ?? []
+const distIndex = files.find(file => file.path === "dist/index.mjs")
+const distFiles = files.filter(file => file.path.startsWith("dist/"))
+const distTotalBytes = distFiles.reduce((sum, file) => sum + file.size, 0)
+
+if (!distIndex)
+  throw new Error("dist/index.mjs is missing from the package payload")
+
+assertWithin("packed package size", metadata.size, thresholds.packedBytes)
+assertWithin("unpacked package size", metadata.unpackedSize, thresholds.unpackedBytes)
+assertWithin("dist/index.mjs size", distIndex.size, thresholds.distIndexBytes)
+assertWithin("dist total size", distTotalBytes, thresholds.distTotalBytes)
+
+console.log([
+  "package size guard passed",
+  `packed=${formatBytes(metadata.size)} <= ${formatBytes(thresholds.packedBytes)}`,
+  `unpacked=${formatBytes(metadata.unpackedSize)} <= ${formatBytes(thresholds.unpackedBytes)}`,
+  `dist/index.mjs=${formatBytes(distIndex.size)} <= ${formatBytes(thresholds.distIndexBytes)}`,
+  `distTotal=${formatBytes(distTotalBytes)} <= ${formatBytes(thresholds.distTotalBytes)}`,
+].join("\n"))

--- a/packages/data/src/runtime.ts
+++ b/packages/data/src/runtime.ts
@@ -1,19 +1,28 @@
-import runtimeGameDataJson from "../cleaned/runtime/game-data.json" with { type: "json" }
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import {
   assertNanokaRuntimeGameDataArtifact,
   type NanokaRuntimeGameDataArtifact,
 } from "./runtime-policy"
 
-export const nanokaRuntimeGameDataArtifact = runtimeGameDataJson as unknown as NanokaRuntimeGameDataArtifact
+const runtimeGameDataPath = fileURLToPath(new URL("../cleaned/runtime/game-data.json", import.meta.url))
+
+let cachedNanokaRuntimeGameDataArtifact: NanokaRuntimeGameDataArtifact | undefined
+
+export function loadNanokaRuntimeGameDataArtifact() {
+  cachedNanokaRuntimeGameDataArtifact ??= JSON.parse(readFileSync(runtimeGameDataPath, "utf8")) as NanokaRuntimeGameDataArtifact
+  assertNanokaRuntimeGameDataArtifact(cachedNanokaRuntimeGameDataArtifact)
+  return cachedNanokaRuntimeGameDataArtifact
+}
+
+export const nanokaRuntimeGameDataArtifact = loadNanokaRuntimeGameDataArtifact()
 
 export function getNanokaRuntimeGameData() {
-  assertNanokaRuntimeGameDataArtifact(nanokaRuntimeGameDataArtifact)
-  return nanokaRuntimeGameDataArtifact.data
+  return loadNanokaRuntimeGameDataArtifact().data
 }
 
 export function getNanokaRuntimeSourcePolicy() {
-  assertNanokaRuntimeGameDataArtifact(nanokaRuntimeGameDataArtifact)
-  return nanokaRuntimeGameDataArtifact.runtimeSourcePolicy
+  return loadNanokaRuntimeGameDataArtifact().runtimeSourcePolicy
 }
 
 export {


### PR DESCRIPTION
## Summary
- stop bundling `cleaned/runtime/game-data.json` into `@randomplay/data` `dist/index.mjs`; the root runtime API now reads the packaged JSON artifact from disk and caches it
- add `verify:package-size` to guard packed size, unpacked size, `dist/index.mjs`, and total `dist` bytes
- wire the package-size guard into release CI before publish
- document the size guard in `packages/data/README.md`

## Size results
- `dist/index.mjs`: ~30 MB -> 52.4 KB
- `dist/` total: ~31.7 MB -> 130.83 KB
- npm dry-run packed size: 2.14 MiB
- npm dry-run unpacked size: 40.86 MiB (down from QA-observed ~74.5 MB)
- package still includes `cleaned/runtime/game-data.json`; direct JSON consumers remain supported

## Verification
- `pnpm --filter @randomplay/data check`
- `pnpm --filter @randomplay/data test` (145/145)
- `pnpm --filter @randomplay/data build`
- `pnpm --filter @randomplay/data verify:nanoka-runtime`
- `pnpm --filter @randomplay/data verify:package-size`
- `pnpm --filter @randomplay/data verify:source-registry`
- `pnpm --filter @randomplay/data verify:golden-v1`
- `pnpm --filter @randomplay/data sync-cleaned -- --check`
- `pnpm check`
- `pnpm build`
- `pnpm test` (225 total: core 53, data 145, cli 27)
- npm pack dry-run payload check: keeps runtime JSON + dist, excludes raw source / `.xlsx` / tests / scripts
- direct import smoke from built `dist/index.mjs` and direct JSON import both return 505 historical DA periods
- `git diff --check`