### PR TITLE
test: relax verifier-heavy Vitest timeouts

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -31,5 +31,11 @@ Repo-specific notes:
   workflow red, but the publish and GitHub Release may already be complete; use
   the QA release-readiness checklist to distinguish npm propagation lag from a
   real package/install/runtime defect.
+- Test timeouts intentionally distinguish unit tests from verifier-heavy suites.
+  `@randomplay/core` stays on Vitest's short default timeout. `@randomplay/data`
+  and `@randomplay/cli` set a 30s Vitest timeout because their tests shell out to
+  `pnpm`, `npm pack`, `tsx`, or the CLI and can vary on cold GitHub runners. This
+  is only an interruption buffer; source gates, schema checks, package-size
+  limits, and runtime assertions remain strict.
 - The `npm-publish` environment, Trusted Publisher bindings, and `v*.*.*`
   tag-protection ruleset are repository settings, not source files.

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    hookTimeout: 30_000,
+    teardownTimeout: 30_000,
+    testTimeout: 30_000,
+  },
+})

--- a/packages/data/src/golden-v1.test.ts
+++ b/packages/data/src/golden-v1.test.ts
@@ -27,7 +27,7 @@ describe("V1 golden true-data replay baseline", () => {
         stdio: ["ignore", "pipe", "pipe"],
       },
     )
-  }, 20_000)
+  })
 
   it("tracks the 28-anchor executable gate with no deferred anchors", () => {
     const report = readJson<{

--- a/packages/data/src/nanoka-runtime.test.ts
+++ b/packages/data/src/nanoka-runtime.test.ts
@@ -26,7 +26,7 @@ describe("nanoka runtime game data cutover", () => {
       cwd: join(repoRoot, "packages/data"),
       stdio: ["ignore", "pipe", "pipe"],
     })
-  }, 15000)
+  })
 
   it("exports a nanoka-only runtime GameData artifact", () => {
     assertNanokaRuntimeGameDataArtifact(nanokaRuntimeGameDataArtifact)

--- a/packages/data/vitest.config.ts
+++ b/packages/data/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    hookTimeout: 30_000,
+    teardownTimeout: 30_000,
+    testTimeout: 30_000,
+  },
+})


### PR DESCRIPTION
## Summary
- add 30s Vitest timeout configs for `@randomplay/data` and `@randomplay/cli`, the two suites that shell out to `pnpm` / `npm pack` / `tsx` / CLI commands
- keep `@randomplay/core` on Vitest's default short timeout for pure unit coverage
- remove now-redundant per-test verifier timeouts and document the release timeout policy

## Audit notes
- `release.yml` has no short `timeout-minutes` setting causing the V0.1.1 interruption; the release failure came from Vitest's default 5s per-test timeout.
- child-process verifier calls do not set shorter subprocess timeouts; the interruption boundary was the test runner timeout.
- registry smoke remains at the existing 20x60s retry budget from task #99.

## Verification
- `pnpm --filter @randomplay/data test`
- `pnpm --filter @randomplay/cli test`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @randomplay/data verify:package-size`
- `git diff --check`
