### PR TITLE
feat(ai-plugin): scaffold V1.2.2 plugin skeleton

### DIFF
--- a/.claude-plugin/plugins/fairy/plugin.json
+++ b/.claude-plugin/plugins/fairy/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "fairy",
+  "version": "1.2.2",
+  "displayName": {
+    "en": "fairy — ZZZ damage calculator",
+    "zh": "fairy — 绝区零伤害计算器"
+  },
+  "description": "AI-driven assistant for Zenless Zone Zero damage calculation. Build reviewable BattleSnapshot drafts from natural language, run the trusted fairy CLI, and explain trusted CalcResult JSON.",
+  "author": "LoTwT",
+  "license": "MIT",
+  "homepage": "https://github.com/LoTwT/fairy",
+  "minFairyCliVersion": "0.1.2",
+  "supportedTools": [
+    "claude-code",
+    "codex"
+  ],
+  "skills": [
+    "fairy-snapshot",
+    "fairy-calc",
+    "fairy-explain"
+  ],
+  "docs": {
+    "architecture": "docs/ai-plugin/architecture.md",
+    "userJourneys": "docs/ai-plugin/user-journeys.md",
+    "promptTemplates": "docs/ai-plugin/prompt-templates.md",
+    "acceptance": "docs/ai-plugin/acceptance.md",
+    "decision": "docs/product/decisions/D-21-ai-plugin.md"
+  }
+}

--- a/.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: fairy-calc
+description: Use when the user has a fairy BattleSnapshot or a confirmed fairy-snapshot draft and needs trusted calculation through the fairy CLI. Always call fairy calc for validation/calculation, parse the CLI JSON, and summarize only actual fields from the returned CalcResult.
+displayName:
+  en: Calculate damage
+  zh: 计算伤害
+---
+
+# fairy-calc
+
+## Purpose
+
+Run a trusted fairy CLI calculation for a confirmed `BattleSnapshot` and produce
+a brief user-facing summary from the returned `CalcResult`.
+
+## Trigger Phrases
+
+- calc damage
+- calculate damage
+- compute damage
+- run fairy
+- 算伤害
+- 跑一下
+- 看结果
+
+## Inputs
+
+- `snapshot`: schema-valid `BattleSnapshot` JSON or a path to one.
+- `view`: optional CLI view, default `verbose` for plugin validation.
+- `lang`: optional session language, `zh` or `en`.
+
+## Outputs
+
+- `calcResult`: the unmodified CLI JSON.
+- `briefSummary`: one or two paragraphs based only on `calcResult`.
+- `errors`: user-facing fail-loud copy when CLI invocation fails.
+
+## Workflow
+
+1. Check that `fairy` / `@randomplay/cli` is installed and satisfies
+   `minFairyCliVersion`.
+2. Invoke:
+
+   ```bash
+   fairy calc <snapshot> --view verbose --lang <zh|en>
+   ```
+
+3. Treat the CLI JSON as the only numeric calculation baseline.
+4. Preserve warnings and source/runtime context in the user-facing summary.
+5. On failure, stop and surface actionable error copy. Do not continue with a
+   model-generated estimate.
+
+## Boundaries
+
+- Do not implement formula logic in the AI layer.
+- Do not modify `CalcResult` fields.
+- Do not fabricate totals, multipliers, trace steps, or source refs.
+- Do not depend on nonexistent preflight/dry-run flags or deferred compare
+  commands.
+- Do not read raw source archives or retired source snapshots.
+
+## Failure Policy
+
+- Missing or too-old CLI: fail loud with an install/upgrade instruction.
+- CLI schema error: translate stderr into a user-facing correction prompt.
+- CLI runtime error: stop and preserve the error context; do not summarize.
+
+## References
+
+- `docs/ai-plugin/architecture.md`
+- `docs/ai-plugin/user-journeys.md`
+- `docs/ai-plugin/prompt-templates.md`
+- `docs/ai-plugin/acceptance.md`
+- `docs/product/decisions/D-21-ai-plugin.md`

--- a/.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: fairy-explain
+description: Use when the user provides an existing fairy CalcResult JSON and needs a natural-language explanation of actual summary, trace, warnings, modifiers, and sourceRef fields. Never rerun calculation or invent fields absent from the input JSON.
+displayName:
+  en: Explain result
+  zh: 解释结果
+---
+
+# fairy-explain
+
+## Purpose
+
+Explain an existing fairy `CalcResult` JSON without rerunning calculation.
+
+## Trigger Phrases
+
+- explain
+- explain trace
+- explain this result
+- trace breakdown
+- 解释结果
+- 解释 trace
+- 解读
+- 分析
+- 为什么是这个数
+
+## Inputs
+
+- `calcResult`: existing fairy `CalcResult` JSON or a path to one.
+- `focus`: optional focus area: `trace`, `summary`, `warnings`, or `full`.
+- `lang`: optional session language, `zh` or `en`.
+
+## Outputs
+
+- `explanation`: natural-language walkthrough in the session language.
+- `grounding`: references to actual `CalcResult` fields used by the
+  explanation.
+
+## Workflow
+
+1. Parse the provided `CalcResult`.
+2. Identify available summary lanes, warnings, trace entries, modifiers, and
+   source refs.
+3. Explain only fields present in the input JSON.
+4. State when trace detail is unavailable instead of reconstructing it.
+5. Include data source / disclaimer copy where relevant.
+
+## Boundaries
+
+- Do not call `fairy calc`; if the user wants a new calculation, switch to
+  `fairy-calc`.
+- Do not infer multipliers, totals, source refs, or trace steps from natural
+  language.
+- Do not explain fields absent from the input `CalcResult`.
+- Do not read raw source archives or retired source snapshots.
+
+## Failure Policy
+
+- Malformed JSON: ask the user to paste complete `fairy calc --view verbose`
+  output.
+- Missing trace: explain summary/warnings and state that trace detail is absent.
+- Unknown sourceRef label: show the sourceRef and avoid inventing a friendly
+  name.
+
+## References
+
+- `docs/ai-plugin/architecture.md`
+- `docs/ai-plugin/user-journeys.md`
+- `docs/ai-plugin/prompt-templates.md`
+- `docs/ai-plugin/acceptance.md`
+- `docs/product/decisions/D-21-ai-plugin.md`

--- a/.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fairy-snapshot
+description: Use when the user describes a Zenless Zone Zero build in natural language or provides a partial BattleSnapshot and needs a reviewable fairy BattleSnapshot draft. Ask for missing critical fields, keep default and unknown notes in draft metadata, and hand off to fairy-calc only after user review/confirm.
+displayName:
+  en: Build snapshot
+  zh: 生成快照
+---
+
+# fairy-snapshot
+
+## Purpose
+
+Turn a user build description into a reviewable `BattleSnapshot` draft for
+fairy. This skill structures input; it does not calculate damage.
+
+## Trigger Phrases
+
+- build snapshot
+- build a snapshot
+- make snapshot
+- compose snapshot
+- 组配装
+- 生成快照
+- 我想算
+- 帮我算
+- 怎么算
+
+## Inputs
+
+- `userBuildDescription`: natural language in zh, en, or mixed language.
+- `partialSnapshot`: optional `BattleSnapshot` draft, including future
+  V1.2.3 vision/OCR output.
+- `lang`: optional session language override, `zh` or `en`.
+
+## Outputs
+
+- `snapshot`: reviewable `BattleSnapshot` draft.
+- `draftMetadata.defaultedFields`: optional defaults or omissions surfaced to
+  the user; never written as ad hoc `BattleSnapshot` fields.
+- `draftMetadata.unknownFields`: unknown fields surfaced to the user; never
+  written as ad hoc `BattleSnapshot` fields.
+- `questions`: missing critical fields grouped for the ask-user dialog.
+
+## Workflow
+
+1. Detect dialog language using the session rule from
+   `docs/ai-plugin/user-journeys.md`.
+2. Normalize user-facing entity aliases through packaged cleaned data and
+   public aliases. Do not read raw source archives.
+3. Classify missing fields with the 3-tier policy:
+   critical, optional, unknown.
+4. Ask for critical fields before handoff.
+5. Present the draft snapshot and draft metadata for user review/confirm.
+6. Hand off confirmed snapshots to `fairy-calc` for CLI validation and
+   calculation.
+
+## Boundaries
+
+- Do not compute damage, daze, anomaly, disorder, or multipliers.
+- Do not call `fairy calc` directly from this skill.
+- Do not invent critical values such as agent level, W-Engine, Drive Disc set,
+  enemy, or attack segment.
+- Do not add fields or string markers that violate the strict
+  `BattleSnapshot` schema.
+- Do not read raw source archives or retired source snapshots.
+
+## Failure Policy
+
+- If a critical field is missing, ask the user and do not hand off to
+  `fairy-calc`.
+- If an entity is ambiguous, present candidates with stable IDs and ask the
+  user to choose.
+- If no schema-valid reduced path exists, fail loud and explain what field is
+  needed.
+
+## References
+
+- `docs/ai-plugin/architecture.md`
+- `docs/ai-plugin/user-journeys.md`
+- `docs/ai-plugin/prompt-templates.md`
+- `docs/ai-plugin/acceptance.md`
+- `docs/product/decisions/D-21-ai-plugin.md`

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,38 @@
+# fairy AI plugin · Codex usage notes
+
+V1.2.2 supports Codex as a compatibility surface, not a second full plugin
+runtime. Codex agents should use the same canonical skill contracts defined
+under `.claude-plugin/plugins/fairy/`.
+
+## Skill Contracts
+
+- `.claude-plugin/plugins/fairy/plugin.json`
+- `.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md`
+- `.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md`
+- `.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md`
+
+## Usage Rules
+
+1. Use `fairy-snapshot` when a user describes a ZZZ build and needs a
+   reviewable `BattleSnapshot` draft.
+2. Use `fairy-calc` after user review/confirm or when the user already provides
+   a `BattleSnapshot`.
+3. Use `fairy-explain` only for existing `CalcResult` JSON.
+4. Never calculate damage in model reasoning. Run `fairy calc` through the CLI.
+5. Do not use Cursor-specific configuration in V1.2.2.
+
+## Local Verification
+
+Run the metadata verifier before opening implementation PRs:
+
+```bash
+pnpm verify:ai-plugin
+```
+
+The implementation and acceptance details live in:
+
+- `docs/ai-plugin/architecture.md`
+- `docs/ai-plugin/user-journeys.md`
+- `docs/ai-plugin/prompt-templates.md`
+- `docs/ai-plugin/acceptance.md`
+- `docs/product/decisions/D-21-ai-plugin.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Fairy 是绝区零 1-3 代理人静态快照伤害计算器。V1 目标是 `@ran
 - 数据契约：[data-contract/](data-contract/)
 - 架构与工程：[architecture/](architecture/)
 - 数据来源：[data-source/](data-source/)
+- AI plugin V1.2.2 plan：[ai-plugin/architecture.md](ai-plugin/architecture.md)
 - 发布流程：[release/README.md](release/README.md)
 - QA 策略：[qa/](qa/)
 - UX 文案与场景：[ux/](ux/)

--- a/examples/ai-plugin/README.md
+++ b/examples/ai-plugin/README.md
@@ -1,0 +1,14 @@
+# fairy AI plugin examples
+
+This directory is the single source of example prompts and fixtures for the
+V1.2.2 AI plugin implementation.
+
+Planned ownership:
+
+- `prompts/`: UX-owned prompt scenarios and few-shot examples.
+- `snapshots/`: UX-owned `BattleSnapshot` fixture outputs.
+- `expected/`: UX-owned expected structures consumed by QA smoke tests.
+
+QA consumes these files for G3/G4/G5 fixture assertions. Keep examples aligned
+with `docs/ai-plugin/prompt-templates.md` and
+`docs/ai-plugin/acceptance.md`.

--- a/examples/ai-plugin/expected/.gitkeep
+++ b/examples/ai-plugin/expected/.gitkeep
@@ -1,0 +1,1 @@
+# Filled by UX task #208.

--- a/examples/ai-plugin/prompts/.gitkeep
+++ b/examples/ai-plugin/prompts/.gitkeep
@@ -1,0 +1,1 @@
+# Filled by UX task #208.

--- a/examples/ai-plugin/snapshots/.gitkeep
+++ b/examples/ai-plugin/snapshots/.gitkeep
@@ -1,0 +1,1 @@
+# Filled by UX task #208.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r --if-present build",
-    "check": "node scripts/ensure-core-build.mjs && pnpm -r --if-present check",
+    "check": "node scripts/ensure-core-build.mjs && pnpm verify:ai-plugin && pnpm -r --if-present check",
     "fairy": "node packages/cli/bin/fairy.js",
     "fairy:s1": "node packages/cli/bin/fairy.js calc examples/snapshots/s1-yixuan-sheer.json --lang zh --pretty",
     "fairy:s2": "node packages/cli/bin/fairy.js calc examples/snapshots/s2-yanagi-disorder.json --lang zh --pretty",
@@ -15,7 +15,8 @@
     "changelog": "node scripts/update-changelog.mjs",
     "prepare": "simple-git-hooks",
     "release:bump": "bumpp",
-    "test": "node scripts/ensure-core-build.mjs && pnpm -r --if-present test"
+    "test": "node scripts/ensure-core-build.mjs && pnpm -r --if-present test",
+    "verify:ai-plugin": "node scripts/verify-ai-plugin.mjs"
   },
   "simple-git-hooks": {
     "commit-msg": "pnpm exec commitlint --edit \"$1\""

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -1,0 +1,151 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)))
+
+const pluginRoot = path.join(repoRoot, ".claude-plugin/plugins/fairy")
+const pluginJsonPath = path.join(pluginRoot, "plugin.json")
+const skillNames = ["fairy-snapshot", "fairy-calc", "fairy-explain"]
+const requiredDocs = [
+  "docs/ai-plugin/architecture.md",
+  "docs/ai-plugin/user-journeys.md",
+  "docs/ai-plugin/prompt-templates.md",
+  "docs/ai-plugin/acceptance.md",
+  "docs/product/decisions/D-21-ai-plugin.md",
+]
+const exampleDirs = [
+  "examples/ai-plugin/prompts",
+  "examples/ai-plugin/snapshots",
+  "examples/ai-plugin/expected",
+]
+
+const errors = []
+
+function assert(condition, message) {
+  if (!condition)
+    errors.push(message)
+}
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"))
+  }
+  catch (error) {
+    errors.push(`${path.relative(repoRoot, filePath)} is not valid JSON: ${error.message}`)
+    return {}
+  }
+}
+
+function listFilesRecursive(dir) {
+  if (!existsSync(dir))
+    return []
+
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory())
+      return listFilesRecursive(fullPath)
+    return [fullPath]
+  })
+}
+
+function includesAll(text, relativePath, snippets) {
+  for (const snippet of snippets)
+    assert(text.includes(snippet), `${relativePath} missing required text: ${snippet}`)
+}
+
+assert(existsSync(pluginJsonPath), ".claude-plugin/plugins/fairy/plugin.json is missing")
+const plugin = readJson(pluginJsonPath)
+
+assert(plugin.name === "fairy", "plugin.json name must be fairy")
+assert(typeof plugin.version === "string" && plugin.version.length > 0, "plugin.json version is required")
+assert(plugin.minFairyCliVersion === "0.1.2", "plugin.json minFairyCliVersion must be 0.1.2")
+assert(plugin.displayName?.en && plugin.displayName?.zh, "plugin.json displayName.en and displayName.zh are required")
+assert(Array.isArray(plugin.supportedTools), "plugin.json supportedTools must be an array")
+assert(plugin.supportedTools?.includes("claude-code"), "plugin.json supportedTools must include claude-code")
+assert(plugin.supportedTools?.includes("codex"), "plugin.json supportedTools must include codex")
+assert(!plugin.supportedTools?.includes("cursor"), "plugin.json must not include cursor for V1.2.2")
+assert(JSON.stringify(plugin.skills) === JSON.stringify(skillNames), "plugin.json skills must match canonical skill names")
+
+for (const doc of requiredDocs)
+  assert(existsSync(path.join(repoRoot, doc)), `required doc is missing: ${doc}`)
+
+for (const [key, doc] of Object.entries(plugin.docs ?? {}))
+  assert(existsSync(path.join(repoRoot, doc)), `plugin.json docs.${key} points to a missing file: ${doc}`)
+
+for (const dir of exampleDirs)
+  assert(existsSync(path.join(repoRoot, dir)), `example directory is missing: ${dir}`)
+
+assert(existsSync(path.join(repoRoot, ".codex/README.md")), ".codex/README.md is missing")
+
+for (const skillName of skillNames) {
+  const skillRelativePath = `.claude-plugin/plugins/fairy/skills/${skillName}/SKILL.md`
+  const skillPath = path.join(repoRoot, skillRelativePath)
+  assert(existsSync(skillPath), `${skillRelativePath} is missing`)
+  if (!existsSync(skillPath))
+    continue
+
+  const text = readText(skillRelativePath)
+  includesAll(text, skillRelativePath, [
+    "---",
+    `name: ${skillName}`,
+    "description:",
+    "displayName:",
+    "## Purpose",
+    "## Trigger Phrases",
+    "## Inputs",
+    "## Outputs",
+    "## Workflow",
+    "## Boundaries",
+    "## Failure Policy",
+    "## References",
+  ])
+
+  for (const doc of requiredDocs)
+    assert(text.includes(doc), `${skillRelativePath} must link ${doc}`)
+}
+
+const snapshotSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md")
+assert(!snapshotSkill.includes("fairy calc <snapshot>"), "fairy-snapshot must not call fairy calc directly")
+assert(snapshotSkill.includes("review/confirm"), "fairy-snapshot must document review/confirm handoff")
+
+const calcSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md")
+assert(
+  calcSkill.includes("fairy calc <snapshot> --view verbose --lang <zh|en>"),
+  "fairy-calc must document the canonical CLI command",
+)
+
+const explainSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md")
+assert(explainSkill.includes("Do not call `fairy calc`"), "fairy-explain must forbid calculation")
+assert(explainSkill.includes("explain trace"), "fairy-explain must keep trace as an alias")
+
+const forbiddenPatterns = [
+  { pattern: /--preflight/g, reason: "must not depend on nonexistent --preflight" },
+  { pattern: /--dry-run/g, reason: "must not depend on nonexistent --dry-run" },
+  { pattern: /fairy-compare/g, reason: "compare skill is deferred" },
+  { pattern: /fairy compare/g, reason: "fairy compare command is deferred" },
+  { pattern: /\.cursor/g, reason: "Cursor is deferred from V1.2.2" },
+  { pattern: /packages\/data\/source/g, reason: "plugin must not read raw source" },
+]
+
+for (const file of listFilesRecursive(pluginRoot).concat([path.join(repoRoot, ".codex/README.md")])) {
+  const relativePath = path.relative(repoRoot, file)
+  const text = readFileSync(file, "utf8")
+  for (const { pattern, reason } of forbiddenPatterns) {
+    const matches = text.match(pattern)
+    assert(!matches, `${relativePath}: ${reason}`)
+  }
+}
+
+if (errors.length > 0) {
+  console.error("AI plugin verification failed:")
+  for (const error of errors)
+    console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("AI plugin verification passed.")

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -7,13 +7,14 @@ const repoRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)))
 const pluginRoot = path.join(repoRoot, ".claude-plugin/plugins/fairy")
 const pluginJsonPath = path.join(pluginRoot, "plugin.json")
 const skillNames = ["fairy-snapshot", "fairy-calc", "fairy-explain"]
-const requiredDocs = [
-  "docs/ai-plugin/architecture.md",
-  "docs/ai-plugin/user-journeys.md",
-  "docs/ai-plugin/prompt-templates.md",
-  "docs/ai-plugin/acceptance.md",
-  "docs/product/decisions/D-21-ai-plugin.md",
-]
+const requiredDocsByKey = {
+  architecture: "docs/ai-plugin/architecture.md",
+  userJourneys: "docs/ai-plugin/user-journeys.md",
+  promptTemplates: "docs/ai-plugin/prompt-templates.md",
+  acceptance: "docs/ai-plugin/acceptance.md",
+  decision: "docs/product/decisions/D-21-ai-plugin.md",
+}
+const requiredDocs = Object.values(requiredDocsByKey)
 const exampleDirs = [
   "examples/ai-plugin/prompts",
   "examples/ai-plugin/snapshots",
@@ -74,6 +75,10 @@ assert(JSON.stringify(plugin.skills) === JSON.stringify(skillNames), "plugin.jso
 for (const doc of requiredDocs)
   assert(existsSync(path.join(repoRoot, doc)), `required doc is missing: ${doc}`)
 
+assert(plugin.docs && typeof plugin.docs === "object" && !Array.isArray(plugin.docs), "plugin.json docs object is required")
+for (const [key, doc] of Object.entries(requiredDocsByKey))
+  assert(plugin.docs?.[key] === doc, `plugin.json docs.${key} must be ${doc}`)
+
 for (const [key, doc] of Object.entries(plugin.docs ?? {}))
   assert(existsSync(path.join(repoRoot, doc)), `plugin.json docs.${key} points to a missing file: ${doc}`)
 
@@ -81,6 +86,20 @@ for (const dir of exampleDirs)
   assert(existsSync(path.join(repoRoot, dir)), `example directory is missing: ${dir}`)
 
 assert(existsSync(path.join(repoRoot, ".codex/README.md")), ".codex/README.md is missing")
+
+const skillsRoot = path.join(pluginRoot, "skills")
+assert(existsSync(skillsRoot), ".claude-plugin/plugins/fairy/skills is missing")
+if (existsSync(skillsRoot)) {
+  const actualSkillDirs = readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort()
+  const expectedSkillDirs = [...skillNames].sort()
+  assert(
+    JSON.stringify(actualSkillDirs) === JSON.stringify(expectedSkillDirs),
+    `skills directory set must be exactly ${expectedSkillDirs.join(", ")}; got ${actualSkillDirs.join(", ")}`,
+  )
+}
 
 for (const skillName of skillNames) {
   const skillRelativePath = `.claude-plugin/plugins/fairy/skills/${skillName}/SKILL.md`


### PR DESCRIPTION
## Summary

- adds the V1.2.2 repo-internal Claude Code plugin skeleton under `.claude-plugin/plugins/fairy/`
- adds canonical `plugin.json` and three skill contracts: `fairy-snapshot`, `fairy-calc`, `fairy-explain`
- adds Codex compatibility notes under `.codex/README.md`
- adds the `examples/ai-plugin/` fixture directory skeleton for UX/QA follow-up tasks
- adds `scripts/verify-ai-plugin.mjs` and `pnpm verify:ai-plugin`; root `pnpm check` now runs the verifier
- links AI plugin architecture from `docs/index.md`

## Verification

- `pnpm verify:ai-plugin`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `git diff --check`

## Follow-up

- task #208 fills `examples/ai-plugin/` prompts/snapshots/expected and user-facing copy
- task #209 extends the verifier/harness for G1-G10 assertions
- task #210 performs final integration and release-prep handoff
