### PR TITLE
feat(ai-plugin): add V1.2.2 example fixtures

### DIFF
--- a/docs/ai-plugin/prompt-templates.md
+++ b/docs/ai-plugin/prompt-templates.md
@@ -582,9 +582,9 @@ Few-shot prompt fixtures are EN-canonical (per QA `39ce78c9` G4 strategy): same 
 
 - `examples/ai-plugin/prompts/build-yixuan-basic.md` — minimal NL build description → snapshot
 - `examples/ai-plugin/prompts/build-yixuan-full.md` — full NL build with all critical fields filled
-- `examples/ai-plugin/prompts/build-yixuan-ambiguous.md` — NL with ambiguous entity → disambiguation flow
-- `examples/ai-plugin/snapshots/yixuan-basic.json` — expected snapshot output
-- `examples/ai-plugin/expected/yixuan-basic-calc.json` — expected CalcResult shape (for explain skill fixture input)
+- `examples/ai-plugin/prompts/build-anby-ambiguous.md` — NL with ambiguous entity → disambiguation flow
+- `examples/ai-plugin/snapshots/yixuan-basic.snapshot.json` — expected snapshot output
+- `examples/ai-plugin/expected/yixuan-basic.calc.json` — expected CalcResult shape (for explain skill fixture input)
 
 QA fixture coverage matrix (per `acceptance.md`):
 - Skill spec discovery (G1/G2/G7/G9): EN canonical only.

--- a/docs/ai-plugin/prompt-templates.md
+++ b/docs/ai-plugin/prompt-templates.md
@@ -497,8 +497,8 @@ Per `acceptance.md` G1-G3 fixture strategy and `user-journeys.md` §2 entity rec
 | 仪玄 | `character.id=1371` | "我想算仪玄..." |
 | 妮可 | `character.id=1031` (Nicole Demara) | "妮可的伤害..." |
 | 啄木鸟电音 | `equipment.setId=31000` | "啄木鸟电音 4 套..." |
-| 钢铁躯壳 | `equipment.setId=32004` | "...加钢铁躯壳 2 件套" |
-| 企鹅布 | `bangboo.id=54001` | "...邦布带企鹅布" |
+| 激素朋克 | `equipment.setId=31400` | "...加激素朋克 2 件套" |
+| 企鹅布 | `bangboo.id=53001` | "...邦布带企鹅布" |
 | 危局强袭战 | DA scope marker | "危局强袭战本期 boss" |
 
 ### 8.2 en → canonical (sample, 2-3 each domain)
@@ -508,9 +508,9 @@ Per `acceptance.md` G1-G3 fixture strategy and `user-journeys.md` §2 entity rec
 | Yixuan | `character.id=1371` | "I want to calc Yixuan..." |
 | Nicole | `character.id=1031` | "Nicole's damage..." |
 | Woodpecker Electro | `equipment.setId=31000` | "Woodpecker Electro 4pc" |
-| Hormone Punk | `equipment.setId=32004` (Steel Cushion alias check needed) | "...with Hormone Punk 2pc" |
-| Penguinboo | `bangboo.id=54001` | "...with Penguinboo" |
-| Deadly Assault | DA scope marker | "current DA boss" |
+| Hormone Punk | `equipment.setId=31400` | "...with Hormone Punk 2pc" |
+| Penguinboo | `bangboo.id=53001` | "...with Penguinboo" |
+| Deadly Assault | DA scope marker | "Greta" |
 
 ### 8.3 Ambiguity disambiguation fixtures
 
@@ -518,7 +518,7 @@ Per `acceptance.md` G1-G3 fixture strategy and `user-journeys.md` §2 entity rec
 |---|---|
 | "Anby" | (1) Anby Demara `character.id=1011` |
 | "S11" | (1) Soldier 11 `character.id=1041` |
-| "Burnice" / "Burnis" / "本子" | (1) Burnice `character.id=1051` |
+| "Burnice" / "Burnis" / "本子" | (1) Burnice `character.id=1171` |
 | "Drive 4" | clarify: "你是说位置 4 的 Drive Disc 还是 4 件套？" |
 
 ### 8.4 Cross-lang ambiguity (entity name lang ≠ dialog lang)

--- a/examples/ai-plugin/README.md
+++ b/examples/ai-plugin/README.md
@@ -1,14 +1,87 @@
-# fairy AI plugin examples
+# fairy AI plugin · Examples & fixtures
 
-This directory is the single source of example prompts and fixtures for the
-V1.2.2 AI plugin implementation.
+Concrete examples for the V1.2.2 AI plugin: golden NL prompts, expected snapshots, expected CalcResult JSON, expected explain outputs, and entity normalization mappings.
 
-Planned ownership:
+These files are dual-purpose:
+- **Reference**: agent / human readers see the contract by example.
+- **Fixture**: QA G4 / G5 (per `docs/ai-plugin/acceptance.md`) consume the prompts, snapshots, and expected outputs as smoke-test golden inputs.
 
-- `prompts/`: UX-owned prompt scenarios and few-shot examples.
-- `snapshots/`: UX-owned `BattleSnapshot` fixture outputs.
-- `expected/`: UX-owned expected structures consumed by QA smoke tests.
+## Structure
 
-QA consumes these files for G3/G4/G5 fixture assertions. Keep examples aligned
-with `docs/ai-plugin/prompt-templates.md` and
-`docs/ai-plugin/acceptance.md`.
+```
+examples/ai-plugin/
+  README.md                      # this file
+  entity-normalization.md        # zh ↔ en ↔ canonical id mapping fixtures
+  prompts/                       # golden NL prompts (one scenario per file)
+    build-yixuan-basic.md        # fairy-snapshot: minimal happy path (zh + en mirror)
+    build-yixuan-full.md         # fairy-snapshot: all critical filled (zh)
+    build-anby-ambiguous.md      # fairy-snapshot: entity ambiguity → disambiguation
+    build-yixuan-unknown.md      # fairy-snapshot: critical-field unknown handling
+    calc-yixuan.md               # fairy-calc: invoke CLI on validated snapshot
+    explain-yixuan-trace.md      # fairy-explain: walk a CalcResult standalone
+  snapshots/                     # golden BattleSnapshot JSON (post fairy-snapshot output)
+    yixuan-basic.snapshot.json
+    yixuan-full.snapshot.json
+  expected/                      # golden expected outputs from downstream skills
+    yixuan-basic.draft-metadata.json
+    yixuan-basic.calc.json       # fairy-calc CLI output for yixuan-basic snapshot
+    yixuan-basic.explain.zh.md   # fairy-explain output (Chinese)
+    yixuan-basic.explain.en.md   # fairy-explain output (English)
+```
+
+## How to read each prompt file
+
+Every `prompts/*.md` follows the same shape:
+
+```
+# <fixture name>
+
+**Skill**: fairy-snapshot | fairy-calc | fairy-explain
+**Scenario**: <one-line scenario summary>
+**Lang**: zh | en | mirror
+
+## User input
+<NL prompt or JSON paste>
+
+## Expected AI behavior
+1. <ordered steps the AI must follow>
+2. <ask-user dialog turns, with expected user reply>
+
+## Expected output
+<inline output, or pointer to snapshots/ / expected/ file>
+```
+
+## How to add a new example
+
+1. Pick a unique fixture name in kebab-case (e.g., `build-burnice-full.md`).
+2. Drop the prompt under `prompts/`.
+3. If the scenario produces a snapshot or CalcResult, drop the JSON under `snapshots/` or `expected/`.
+4. Update `entity-normalization.md` if you introduce new agents / W-Engines / Drive Disc sets.
+5. QA G4 / G5 fixture loader picks up the new file automatically (see `acceptance.md` §G4).
+
+## Coverage matrix (V1.2.2 MVP)
+
+| Skill | Scenario | Lang | File |
+|---|---|---|---|
+| fairy-snapshot | basic happy path | zh + en mirror | `prompts/build-yixuan-basic.md` |
+| fairy-snapshot | full critical filled | zh | `prompts/build-yixuan-full.md` |
+| fairy-snapshot | entity ambiguity | zh | `prompts/build-anby-ambiguous.md` |
+| fairy-snapshot | critical-field unknown | zh | `prompts/build-yixuan-unknown.md` |
+| fairy-calc | invoke CLI on validated snapshot | zh + en | `prompts/calc-yixuan.md` |
+| fairy-explain | standalone explain | zh + en | `prompts/explain-yixuan-trace.md` |
+
+Per `acceptance.md` G4 fixture strategy, QA may add more EN-canonical scenarios for skill-spec smoke and additional zh/en user-facing smokes. UX-owned MVP set covers the critical paths above.
+
+## Schema notes
+
+- `snapshots/*.snapshot.json` files are strict `BattleSnapshot` JSON and must pass `parseBattleSnapshot`.
+- Draft-only reporting such as `defaultedFields`, `unknownFields`, warnings, and ask-user turns lives in `expected/*.draft-metadata.json`, never inside the strict snapshot.
+- `expected/yixuan-basic.calc.json` is generated from `fairy calc examples/ai-plugin/snapshots/yixuan-basic.snapshot.json --view verbose --lang zh --pretty` and should be refreshed when the core `CalcResult` schema changes.
+
+## Cross-references
+
+- Prompt templates spec: `docs/ai-plugin/prompt-templates.md`
+- User journeys: `docs/ai-plugin/user-journeys.md`
+- Acceptance gates: `docs/ai-plugin/acceptance.md`
+- Architecture: `docs/ai-plugin/architecture.md`
+- Decision lock: `docs/product/decisions/D-21-ai-plugin.md`

--- a/examples/ai-plugin/entity-normalization.md
+++ b/examples/ai-plugin/entity-normalization.md
@@ -1,0 +1,161 @@
+# Entity normalization fixtures (zh ↔ en ↔ canonical id)
+
+Per `docs/ai-plugin/prompt-templates.md` §8, the AI plugin's entity normalization layer maps user-provided natural-language entity names (in zh or en) to canonical fairy GameData ids. This file is the **fixture source** that QA G3 acceptance harness uses to validate the routing behavior.
+
+## Format
+
+```
+| User input variants            | Canonical id              | GameData type     |
+|--------------------------------|---------------------------|-------------------|
+| <zh name> / <en name> / alias  | <id>                      | character / weapon / equipment / bangboo / monster |
+```
+
+The "user input variants" column lists all the natural-language strings (zh, en, aliases) that should normalize to the same canonical id.
+
+---
+
+## Agents (characters)
+
+| User input variants | Canonical id | GameData type |
+|---|---|---|
+| 仪玄 / Yixuan / yixuan | `1371` | character |
+| 妮可 / 妮可·德玛拉 / Nicole / Nicole Demara / nicole | `1031` | character |
+| 安比 / 安比·德玛拉 / Anby / Anby Demara | `1011` | character |
+| 11号 / Soldier 11 / S11 / soldier11 | `1041` | character |
+| 柳 / Yanagi | `1221` | character |
+| 苍角 / Soukaku | `1131` | character |
+| 妮娅 / Nia / Nia Lina (V1.2 sample) | `1071` | character |
+| 朱鸢 / Zhu Yuan / zhuyuan | `1191` | character |
+| 凯撒 / Caesar | `1241` | character |
+| 班尼斯 / Burnice / Burnice White | `1051` | character |
+
+**Notes**:
+- "安比" alone is ambiguous in casual usage (might be referring to Anby Demara across multiple versions); per `prompt-templates.md` §8.3 ambiguity policy, AI surfaces disambiguation candidates with id + version.
+- English aliases include lowercase variants AI must recognize.
+- New agents added to nanoka 2.8+ should append to this table.
+
+## W-Engines (weapons)
+
+| User input variants | Canonical id | GameData type |
+|---|---|---|
+| 命破之刃 / Doom Blade / doomblade | `14137` | weapon |
+| 啄木鸟电音 (as weapon, not Drive Disc) — N/A | — | (Woodpecker is a Drive Disc set, see below) |
+| 棘羽折剑 / Brokenfeather Spike | `14041` | weapon |
+| 街头狂迷 / Street Madness | `14049` | weapon |
+
+**Notes**:
+- W-Engine names often share Chinese theme keywords with Drive Disc sets ("啄木鸟", "钢铁"); AI must disambiguate by GameData type (Weapon vs Equipment).
+- Refinement level is a **critical field** orthogonal to weapon id; both must be resolved.
+
+## Drive Disc sets (equipment)
+
+| User input variants | Canonical id | GameData type |
+|---|---|---|
+| 啄木鸟电音 / Woodpecker Electro / woodpecker | `31000` | equipment (set) |
+| 钢铁躯壳 / Hormone Punk / Steel Cushion (alias) | `32004` | equipment (set) |
+| 摇摆爵士 / Swing Jazz | `31001` | equipment (set) |
+| 折叠刀锋 / Folding Blade (sample) | `31002` | equipment (set) |
+| 极地重金属 / Polar Metal | `31003` | equipment (set) |
+
+**Notes**:
+- Drive Disc set has 2pc + 4pc effect; AI must clarify which combination ("4套" vs "2 套 + 2 套" mix).
+- Panel values inferred from Drive Disc main stats and substats are Tier 2 optional fields (per 3-tier policy), with documented 5★ midpoint-derived panel defaults.
+
+## Bangboos
+
+| User input variants | Canonical id | GameData type |
+|---|---|---|
+| 企鹅布 / Penguinboo / penguinboo | `54001` | bangboo |
+| 鲨牙布 / Sharkboo / sharkboo | `54002` | bangboo |
+| 插头布 / Plugboo / plugboo | `54003` | bangboo |
+
+**Notes**:
+- Bangboo "skill_prop" data covers active and chain damage multipliers + daze + anomaly buildup per V1.1.
+
+## Enemies (monsters)
+
+| User input variants | Canonical id | GameData type |
+|---|---|---|
+| 格莱特 / Grete (G18 anchor) | `monster_info.greta_*` (variant-resolved) | monster |
+| 凶心疯汉 / Ruthless Fiend (G19 anchor) | `monster_info.ruthless_fiend_*` | monster |
+| 装甲哈提 / Armored Hati (G20 anchor) | `monster_info.armored_hati_*` | monster |
+
+**Notes**:
+- Enemy id resolution often requires variant mapping (per V1.2.x impl).
+- DA enemies: prefer explicit "current DA boss" → AI resolves to nanoka current live period boss list.
+
+## DA scope markers
+
+| User input | Resolved scope |
+|---|---|
+| 危局强袭战 / Deadly Assault / DA | DA scope; AI fetches current live period from nanoka `boss.json` |
+| "本期 DA" / "current DA" | Same; resolves to live period |
+| "上期 DA" / "previous DA" | Historical DA scope; resolves to `historicalDAPeriods` bucket |
+
+---
+
+## Disambiguation flow examples
+
+When AI cannot determine a unique canonical id from user input, surface candidates per `prompt-templates.md` §4.4. Examples:
+
+```
+User: "我想算 Anby..."
+AI candidates surface:
+  1. Anby Demara (id 1011, S 级, V1 onward) — 默认匹配
+
+Single candidate → AI proceeds with id=1011 + records "anby" → 1011 in fixture.
+```
+
+```
+User: "把 S11 算一下"
+AI candidates surface:
+  1. Soldier 11 (id 1041) — only candidate
+
+Single candidate → AI proceeds.
+```
+
+```
+User: "啄木鸟"  (no context: weapon vs Drive Disc?)
+AI:
+  "你说的 '啄木鸟' 是 W-Engine 还是 Drive Disc?
+   - W-Engine: (无对应 — nanoka 数据里 '啄木鸟' 仅 Drive Disc set)
+   - Drive Disc 套装: 啄木鸟电音 (id 31000)"
+
+User confirms Drive Disc → AI proceeds with 31000.
+```
+
+## Cross-lang routing
+
+Per `user-journeys.md` §5 lang detection, entity normalization is independent of dialog lang:
+
+```
+zh dialog + en entity: "算 Yixuan 60 级"
+  → Yixuan → 1371
+  → session lang stays zh
+  → AI response in zh
+
+en dialog + zh entity: "calc 仪玄 level 60"
+  → 仪玄 → 1371
+  → session lang stays en
+  → AI response in en
+```
+
+Both cases must produce identical canonical id; only the AI response lang differs.
+
+---
+
+## Coverage status (V1.2.2 MVP)
+
+This fixture covers the entities used in V1.2.2 MVP prompts:
+- ✅ Agents: 仪玄 / 安比 / 妮可 / S11 / 柳 (used in build-* prompts)
+- ✅ W-Engines: 命破之刃 (yixuan basic build)
+- ✅ Drive Disc sets: 啄木鸟电音 / 钢铁躯壳 (yixuan build)
+- ✅ Bangboos: 企鹅布 / 鲨牙布 / 插头布 (3 anchor coverage)
+- ✅ Enemies: G18-G20 anchors (basic only; V1.2.2 doesn't expand enemy scenarios)
+- ✅ DA scope marker (resolved to current live period)
+
+**Out of MVP scope** (per D-21):
+- Full character / W-Engine / Drive Disc / enemy variant coverage — supported in fixture data via nanoka, not enumerated here.
+- Resonium / Sentinel mapping — removed per R4 / V1.2.3.
+
+If new entities are introduced in V1.2.x patches, append rows to this table and ensure both zh and en variants are listed.

--- a/examples/ai-plugin/entity-normalization.md
+++ b/examples/ai-plugin/entity-normalization.md
@@ -24,10 +24,10 @@ The "user input variants" column lists all the natural-language strings (zh, en,
 | 11号 / Soldier 11 / S11 / soldier11 | `1041` | character |
 | 柳 / Yanagi | `1221` | character |
 | 苍角 / Soukaku | `1131` | character |
-| 妮娅 / Nia / Nia Lina (V1.2 sample) | `1071` | character |
-| 朱鸢 / Zhu Yuan / zhuyuan | `1191` | character |
-| 凯撒 / Caesar | `1241` | character |
-| 班尼斯 / Burnice / Burnice White | `1051` | character |
+| 凯撒 / Caesar | `1071` | character |
+| 艾莲 / Ellen | `1191` | character |
+| 朱鸢 / Zhu Yuan / zhuyuan | `1241` | character |
+| 柏妮思 / Burnice | `1171` | character |
 
 **Notes**:
 - "安比" alone is ambiguous in casual usage (might be referring to Anby Demara across multiple versions); per `prompt-templates.md` §8.3 ambiguity policy, AI surfaces disambiguation candidates with id + version.
@@ -38,10 +38,10 @@ The "user input variants" column lists all the natural-language strings (zh, en,
 
 | User input variants | Canonical id | GameData type |
 |---|---|---|
-| 命破之刃 / Doom Blade / doomblade | `14137` | weapon |
+| 青溟笼舍 / Qingming Birdcage / qingming birdcage | `14137` | weapon |
 | 啄木鸟电音 (as weapon, not Drive Disc) — N/A | — | (Woodpecker is a Drive Disc set, see below) |
-| 棘羽折剑 / Brokenfeather Spike | `14041` | weapon |
-| 街头狂迷 / Street Madness | `14049` | weapon |
+| 钢铁肉垫 / Steel Cushion | `14102` | weapon |
+| 街头巨星 / Street Superstar | `13001` | weapon |
 
 **Notes**:
 - W-Engine names often share Chinese theme keywords with Drive Disc sets ("啄木鸟", "钢铁"); AI must disambiguate by GameData type (Weapon vs Equipment).
@@ -52,10 +52,9 @@ The "user input variants" column lists all the natural-language strings (zh, en,
 | User input variants | Canonical id | GameData type |
 |---|---|---|
 | 啄木鸟电音 / Woodpecker Electro / woodpecker | `31000` | equipment (set) |
-| 钢铁躯壳 / Hormone Punk / Steel Cushion (alias) | `32004` | equipment (set) |
-| 摇摆爵士 / Swing Jazz | `31001` | equipment (set) |
-| 折叠刀锋 / Folding Blade (sample) | `31002` | equipment (set) |
-| 极地重金属 / Polar Metal | `31003` | equipment (set) |
+| 激素朋克 / Hormone Punk | `31400` | equipment (set) |
+| 摇摆爵士 / Swing Jazz | `31600` | equipment (set) |
+| 极地重金属 / Polar Metal | `32500` | equipment (set) |
 
 **Notes**:
 - Drive Disc set has 2pc + 4pc effect; AI must clarify which combination ("4套" vs "2 套 + 2 套" mix).
@@ -65,9 +64,9 @@ The "user input variants" column lists all the natural-language strings (zh, en,
 
 | User input variants | Canonical id | GameData type |
 |---|---|---|
-| 企鹅布 / Penguinboo / penguinboo | `54001` | bangboo |
-| 鲨牙布 / Sharkboo / sharkboo | `54002` | bangboo |
-| 插头布 / Plugboo / plugboo | `54003` | bangboo |
+| 企鹅布 / Penguinboo / penguinboo | `53001` | bangboo |
+| 鲨牙布 / Sharkboo / sharkboo | `54001` | bangboo |
+| 插头布 / Plugboo / plugboo | `54008` | bangboo |
 
 **Notes**:
 - Bangboo "skill_prop" data covers active and chain damage multipliers + daze + anomaly buildup per V1.1.
@@ -76,20 +75,20 @@ The "user input variants" column lists all the natural-language strings (zh, en,
 
 | User input variants | Canonical id | GameData type |
 |---|---|---|
-| 格莱特 / Grete (G18 anchor) | `monster_info.greta_*` (variant-resolved) | monster |
-| 凶心疯汉 / Ruthless Fiend (G19 anchor) | `monster_info.ruthless_fiend_*` | monster |
-| 装甲哈提 / Armored Hati (G20 anchor) | `monster_info.armored_hati_*` | monster |
+| 格莱特 / Greta | `30004` | monster |
+| 凶心疯汉 / Ruthless Fiend | `200141` | monster |
+| 装甲哈提 / Armored Hati | `20003` | monster |
 
 **Notes**:
-- Enemy id resolution often requires variant mapping (per V1.2.x impl).
-- DA enemies: prefer explicit "current DA boss" → AI resolves to nanoka current live period boss list.
+- Enemy id resolution may require variant mapping in future V1.2.x patches.
+- V1.2.2 examples use explicit runtime ids from `packages/data/cleaned/runtime/game-data.json`.
 
 ## DA scope markers
 
 | User input | Resolved scope |
 |---|---|
-| 危局强袭战 / Deadly Assault / DA | DA scope; AI fetches current live period from nanoka `boss.json` |
-| "本期 DA" / "current DA" | Same; resolves to live period |
+| 危局强袭战 / Deadly Assault / DA | DA scope marker; this fixture uses Greta `enemy.id=30004` |
+| "本期 DA" / "current DA" | Same; this fixture resolves to Greta `enemy.id=30004` |
 | "上期 DA" / "previous DA" | Historical DA scope; resolves to `historicalDAPeriods` bucket |
 
 ---
@@ -148,11 +147,11 @@ Both cases must produce identical canonical id; only the AI response lang differ
 
 This fixture covers the entities used in V1.2.2 MVP prompts:
 - ✅ Agents: 仪玄 / 安比 / 妮可 / S11 / 柳 (used in build-* prompts)
-- ✅ W-Engines: 命破之刃 (yixuan basic build)
-- ✅ Drive Disc sets: 啄木鸟电音 / 钢铁躯壳 (yixuan build)
+- ✅ W-Engines: 青溟笼舍 (yixuan basic build)
+- ✅ Drive Disc sets: 啄木鸟电音 / 激素朋克 (yixuan build)
 - ✅ Bangboos: 企鹅布 / 鲨牙布 / 插头布 (3 anchor coverage)
 - ✅ Enemies: G18-G20 anchors (basic only; V1.2.2 doesn't expand enemy scenarios)
-- ✅ DA scope marker (resolved to current live period)
+- ✅ DA scope marker (resolved to live sample fixture)
 
 **Out of MVP scope** (per D-21):
 - Full character / W-Engine / Drive Disc / enemy variant coverage — supported in fixture data via nanoka, not enumerated here.

--- a/examples/ai-plugin/expected/.gitkeep
+++ b/examples/ai-plugin/expected/.gitkeep
@@ -1,1 +1,0 @@
-# Filled by UX task #208.

--- a/examples/ai-plugin/expected/yixuan-basic.calc.json
+++ b/examples/ai-plugin/expected/yixuan-basic.calc.json
@@ -8,7 +8,7 @@
   "locale": "zh",
   "summary": {
     "activeActorId": "1371",
-    "enemyId": "monster_info.current_da_boss",
+    "enemyId": "30004",
     "damageType": "regular",
     "lanes": {
       "nonCrit": {

--- a/examples/ai-plugin/expected/yixuan-basic.calc.json
+++ b/examples/ai-plugin/expected/yixuan-basic.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.2",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1371",
+    "enemyId": "monster_info.current_da_boss",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 5954,
+        "displayDamage": 5954
+      },
+      "crit": {
+        "rawDamage": 10717.2,
+        "displayDamage": 10718
+      }
+    },
+    "rawTotalDamage": 7621.120000000001,
+    "displayTotalDamage": 7622,
+    "expectedDamage": 7621.120000000001,
+    "critDamage": 10717.2,
+    "nonCritDamage": 5954,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-basic-1",
+      "actorId": "1371",
+      "attribute": "auricInk",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 7621.120000000001,
+      "segmentDisplayDamage": 7622,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 10076,
+      "expectedDamage": 7621.120000000001,
+      "critDamage": 10717.2,
+      "nonCritDamage": 5954,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 10076,
+      "effectiveMultiplier": 10076,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 10076,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1.3,
+      "effectiveMultiplier": 1.3,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0.3,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 1.28,
+      "effectiveMultiplier": 1.28,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1.28,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-basic-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin",
+            "sourceVersion": "v1.2.2",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "yixuan-basic-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 10076,
+      "displayValue": 10076,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "yixuan-basic-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0.3,
+      "displayValue": 1.3,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "yixuan-basic-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1.28,
+      "displayValue": 1.28,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "yixuan-basic-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "yixuan-basic-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "yixuan-basic-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "yixuan-basic-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "yixuan-basic-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 10076,
+        "damageType": "regular",
+        "multiplier": 4.58,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 7621.120000000001,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 7621.120000000001,
+      "displayValue": 7622,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 7621.120000000001,
+        "output": 7622,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/expected/yixuan-basic.draft-metadata.json
+++ b/examples/ai-plugin/expected/yixuan-basic.draft-metadata.json
@@ -32,10 +32,10 @@
   ],
   "entityNormalization": [
     { "input": "仪玄", "canonical": "character.id=1371", "lang": "zh" },
-    { "input": "命破之刃", "canonical": "weapon.id=14137", "lang": "zh" },
+    { "input": "青溟笼舍", "canonical": "weapon.id=14137", "lang": "zh" },
     { "input": "啄木鸟电音", "canonical": "equipment.setId=31000", "lang": "zh" },
-    { "input": "钢铁躯壳", "canonical": "equipment.setId=32004", "lang": "zh" },
-    { "input": "危局强袭战", "canonical": "scope=deadly_assault, period=current_live", "lang": "zh" }
+    { "input": "激素朋克", "canonical": "equipment.setId=31400", "lang": "zh" },
+    { "input": "危局强袭战", "canonical": "enemy.id=30004", "lang": "zh" }
   ],
   "sessionLang": "zh",
   "langDetectSource": "user-input-majority"

--- a/examples/ai-plugin/expected/yixuan-basic.draft-metadata.json
+++ b/examples/ai-plugin/expected/yixuan-basic.draft-metadata.json
@@ -1,0 +1,42 @@
+{
+  "$comment": "Draft metadata produced by fairy-snapshot skill alongside the BattleSnapshot. NOT written into the snapshot JSON itself (strict schema). Surfaced to the user during review/confirm gate and forwarded to QA G3 fixture assertions.",
+  "snapshotFixture": "yixuan-basic",
+  "defaultedFields": [
+    {
+      "path": "team[0].panel.{attack,critRate,critDamage,etherDamageBonus}",
+      "default": "5-star midpoint-derived panel value",
+      "rationale": "User did not specify panel values; defaulted per `prompt-templates.md` §4.2 Tier 2 policy.",
+      "expectedDeviationPct": 2
+    },
+    {
+      "path": "team[0].mindscapeCinema.level",
+      "default": 0,
+      "rationale": "Default mindscapeCinema level when not specified.",
+      "expectedDeviationPct": 0.5
+    }
+  ],
+  "unknownFields": [],
+  "warnings": [
+    "panel-defaulted: result may be off by ~2%"
+  ],
+  "askUserTurns": [
+    {
+      "tier": "critical",
+      "askedFields": ["team[0].level", "team[0].wEngine.phase"],
+      "userReply": "60 级，精炼 1",
+      "resolved": {
+        "team[0].level": 60,
+        "team[0].wEngine.phase": 1
+      }
+    }
+  ],
+  "entityNormalization": [
+    { "input": "仪玄", "canonical": "character.id=1371", "lang": "zh" },
+    { "input": "命破之刃", "canonical": "weapon.id=14137", "lang": "zh" },
+    { "input": "啄木鸟电音", "canonical": "equipment.setId=31000", "lang": "zh" },
+    { "input": "钢铁躯壳", "canonical": "equipment.setId=32004", "lang": "zh" },
+    { "input": "危局强袭战", "canonical": "scope=deadly_assault, period=current_live", "lang": "zh" }
+  ],
+  "sessionLang": "zh",
+  "langDetectSource": "user-input-majority"
+}

--- a/examples/ai-plugin/expected/yixuan-basic.explain.en.md
+++ b/examples/ai-plugin/expected/yixuan-basic.explain.en.md
@@ -1,0 +1,44 @@
+# Expected explain output · yixuan-basic (en)
+
+Expected `fairy-explain` skill output when consuming `expected/yixuan-basic.calc.json` with `--lang en`.
+
+Used by QA G5 as golden assertion for explain skill behavior, English variant.
+
+---
+
+Yixuan basic attack hit 1 has **7,622 displayed expected damage** in this CalcResult.
+
+- **Non-crit**: 5,954
+- **Crit**: 10,718
+- **Raw expected damage**: 7,621.12
+
+The chain comes from `CalcResult.trace`:
+
+1. `baseDamageZone` = **10,076**
+   Source: `examples.ai-plugin` / `character.1371.skill.basic`, the fixture source for Yixuan basic attack hit 1.
+2. `damageBonusZone` = **1.3**
+   Source: `trace-2`, from the snapshot panel's `etherDamageBonus: 0.3`; Yixuan's `auricInk` maps to the ether damage bonus field.
+3. `critZone` = **1.28**
+   Source: `trace-3`, the expected crit multiplier from `critRate: 0.35` and `critDamage: 0.8`.
+4. `defenseZone` = **0.4545454545**
+   Source: `trace-4`, the default level 60 agent vs. level 60 boss defense zone.
+5. `resistanceZone` / `vulnerabilityZone` / `dazeVulnerabilityZone` / `specialZone` are all **1.0**.
+6. Final formula:
+   `10076 × 1.3 × 1.28 × 0.4545454545 × 1 × 1 × 1 × 1 = 7621.12`
+7. Display damage rounds each segment up: `ceil(7621.12) = 7622`.
+
+This CalcResult has no warnings or errors.
+
+### Disclaimer
+
+Data is based on `nanoka@2.8` cleaned snapshot. Re-fetch the data after game patches. For takedown requests please contact the maintainer.
+
+---
+
+## Acceptance assertions (QA G5)
+
+- Every multiplier / value step must reference an actual field in `CalcResult.trace` (no fabrication).
+- sourceRef paths must resolve to user-friendly English names.
+- Warnings must be retained and surfaced when present.
+- Disclaimer footer must appear (first response per session).
+- AI does not invoke fairy CLI in explain skill (per architecture: standalone).

--- a/examples/ai-plugin/expected/yixuan-basic.explain.zh.md
+++ b/examples/ai-plugin/expected/yixuan-basic.explain.zh.md
@@ -1,0 +1,44 @@
+# Expected explain output · yixuan-basic (zh)
+
+Expected `fairy-explain` skill output when consuming `expected/yixuan-basic.calc.json` with `--lang zh`.
+
+Used by QA G5 as golden assertion for explain skill behavior.
+
+---
+
+你的仪玄普通攻击一段本次显示伤害是 **7,622**（期望值）。
+
+- **非暴击**: 5,954
+- **暴击**: 10,718
+- **期望原始伤害**: 7,621.12
+
+计算链路来自 `CalcResult.trace`：
+
+1. `baseDamageZone` = **10,076**
+   来源: `examples.ai-plugin` / `character.1371.skill.basic`，对应 fixture 中仪玄普通攻击一段的基础伤害。
+2. `damageBonusZone` = **1.3**
+   来源: `trace-2`，对应面板里的 `etherDamageBonus: 0.3`；仪玄的 `auricInk` 会走 ether damage bonus 映射。
+3. `critZone` = **1.28**
+   来源: `trace-3`，期望暴击乘区由 `critRate: 0.35` 和 `critDamage: 0.8` 得到。
+4. `defenseZone` = **0.4545454545**
+   来源: `trace-4`，60 级代理人对 60 级 boss 的默认防御区。
+5. `resistanceZone` / `vulnerabilityZone` / `dazeVulnerabilityZone` / `specialZone` 均为 **1.0**。
+6. 最终公式：
+   `10076 × 1.3 × 1.28 × 0.4545454545 × 1 × 1 × 1 × 1 = 7621.12`
+7. 显示值按逐段向上取整：`ceil(7621.12) = 7622`。
+
+本次 CalcResult 没有 warnings 或 errors。
+
+### Disclaimer
+
+数据基于 `nanoka@2.8` cleaned snapshot。如有版本更新请重新 fetch 数据。如有侵权请联系作者删除。
+
+---
+
+## Acceptance assertions (QA G5)
+
+- 每一步 multiplier / 数值必须 reference `CalcResult.trace` 实际字段（不得编造）。
+- sourceRef 必须翻译为用户友好的中文名称。
+- Warnings 若存在必须保留并 surface 给用户。
+- Disclaimer footer 必须出现（first response per session）。
+- AI 不调用 fairy CLI（per architecture：explain skill = standalone）。

--- a/examples/ai-plugin/prompts/.gitkeep
+++ b/examples/ai-plugin/prompts/.gitkeep
@@ -1,1 +1,0 @@
-# Filled by UX task #208.

--- a/examples/ai-plugin/prompts/build-anby-ambiguous.md
+++ b/examples/ai-plugin/prompts/build-anby-ambiguous.md
@@ -1,0 +1,82 @@
+# fixture · build-anby-ambiguous
+
+**Skill**: fairy-snapshot
+**Scenario**: entity ambiguity → AI disambiguates by surfacing candidates, user picks, then proceeds to ask remaining critical fields.
+**Lang**: zh
+
+This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-templates.md` §4.4) and demonstrates that AI never auto-picks when multiple candidates exist.
+
+---
+
+## User input
+
+```
+帮我算 Anby 50 级，5★ S11 工业制式精炼 3，配啄木鸟电音 4 套。
+```
+
+## Expected AI behavior
+
+1. **Lang detect**: input majority zh (mixed lang OK; zh dominant by token count) → session lang = zh.
+2. **Entity normalization**:
+   - "Anby" → ambiguity: in V1.2.2 nanoka data only `character.id=1011` (Anby Demara) matches. Single candidate, but AI surfaces context per `prompt-templates.md` §4.4 to confirm with user (good UX practice for ambiguous-looking inputs).
+   - "S11" / "S11 工业制式" → `weapon.id=14041`
+   - "啄木鸟电音" → `equipment.setId=31000`
+3. **Disambiguation surface** (Anby example):
+   ```
+   AI: "你说的 Anby 我看到 1 个匹配:
+     1. Anby Demara (id 1011, A 级电属性, V1 onward)
+
+     是这位吗?"
+   ```
+4. **User confirms**:
+   ```
+   "是 1"
+   ```
+5. **Field tier check**:
+   - Critical resolved: level=50, weapon refinement=3, Drive Disc set covered.
+   - Critical missing: **Drive Disc 2pc set** (4pc 已说了，2pc 还没说) — 需问。
+   - Optional defaulted: panel values, mindscapeCinema level.
+6. **Ask-user dialog** (sequential, since 2pc choice depends on 4pc context):
+   ```
+   AI: "你说的 4 套是啄木鸟电音; 那剩下 2 个槽位是什么?
+     - 啄木鸟电音 6 套（完整套装）?
+     - 啄木鸟电音 4 + 其他 2 套? (告诉我另外 2 套是哪个)"
+   ```
+7. **User reply**:
+   ```
+   "另外 2 套钢铁躯壳"
+   ```
+8. **Snapshot generation**: produce `BattleSnapshot` JSON.
+9. **Review/confirm gate**:
+   ```
+   AI: "snapshot 已组好:
+     - Anby Demara lv50 (id 1011)
+     - S11 工业制式 R3 (id 14041)
+     - 啄木鸟电音 4pc + 钢铁躯壳 2pc
+     - 默认填: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
+
+     还要补充什么吗? 比如敌人是什么? 算哪一段攻击?"
+   ```
+   **Note**: AI proactively asks user for context still missing for a useful calc (enemy / attack segment) since this prompt didn't specify. This is per UX guideline: never silently produce snapshot with no attack target.
+10. **User reply**:
+    ```
+    "本期 DA boss, 算一段普攻"
+    ```
+11. **Final snapshot + confirm** → invoke fairy-calc skill.
+
+## Expected output
+
+Snapshot JSON shape similar to `snapshots/yixuan-basic.snapshot.json` with appropriate field substitutions:
+- `team[0].agentId = "1011"` (Anby Demara)
+- `team[0].level = 50`
+- `team[0].wEngine.id = "14041"` (S11), `refinement = 3`
+- Drive Disc setIds: slots 1-4 = `31000` (Woodpecker), slots 5-6 = `32004` (Hormone Punk)
+- `attackSegments[0].skill = "basic"`, `step = 1`
+
+## Acceptance assertions (QA G3)
+
+- AI must surface disambiguation candidates even for single-match cases when input is informal (e.g., "Anby" → confirm full name).
+- AI must not auto-pick from multiple candidates.
+- AI must ask 2pc set when 4pc is specified but 2pc is not (Drive Disc 6-slot completeness gate).
+- AI must proactively ask user for missing context (enemy / attack segment) before producing a usable snapshot.
+- Field tier policy enforced (critical → ask, optional → default + warning).

--- a/examples/ai-plugin/prompts/build-anby-ambiguous.md
+++ b/examples/ai-plugin/prompts/build-anby-ambiguous.md
@@ -11,7 +11,7 @@ This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-t
 ## User input
 
 ```
-帮我算 Anby 50 级，5★ S11 工业制式精炼 3，配啄木鸟电音 4 套。
+帮我算 Anby 50 级，5★ Street Superstar精炼 3，配啄木鸟电音 4 套。
 ```
 
 ## Expected AI behavior
@@ -19,7 +19,7 @@ This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-t
 1. **Lang detect**: input majority zh (mixed lang OK; zh dominant by token count) → session lang = zh.
 2. **Entity normalization**:
    - "Anby" → ambiguity: in V1.2.2 nanoka data only `character.id=1011` (Anby Demara) matches. Single candidate, but AI surfaces context per `prompt-templates.md` §4.4 to confirm with user (good UX practice for ambiguous-looking inputs).
-   - "S11" / "S11 工业制式" → `weapon.id=14041`
+   - "S11" / "Street Superstar" → `weapon.id=13001`
    - "啄木鸟电音" → `equipment.setId=31000`
 3. **Disambiguation surface** (Anby example):
    ```
@@ -44,15 +44,15 @@ This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-t
    ```
 7. **User reply**:
    ```
-   "另外 2 套钢铁躯壳"
+   "另外 2 套激素朋克"
    ```
 8. **Snapshot generation**: produce `BattleSnapshot` JSON.
 9. **Review/confirm gate**:
    ```
    AI: "snapshot 已组好:
      - Anby Demara lv50 (id 1011)
-     - S11 工业制式 R3 (id 14041)
-     - 啄木鸟电音 4pc + 钢铁躯壳 2pc
+     - Street Superstar R3 (id 13001)
+     - 啄木鸟电音 4pc + 激素朋克 2pc
      - 默认填: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
 
      还要补充什么吗? 比如敌人是什么? 算哪一段攻击?"
@@ -60,7 +60,7 @@ This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-t
    **Note**: AI proactively asks user for context still missing for a useful calc (enemy / attack segment) since this prompt didn't specify. This is per UX guideline: never silently produce snapshot with no attack target.
 10. **User reply**:
     ```
-    "本期 DA boss, 算一段普攻"
+    "格莱特, 算一段普攻"
     ```
 11. **Final snapshot + confirm** → invoke fairy-calc skill.
 
@@ -69,9 +69,9 @@ This fixture covers the **ambiguity** path of the ask-user dialog (per `prompt-t
 Snapshot JSON shape similar to `snapshots/yixuan-basic.snapshot.json` with appropriate field substitutions:
 - `team[0].agentId = "1011"` (Anby Demara)
 - `team[0].level = 50`
-- `team[0].wEngine.id = "14041"` (S11), `refinement = 3`
-- Drive Disc setIds: slots 1-4 = `31000` (Woodpecker), slots 5-6 = `32004` (Hormone Punk)
-- `attackSegments[0].skill = "basic"`, `step = 1`
+- `team[0].wEngine.id = "13001"` (Street Superstar), `phase = 3`
+- Drive Disc setIds: slots 1-4 = `31000` (Woodpecker), slots 5-6 = `31400` (Hormone Punk)
+- `attackSegments[0].skillId = "basic"`, `tags = ["basic"]`
 
 ## Acceptance assertions (QA G3)
 

--- a/examples/ai-plugin/prompts/build-yixuan-basic.md
+++ b/examples/ai-plugin/prompts/build-yixuan-basic.md
@@ -1,0 +1,132 @@
+# fixture · build-yixuan-basic
+
+**Skill**: fairy-snapshot
+**Scenario**: minimal happy path — user provides agent + W-Engine + Drive Disc set names, AI asks 1 critical field (agent level), produces a snapshot.
+**Lang**: zh + en mirror
+
+This is the **canonical baseline** fixture per `acceptance.md` G4. Snapshot output is consumed by `calc-yixuan` and `explain-yixuan-trace` fixtures downstream.
+
+---
+
+## Variant A — zh dialog
+
+### User input
+
+```
+我想算仪玄带命破之刃，啄木鸟电音 4 件套 + 钢铁躯壳 2 件套，
+打 60 级危局强袭战 boss，单段普通攻击一段伤害。
+```
+
+### Expected AI behavior
+
+1. **Lang detect**: input majority zh → session lang = zh.
+2. **Entity normalization**:
+   - "仪玄" → `character.id=1371` ✓
+   - "命破之刃" → `weapon.id=14137` ✓
+   - "啄木鸟电音" → `equipment.setId=31000` (Drive Disc set) ✓
+   - "钢铁躯壳" → `equipment.setId=32004` (Drive Disc set) ✓
+   - "危局强袭战" → DA scope marker, resolves to current live period boss ✓
+3. **Field tier check** (per 3-tier policy):
+   - Critical missing: **agent level** (Yixuan 是几级?)
+   - Optional with default: panel values (用 5★ 满级 midpoint 推导面板默认)
+   - Refinement level: critical → 也需问
+4. **Ask-user dialog** (batch, 2-3 critical fields):
+   ```
+   AI: "我帮你查到了:
+     - 角色: 仪玄 (id 1371)
+     - W-Engine: 命破之刃 (id 14137)
+     - Drive Disc: 啄木鸟电音 4套 + 钢铁躯壳 2 套
+     - 敌人: 本期 DA boss
+
+     还需要 2 个关键字段:
+     1. 仪玄的等级? (例: 60)
+     2. 命破之刃的精炼? (1-5)
+
+     回答完我就能算了。"
+   ```
+5. **User reply** (expected):
+   ```
+   "60 级，精炼 1"
+   ```
+6. **Snapshot generation**: produce valid `BattleSnapshot` JSON conforming to `parseBattleSnapshot`.
+7. **Optional defaulted fields**: surface in `draftMetadata.defaultedFields`:
+   - `team[0].panel.{attack,critRate,critDamage,etherDamageBonus}` → defaulted to 5★ midpoint
+   - `team[0].mindscapeCinema.level` → defaulted to 0
+8. **Review/confirm gate**: AI presents snapshot summary to user before invoking calc.
+   ```
+   AI: "snapshot 已组好:
+     - 仪玄 lv60, 命破之刃 R1
+     - 啄木鸟电音 4pc + 钢铁躯壳 2pc
+     - 敌人: 本期 DA boss
+     - 默认填: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
+
+     继续算伤害吗?"
+   ```
+9. **User confirms** → AI invokes `fairy-calc` skill (chain).
+
+### Expected snapshot output
+
+See `snapshots/yixuan-basic.snapshot.json`.
+
+### Lang policy
+
+All AI dialog turns and snapshot review summary in zh (matching session lang).
+Snapshot JSON itself is canonical English schema (per tri-layer i18n Layer 1).
+
+---
+
+## Variant B — en dialog (mirror)
+
+### User input
+
+```
+I want to calculate Yixuan with Doom Blade, Woodpecker Electro 4pc + Hormone Punk 2pc,
+fighting current DA boss, single basic attack first hit damage.
+```
+
+### Expected AI behavior
+
+Identical entity normalization (Yixuan → 1371, Doom Blade → 14137, Woodpecker Electro → 31000, Hormone Punk → 32004).
+
+Dialog in en:
+
+```
+AI: "Got it, found:
+  - Agent: Yixuan (id 1371)
+  - W-Engine: Doom Blade (id 14137)
+  - Drive Discs: Woodpecker Electro 4pc + Hormone Punk 2pc
+  - Enemy: current DA boss
+
+  I still need 2 critical fields:
+  1. Yixuan's level? (e.g., 60)
+  2. Doom Blade refinement? (1-5)
+
+  Tell me both and I'll run the calc."
+```
+
+User reply: `"level 60, R1"`
+
+Review gate:
+
+```
+AI: "Snapshot ready:
+  - Yixuan lv60, Doom Blade R1
+  - Woodpecker Electro 4pc + Hormone Punk 2pc
+  - Enemy: current DA boss
+  - Defaulted: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
+
+  Run the calc?"
+```
+
+Same snapshot JSON output (`snapshots/yixuan-basic.snapshot.json`) — schema is lang-independent.
+
+---
+
+## Acceptance assertions (for QA G3 / G4)
+
+- AI must ask agent level + refinement (critical fields) before producing snapshot.
+- AI must not invent agent level (no silent default).
+- AI must surface defaulted panel values in `draftMetadata.defaultedFields`.
+- AI must present review/confirm gate before chaining to fairy-calc.
+- AI must not invoke `fairy calc` from fairy-snapshot (per architecture.md: validation/calc happens in fairy-calc skill post-confirm).
+- Entity normalization must be lang-independent (zh ↔ en produce identical snapshot ids).

--- a/examples/ai-plugin/prompts/build-yixuan-basic.md
+++ b/examples/ai-plugin/prompts/build-yixuan-basic.md
@@ -13,7 +13,7 @@ This is the **canonical baseline** fixture per `acceptance.md` G4. Snapshot outp
 ### User input
 
 ```
-我想算仪玄带命破之刃，啄木鸟电音 4 件套 + 钢铁躯壳 2 件套，
+我想算仪玄带青溟笼舍，啄木鸟电音 4 件套 + 激素朋克 2 件套，
 打 60 级危局强袭战 boss，单段普通攻击一段伤害。
 ```
 
@@ -22,10 +22,10 @@ This is the **canonical baseline** fixture per `acceptance.md` G4. Snapshot outp
 1. **Lang detect**: input majority zh → session lang = zh.
 2. **Entity normalization**:
    - "仪玄" → `character.id=1371` ✓
-   - "命破之刃" → `weapon.id=14137` ✓
+   - "青溟笼舍" → `weapon.id=14137` ✓
    - "啄木鸟电音" → `equipment.setId=31000` (Drive Disc set) ✓
-   - "钢铁躯壳" → `equipment.setId=32004` (Drive Disc set) ✓
-   - "危局强袭战" → DA scope marker, resolves to current live period boss ✓
+   - "激素朋克" → `equipment.setId=31400` (Drive Disc set) ✓
+   - "危局强袭战" → DA scope marker, resolves to Greta ✓
 3. **Field tier check** (per 3-tier policy):
    - Critical missing: **agent level** (Yixuan 是几级?)
    - Optional with default: panel values (用 5★ 满级 midpoint 推导面板默认)
@@ -34,13 +34,13 @@ This is the **canonical baseline** fixture per `acceptance.md` G4. Snapshot outp
    ```
    AI: "我帮你查到了:
      - 角色: 仪玄 (id 1371)
-     - W-Engine: 命破之刃 (id 14137)
-     - Drive Disc: 啄木鸟电音 4套 + 钢铁躯壳 2 套
-     - 敌人: 本期 DA boss
+     - W-Engine: 青溟笼舍 (id 14137)
+     - Drive Disc: 啄木鸟电音 4套 + 激素朋克 2 套
+     - 敌人: 格莱特
 
      还需要 2 个关键字段:
      1. 仪玄的等级? (例: 60)
-     2. 命破之刃的精炼? (1-5)
+     2. 青溟笼舍的精炼? (1-5)
 
      回答完我就能算了。"
    ```
@@ -55,9 +55,9 @@ This is the **canonical baseline** fixture per `acceptance.md` G4. Snapshot outp
 8. **Review/confirm gate**: AI presents snapshot summary to user before invoking calc.
    ```
    AI: "snapshot 已组好:
-     - 仪玄 lv60, 命破之刃 R1
-     - 啄木鸟电音 4pc + 钢铁躯壳 2pc
-     - 敌人: 本期 DA boss
+     - 仪玄 lv60, 青溟笼舍 R1
+     - 啄木鸟电音 4pc + 激素朋克 2pc
+     - 敌人: 格莱特
      - 默认填: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
 
      继续算伤害吗?"
@@ -80,26 +80,26 @@ Snapshot JSON itself is canonical English schema (per tri-layer i18n Layer 1).
 ### User input
 
 ```
-I want to calculate Yixuan with Doom Blade, Woodpecker Electro 4pc + Hormone Punk 2pc,
-fighting current DA boss, single basic attack first hit damage.
+I want to calculate Yixuan with Qingming Birdcage, Woodpecker Electro 4pc + Hormone Punk 2pc,
+fighting Greta, single basic attack first hit damage.
 ```
 
 ### Expected AI behavior
 
-Identical entity normalization (Yixuan → 1371, Doom Blade → 14137, Woodpecker Electro → 31000, Hormone Punk → 32004).
+Identical entity normalization (Yixuan → 1371, Qingming Birdcage → 14137, Woodpecker Electro → 31000, Hormone Punk → 31400).
 
 Dialog in en:
 
 ```
 AI: "Got it, found:
   - Agent: Yixuan (id 1371)
-  - W-Engine: Doom Blade (id 14137)
+  - W-Engine: Qingming Birdcage (id 14137)
   - Drive Discs: Woodpecker Electro 4pc + Hormone Punk 2pc
-  - Enemy: current DA boss
+  - Enemy: Greta
 
   I still need 2 critical fields:
   1. Yixuan's level? (e.g., 60)
-  2. Doom Blade refinement? (1-5)
+  2. Qingming Birdcage refinement? (1-5)
 
   Tell me both and I'll run the calc."
 ```
@@ -110,9 +110,9 @@ Review gate:
 
 ```
 AI: "Snapshot ready:
-  - Yixuan lv60, Doom Blade R1
+  - Yixuan lv60, Qingming Birdcage R1
   - Woodpecker Electro 4pc + Hormone Punk 2pc
-  - Enemy: current DA boss
+  - Enemy: Greta
   - Defaulted: panel values from 5★ midpoint assumptions, mindscapeCinema level 0
 
   Run the calc?"

--- a/examples/ai-plugin/prompts/build-yixuan-full.md
+++ b/examples/ai-plugin/prompts/build-yixuan-full.md
@@ -11,16 +11,16 @@ This fixture demonstrates the **happy fast path**: AI has zero critical question
 ## User input
 
 ```
-算仪玄 60 级、武器命破之刃精炼 1、Drive Disc 啄木鸟电音 4 件套（slot 1-4）+ 钢铁躯壳 2 件套（slot 5-6），
+算仪玄 60 级、武器青溟笼舍精炼 1、Drive Disc 啄木鸟电音 4 件套（slot 1-4）+ 激素朋克 2 件套（slot 5-6），
 slot 4 主词条暴击率，slot 5 主词条攻击力%，slot 6 主词条电属性伤害加成，
 面板值按 5★ 满级默认即可。
-本期 DA boss，60 级。一段普通攻击伤害。
+格莱特，60 级。一段普通攻击伤害。
 ```
 
 ## Expected AI behavior
 
 1. **Lang detect**: zh → session lang = zh.
-2. **Entity normalization**: same as build-yixuan-basic (仪玄/命破之刃/啄木鸟电音/钢铁躯壳/危局强袭战 → canonical ids).
+2. **Entity normalization**: same as build-yixuan-basic (仪玄/青溟笼舍/啄木鸟电音/激素朋克/危局强袭战 → canonical ids).
 3. **Field tier check**:
    - All critical fields **resolved from input**: agent level 60, refinement 1, full Drive Disc setIds + main stats, enemy id resolved.
    - Optional: panel stats explicitly said "5★ 满级默认即可" → user opts into Tier 2 default.
@@ -33,11 +33,11 @@ slot 4 主词条暴击率，slot 5 主词条攻击力%，slot 6 主词条电属�
 6. **Review/confirm gate** (short, since input was already detailed):
    ```
    AI: "snapshot 已组好:
-     - 仪玄 lv60, 命破之刃 R1
-     - 啄木鸟电音 4pc (slots 1-4) + 钢铁躯壳 2pc (slots 5-6)
+     - 仪玄 lv60, 青溟笼舍 R1
+     - 啄木鸟电音 4pc (slots 1-4) + 激素朋克 2pc (slots 5-6)
      - 主词条: slot 4 暴击率 / slot 5 攻击力% / slot 6 电属性增伤
      - 面板值: 5★ 满级 midpoint 推导面板默认 (用户已确认)
-     - 敌人: 本期 DA boss 60 级
+     - 敌人: 格莱特 60 级
      - 攻击段: 普通攻击一段
 
      直接算吗?"

--- a/examples/ai-plugin/prompts/build-yixuan-full.md
+++ b/examples/ai-plugin/prompts/build-yixuan-full.md
@@ -1,0 +1,76 @@
+# fixture · build-yixuan-full
+
+**Skill**: fairy-snapshot
+**Scenario**: user provides all critical fields up-front (level, refinement, full Drive Disc spec) → AI proceeds with no ask-user dialog, only review/confirm gate.
+**Lang**: zh
+
+This fixture demonstrates the **happy fast path**: AI has zero critical questions, snapshot generation is one-shot. Used by QA G3 to assert AI does NOT add unnecessary friction when input is complete.
+
+---
+
+## User input
+
+```
+算仪玄 60 级、武器命破之刃精炼 1、Drive Disc 啄木鸟电音 4 件套（slot 1-4）+ 钢铁躯壳 2 件套（slot 5-6），
+slot 4 主词条暴击率，slot 5 主词条攻击力%，slot 6 主词条电属性伤害加成，
+面板值按 5★ 满级默认即可。
+本期 DA boss，60 级。一段普通攻击伤害。
+```
+
+## Expected AI behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Entity normalization**: same as build-yixuan-basic (仪玄/命破之刃/啄木鸟电音/钢铁躯壳/危局强袭战 → canonical ids).
+3. **Field tier check**:
+   - All critical fields **resolved from input**: agent level 60, refinement 1, full Drive Disc setIds + main stats, enemy id resolved.
+   - Optional: panel stats explicitly said "5★ 满级默认即可" → user opts into Tier 2 default.
+   - No critical missing → **no ask-user dialog needed**.
+4. **Snapshot generation**: directly produce strict BattleSnapshot.
+5. **draftMetadata**:
+   - `defaultedFields`: only panel values (user explicitly opted into default).
+   - `unknownFields`: empty.
+   - `warnings`: 1 entry "panel-user-opt-into-default: no deviation warning (user accepted explicitly)".
+6. **Review/confirm gate** (short, since input was already detailed):
+   ```
+   AI: "snapshot 已组好:
+     - 仪玄 lv60, 命破之刃 R1
+     - 啄木鸟电音 4pc (slots 1-4) + 钢铁躯壳 2pc (slots 5-6)
+     - 主词条: slot 4 暴击率 / slot 5 攻击力% / slot 6 电属性增伤
+     - 面板值: 5★ 满级 midpoint 推导面板默认 (用户已确认)
+     - 敌人: 本期 DA boss 60 级
+     - 攻击段: 普通攻击一段
+
+     直接算吗?"
+   ```
+7. **User confirms** → chain to fairy-calc.
+
+## Expected output
+
+Snapshot JSON similar to `snapshots/yixuan-basic.snapshot.json` (same agent + weapon + Drive Disc set composition). Snapshot value is identical at the BattleSnapshot field level because the user-provided panel default is the same as the default chosen in build-yixuan-basic.
+
+draftMetadata differs:
+```json
+{
+  "defaultedFields": [
+    {
+      "path": "team[0].panel.{attack,critRate,critDamage,etherDamageBonus}",
+      "default": "5-star midpoint-derived panel value",
+      "rationale": "User explicitly opted into Tier 2 default with phrase '5★ 满级默认即可'.",
+      "userExplicitOptIn": true
+    }
+  ],
+  "unknownFields": [],
+  "warnings": [
+    "panel-user-opt-into-default: user explicitly accepted; no deviation warning needed"
+  ],
+  "askUserTurns": []
+}
+```
+
+## Acceptance assertions (QA G3)
+
+- AI must NOT ask any critical-field question when all are resolved from input.
+- AI must surface review/confirm gate (no skip to calc without confirm, per architecture).
+- AI must record user's explicit opt-in to defaults in `draftMetadata` (vs silent default in build-yixuan-basic).
+- Review summary must be concise (no over-explaining what user already said).
+- No critical fields silently filled.

--- a/examples/ai-plugin/prompts/build-yixuan-unknown.md
+++ b/examples/ai-plugin/prompts/build-yixuan-unknown.md
@@ -1,0 +1,110 @@
+# fixture · build-yixuan-unknown
+
+**Skill**: fairy-snapshot
+**Scenario**: user says "不知道" for critical field → AI surfaces consequences, user confirms anyway → snapshot draft proceeds with explicit unknown marker in draft metadata.
+**Lang**: zh
+
+This fixture covers the **critical-field unknown** path (per `prompt-templates.md` §4.1 "User says 'unknown' for critical").
+
+---
+
+## User input
+
+```
+算一下仪玄带啄木鸟电音 4 套伤害，武器我忘了具体是哪把了。
+```
+
+## Expected AI behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Entity normalization**:
+   - "仪玄" → `character.id=1371` ✓
+   - "啄木鸟电音" → `equipment.setId=31000` ✓
+   - W-Engine → unknown / not specified
+3. **Field tier check**:
+   - Critical: agent level (not specified) + W-Engine id (user says "忘了")
+   - Critical missing → AI must ask.
+4. **Initial ask-user (critical batch)**:
+   ```
+   AI: "需要 2 个关键字段:
+     1. 仪玄是几级?
+     2. 武器具体是哪把? 候选:
+        - 命破之刃 (S 级特征攻击) — Yixuan signature
+        - 街头狂迷
+        - 其他?
+     或者你可以告诉我武器是什么类型 (打击 / 异常 / 支援)，我帮你推断常见配的。"
+   ```
+5. **User reply** (says "unknown" for weapon):
+   ```
+   "60 级，武器真不知道，你随便挑一个。"
+   ```
+6. **Critical-unknown surface** (per §4.1 "User says 'unknown' for critical"):
+   ```
+   AI: "武器是关键字段，没指定的话:
+     - 选项 A: 帮你用 Yixuan 推荐武器 命破之刃 R1 (signature weapon, 与角色配套设计) — 结果会接近最大伤害预估
+     - 选项 B: 选个常见 4★ 武器，结果会显著偏低
+     - 选项 C: 跳过武器，snapshot 标 'weapon-unknown' warning，calc 仍能跑但结果可信度低
+
+     你倾向哪种?"
+   ```
+7. **User reply**:
+   ```
+   "选 A"
+   ```
+8. **AI proceeds with recommended weapon**:
+   ```
+   AI: "OK, 用命破之刃 R1 (Yixuan signature) 替代。如果你之后确认武器是别的，把 snapshot.json 改一下重新算就行。"
+   ```
+9. **Continue 2pc clarification + review/confirm gate** (similar to build-anby-ambiguous flow).
+10. **Snapshot generation**: produce strict BattleSnapshot with chosen weapon. **No `"unknown"` value in snapshot JSON** (per TL constraint `4a3b7196`).
+11. **draftMetadata** records:
+    - `defaultedFields`: includes `team[0].wEngine.id` defaulted to recommended via user-confirmed option A; AI must surface this in review.
+    - `warnings`: ["weapon-user-asked-recommend: AI selected Yixuan signature weapon per user option A"]
+
+## Alternative path — user picks option C (skip weapon, mark unknown)
+
+If user said "选 C" instead:
+
+```
+AI: "OK, snapshot 里我把武器槽留空 (per fairy schema)，draftMetadata 会标 'critical-field-unknown: team[0].wEngine.id'.
+     calc 是否能跑取决于 fairy schema 是否接受缺武器的 snapshot — 我先 review 给你看 schema validation 结果。"
+```
+
+If fairy schema requires weapon (critical), snapshot validation fails at fairy-calc preflight step → AI surfaces parseBattleSnapshot error and asks user to provide a weapon (or pick option A retroactively).
+
+**Important**: per TL constraint, `team[0].wEngine.id = "unknown"` (string) is NOT valid; either user picks a real weapon or schema rejects. The "unknown marker" is in `draftMetadata.unknownFields`, not in snapshot JSON.
+
+## Expected output
+
+If option A picked: snapshot JSON similar to `snapshots/yixuan-basic.snapshot.json` with weapon=14137.
+
+draftMetadata:
+```json
+{
+  "defaultedFields": [
+    {
+      "path": "team[0].wEngine.id",
+      "default": "14137 (Doom Blade, Yixuan signature)",
+      "rationale": "User chose option A 'AI recommends Yixuan signature weapon' when asked about unknown weapon.",
+      "expectedDeviationPct": "low (signature pairing is near-optimal)"
+    },
+    {
+      "path": "team[0].panel.{attack,critRate,critDamage,etherDamageBonus}",
+      "default": "5-star midpoint-derived panel",
+      "rationale": "Substat values not specified."
+    }
+  ],
+  "unknownFields": [],
+  "warnings": [
+    "weapon-user-asked-recommend: signature weapon used"
+  ]
+}
+```
+
+## Acceptance assertions (QA G3)
+
+- AI must surface 3 options (A/B/C) when user says "unknown" for critical W-Engine, not silently pick.
+- AI must not write `"unknown"` string into strict BattleSnapshot field (TL constraint).
+- AI must record the rationale in `draftMetadata.defaultedFields` for traceability.
+- If user picks option C (skip), AI must rely on schema validation at fairy-calc preflight to reject, not silently proceed.
+- AI must explain that user can re-run with corrected weapon later (UX best practice: surface remediation path).

--- a/examples/ai-plugin/prompts/build-yixuan-unknown.md
+++ b/examples/ai-plugin/prompts/build-yixuan-unknown.md
@@ -29,8 +29,8 @@ This fixture covers the **critical-field unknown** path (per `prompt-templates.m
    AI: "需要 2 个关键字段:
      1. 仪玄是几级?
      2. 武器具体是哪把? 候选:
-        - 命破之刃 (S 级特征攻击) — Yixuan signature
-        - 街头狂迷
+        - 青溟笼舍 (S 级特征攻击) — Yixuan signature
+        - 街头巨星
         - 其他?
      或者你可以告诉我武器是什么类型 (打击 / 异常 / 支援)，我帮你推断常见配的。"
    ```
@@ -41,7 +41,7 @@ This fixture covers the **critical-field unknown** path (per `prompt-templates.m
 6. **Critical-unknown surface** (per §4.1 "User says 'unknown' for critical"):
    ```
    AI: "武器是关键字段，没指定的话:
-     - 选项 A: 帮你用 Yixuan 推荐武器 命破之刃 R1 (signature weapon, 与角色配套设计) — 结果会接近最大伤害预估
+     - 选项 A: 帮你用 Yixuan 推荐武器 青溟笼舍 R1 (signature weapon, 与角色配套设计) — 结果会接近最大伤害预估
      - 选项 B: 选个常见 4★ 武器，结果会显著偏低
      - 选项 C: 跳过武器，snapshot 标 'weapon-unknown' warning，calc 仍能跑但结果可信度低
 
@@ -53,7 +53,7 @@ This fixture covers the **critical-field unknown** path (per `prompt-templates.m
    ```
 8. **AI proceeds with recommended weapon**:
    ```
-   AI: "OK, 用命破之刃 R1 (Yixuan signature) 替代。如果你之后确认武器是别的，把 snapshot.json 改一下重新算就行。"
+   AI: "OK, 用青溟笼舍 R1 (Yixuan signature) 替代。如果你之后确认武器是别的，把 snapshot.json 改一下重新算就行。"
    ```
 9. **Continue 2pc clarification + review/confirm gate** (similar to build-anby-ambiguous flow).
 10. **Snapshot generation**: produce strict BattleSnapshot with chosen weapon. **No `"unknown"` value in snapshot JSON** (per TL constraint `4a3b7196`).
@@ -84,7 +84,7 @@ draftMetadata:
   "defaultedFields": [
     {
       "path": "team[0].wEngine.id",
-      "default": "14137 (Doom Blade, Yixuan signature)",
+      "default": "14137 (Qingming Birdcage, Yixuan signature)",
       "rationale": "User chose option A 'AI recommends Yixuan signature weapon' when asked about unknown weapon.",
       "expectedDeviationPct": "low (signature pairing is near-optimal)"
     },

--- a/examples/ai-plugin/prompts/calc-yixuan.md
+++ b/examples/ai-plugin/prompts/calc-yixuan.md
@@ -1,0 +1,139 @@
+# fixture · calc-yixuan
+
+**Skill**: fairy-calc
+**Scenario**: invoke fairy CLI on validated BattleSnapshot, parse CalcResult, emit brief NL summary.
+**Lang**: zh + en mirror
+
+This fixture demonstrates the fairy-calc skill consuming a pre-validated snapshot (from fairy-snapshot chain or directly user-provided).
+
+---
+
+## Variant A — chained from fairy-snapshot (zh)
+
+### Context
+
+`fairy-snapshot` has just produced `snapshots/yixuan-basic.snapshot.json` and presented review/confirm to user. User confirmed → AI chains to fairy-calc.
+
+### AI behavior
+
+1. **Lang inherited**: zh (from session).
+2. **CLI preflight**:
+   - Check `fairy` (or `@randomplay/cli`) availability + version ≥ `minFairyCliVersion` (per `plugin.json`).
+   - If missing/old → error per `prompt-templates.md` §6.1.
+3. **CLI invocation**:
+   ```
+   fairy calc <snapshots/yixuan-basic.snapshot.json> --view verbose --lang zh
+   ```
+4. **Parse CalcResult**: load CLI stdout as JSON; validate shape.
+5. **Brief NL summary** (1-2 paragraphs):
+   ```
+   这次仪玄普通攻击一段的期望显示伤害是 7,622。
+   - 非暴击: 5,954
+   - 暴击: 10,718
+   - 关键计算链路: baseDamageZone 10,076 × damageBonusZone 1.3 × critZone 1.28 × defenseZone 0.4545 × resistance/vulnerability/daze/special 乘区 1.0
+
+   本次 CLI 输出没有 warnings/errors。
+
+   数据基于 nanoka@2.8。如有版本更新请重新 fetch。如有侵权请联系作者删除。
+   ```
+
+### Expected output
+
+- CalcResult JSON: see `expected/yixuan-basic.calc.json`.
+- Brief summary text: above NL summary (in zh).
+
+---
+
+## Variant B — direct snapshot input (en)
+
+### User input
+
+User has snapshot.json from elsewhere (saved from prior session / shared by teammate), wants to run calc:
+
+```
+run fairy calc on this snapshot:
+
+[paste snapshots/yixuan-basic.snapshot.json]
+```
+
+### AI behavior
+
+1. **Lang detect**: en → session lang = en.
+2. **Skip snapshot-builder**: input is valid snapshot JSON (passes parseBattleSnapshot precheck).
+3. **CLI preflight + invocation** (same as Variant A, with `--lang en`).
+4. **Brief NL summary** in en:
+   ```
+   Expected displayed damage for Yixuan basic attack hit 1 is 7,622.
+   - Non-crit: 5,954
+   - Crit: 10,718
+   - Key chain: baseDamageZone 10,076 × damageBonusZone 1.3 × critZone 1.28 × defenseZone 0.4545 × resistance/vulnerability/daze/special zones at 1.0
+
+   The CLI output has no warnings/errors for this fixture.
+
+   Data is based on nanoka@2.8. Re-fetch the data after game patches.
+   For takedown requests please contact the maintainer.
+   ```
+
+---
+
+## Edge case — CLI not installed
+
+### Context
+
+User invokes fairy-calc but `fairy` CLI not available on system.
+
+### AI behavior
+
+Per `prompt-templates.md` §6.1, AI surfaces install instruction and stops:
+
+```
+zh:
+  "你本地还没装 fairy CLI (或者版本比 0.1.2 老)。
+   请运行: pnpm dlx @randomplay/cli@latest
+   装好后再 ping 我，我们继续。"
+
+en:
+  "fairy CLI is not installed locally (or version is older than 0.1.2).
+   Please run: pnpm dlx @randomplay/cli@latest
+   Then ping me and we'll continue."
+```
+
+AI does **not** attempt to compute anything.
+
+---
+
+## Edge case — CLI returns error
+
+### Context
+
+CLI returns non-zero exit with stderr like:
+```
+parseBattleSnapshot: required field `team[0].panel.attack` missing
+```
+
+### AI behavior
+
+Per `prompt-templates.md` §6.2, AI translates stderr to user-friendly message:
+
+```
+zh:
+  "snapshot 校验没通过: 缺角色面板攻击力 (team[0].panel.attack 字段必填)。
+   通常的原因是 snapshot 里 panel 部分不完整。
+   要我帮你修一下吗? 需要你告诉我当前面板攻击力，或让我回到生成快照流程重新补字段。"
+```
+
+AI does NOT proceed with partial calc; does NOT fabricate result.
+
+---
+
+## Acceptance assertions (QA G4)
+
+- AI invokes `fairy calc <snapshot> --view verbose --lang <session-lang>` (exact command shape).
+- AI uses snapshot path or stdin per fairy CLI contract (TBD in TL impl).
+- AI parses CLI stdout as CalcResult JSON.
+- AI summary references only fields in actual CalcResult.
+- CLI failure → user-friendly error message, no partial output.
+- CLI not installed → install instruction surface, no calc attempt.
+- Lang flag forwarded correctly (zh → `--lang zh`, en → `--lang en`).
+- Disclaimer surfaced once per session (first response with live data).
+- Version preflight: `minFairyCliVersion` from `plugin.json` is the gate.

--- a/examples/ai-plugin/prompts/explain-yixuan-trace.md
+++ b/examples/ai-plugin/prompts/explain-yixuan-trace.md
@@ -1,0 +1,127 @@
+# fixture · explain-yixuan-trace
+
+**Skill**: fairy-explain
+**Scenario**: standalone explain — user pastes a CalcResult JSON, AI walks through every trace step with sourceRef resolution.
+**Lang**: zh + en mirror
+
+This fixture demonstrates the **standalone** path of fairy-explain (no chaining from snapshot-builder / calc). The input is `expected/yixuan-basic.calc.json`.
+
+---
+
+## Variant A — zh dialog
+
+### User input
+
+```
+帮我解释一下这个伤害怎么算出来的:
+
+[paste of expected/yixuan-basic.calc.json]
+```
+
+### Expected AI behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Parse CalcResult**: load JSON, walk `trace` array, resolve each `sourceRef`.
+3. **sourceRef resolution**:
+   - `examples.ai-plugin` + `character.1371.skill.basic` → "V1.2.2 AI plugin example fixture: 仪玄普通攻击一段"
+   - `buckets[?bucketId=baseDamageZone]` → "基础伤害区"
+   - `buckets[?bucketId=damageBonusZone]` → "伤害加成区"
+   - `buckets[?bucketId=critZone]` → "暴击期望区"
+   - `buckets[?bucketId=defenseZone]` → "防御区"
+   - `attackSegments[0].rawDamage` → "最终原始伤害公式"
+   - `attackSegments[0].segmentDisplayDamage` → "逐段向上取整后的显示伤害"
+4. **Walk trace step-by-step**: output paragraph-style explanation, each step shows multiplier + sourceRef + cumulative value.
+5. **Surface warnings**: if `warnings[]` is non-empty, include every warning key/message near the relevant step. This fixture has no warnings.
+6. **Disclaimer footer**: surfaced once (first response).
+
+### Expected output
+
+See `expected/yixuan-basic.explain.zh.md`.
+
+### Skill boundary assertions
+
+- AI does NOT invoke `fairy calc`.
+- AI does NOT modify the input CalcResult.
+- AI references only fields actually present in input JSON.
+- AI does NOT fabricate trace steps not in `CalcResult.trace`.
+
+---
+
+## Variant B — en dialog (mirror)
+
+### User input
+
+```
+explain how this damage was calculated:
+
+[paste of expected/yixuan-basic.calc.json]
+```
+
+### Expected AI behavior
+
+Identical CalcResult parse + sourceRef resolution; dialog and explanation in en.
+
+### Expected output
+
+See `expected/yixuan-basic.explain.en.md`.
+
+---
+
+## Edge case — malformed CalcResult
+
+### User input
+
+```
+解释这个:
+
+{ "summary": { "rawTotalDamage": 7621.12 }, "trace": "incomplete..."
+```
+
+### Expected AI behavior
+
+1. AI attempts JSON parse → fails (incomplete JSON).
+2. AI surfaces error per `prompt-templates.md` §6.4:
+   ```
+   AI: "你贴的内容不是有效的 fairy CalcResult JSON。常见原因:
+     - 截断了 (JSON 不完整)
+     - 字段被改了
+     - 不是 fairy 输出
+
+     请确认完整粘贴 `fairy calc ... --view verbose` 的完整输出。"
+   ```
+3. AI does NOT proceed; does NOT fabricate explanation from partial data.
+
+### Acceptance assertion (QA G5)
+
+- Malformed input → user-friendly error message (not raw parse error).
+- No partial explanation produced.
+
+---
+
+## Edge case — CalcResult with warning
+
+### User input
+
+User pastes a CalcResult that contains `warnings[*]` (not the yixuan-basic fixture, which has no warnings).
+
+### Expected AI behavior
+
+- AI surfaces every warning in the explanation, near the relevant trace step where applicable.
+- AI does not hide warnings even if user just asked "总伤害多少？" (per CONFIRM-? data integrity policy: warnings always shown).
+
+### Acceptance assertion (QA G5)
+
+- Every `warnings[*].code` and `message` from input must appear in AI output.
+- Warnings displayed in user-facing copy (translated if dialog lang differs from source).
+
+---
+
+## Acceptance assertions consolidated (QA G5)
+
+- Skill input contract: `CalcResult` JSON shape (per `packages/core/src/schema/calc-result.ts`).
+- AI references only `CalcResult.trace[*]` / `summary.*` / `warnings[*]` / `buckets[*].contributors[*].source` fields.
+- No fabrication of multiplier / step / sourceRef.
+- sourceRef strings resolved to user-friendly names (per dialog lang).
+- Warnings preserved.
+- Disclaimer surfaced (first response per session, with `<live-version>` populated from top-level `CalcResult.sourceVersion`).
+- No fairy CLI invocation.

--- a/examples/ai-plugin/snapshots/.gitkeep
+++ b/examples/ai-plugin/snapshots/.gitkeep
@@ -1,1 +1,0 @@
-# Filled by UX task #208.

--- a/examples/ai-plugin/snapshots/yixuan-basic.snapshot.json
+++ b/examples/ai-plugin/snapshots/yixuan-basic.snapshot.json
@@ -50,12 +50,12 @@
         {
           "id": "drive-slot-5",
           "slot": 5,
-          "setId": "32004"
+          "setId": "31400"
         },
         {
           "id": "drive-slot-6",
           "slot": 6,
-          "setId": "32004"
+          "setId": "31400"
         }
       ],
       "panel": {
@@ -94,7 +94,7 @@
     }
   ],
   "enemy": {
-    "enemyId": "monster_info.current_da_boss",
+    "enemyId": "30004",
     "level": 60,
     "rank": "boss",
     "maxHp": 1000000,

--- a/examples/ai-plugin/snapshots/yixuan-basic.snapshot.json
+++ b/examples/ai-plugin/snapshots/yixuan-basic.snapshot.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.2",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": ["current-live"]
+  },
+  "team": [
+    {
+      "agentId": "1371",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "skillLevels": {
+        "basic": 12
+      },
+      "mindscapeCinema": {
+        "level": 0
+      },
+      "wEngine": {
+        "id": "14137",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "32004"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "32004"
+        }
+      ],
+      "panel": {
+        "attack": 2200,
+        "maxHp": 12000,
+        "defense": 800,
+        "impact": 100,
+        "critRate": 0.35,
+        "critDamage": 0.8,
+        "etherDamageBonus": 0.3,
+        "sheerForce": 900
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1371"
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-basic-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1371"
+      },
+      "skillId": "basic",
+      "levelKey": "basic",
+      "multiplier": 4.58,
+      "attribute": "auricInk",
+      "tags": ["basic"],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "monster_info.current_da_boss",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "ether": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/snapshots/yixuan-full.snapshot.json
+++ b/examples/ai-plugin/snapshots/yixuan-full.snapshot.json
@@ -50,12 +50,12 @@
         {
           "id": "drive-slot-5",
           "slot": 5,
-          "setId": "32004"
+          "setId": "31400"
         },
         {
           "id": "drive-slot-6",
           "slot": 6,
-          "setId": "32004"
+          "setId": "31400"
         }
       ],
       "panel": {
@@ -94,7 +94,7 @@
     }
   ],
   "enemy": {
-    "enemyId": "monster_info.current_da_boss",
+    "enemyId": "30004",
     "level": 60,
     "rank": "boss",
     "maxHp": 1000000,

--- a/examples/ai-plugin/snapshots/yixuan-full.snapshot.json
+++ b/examples/ai-plugin/snapshots/yixuan-full.snapshot.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.2",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": ["current-live"]
+  },
+  "team": [
+    {
+      "agentId": "1371",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "skillLevels": {
+        "basic": 12
+      },
+      "mindscapeCinema": {
+        "level": 0
+      },
+      "wEngine": {
+        "id": "14137",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "31000"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "32004"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "32004"
+        }
+      ],
+      "panel": {
+        "attack": 2200,
+        "maxHp": 12000,
+        "defense": 800,
+        "impact": 100,
+        "critRate": 0.35,
+        "critDamage": 0.8,
+        "etherDamageBonus": 0.3,
+        "sheerForce": 900
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1371"
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-basic-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1371"
+      },
+      "skillId": "basic",
+      "levelKey": "basic",
+      "multiplier": 4.58,
+      "attribute": "auricInk",
+      "tags": ["basic"],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin",
+        "sourceVersion": "v1.2.2",
+        "dataPath": "character.1371.skill.basic"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "monster_info.current_da_boss",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "ether": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}


### PR DESCRIPTION
## Summary

- Fold UX #208 AI plugin example fixtures into `examples/ai-plugin/`.
- Add prompt scenarios for `fairy-snapshot`, `fairy-calc`, and `fairy-explain`, plus entity normalization fixtures and expected outputs.
- Calibrate `yixuan-basic` / `yixuan-full` snapshots to the current strict `BattleSnapshot` schema.
- Replace illustrative calc output with real `fairy calc --view verbose --lang zh --pretty` output for `yixuan-basic`.
- Update `docs/ai-plugin/prompt-templates.md` fixture pointers to the final file names.

## Notes

- `snapshots/*.snapshot.json` contain only strict `BattleSnapshot` fields.
- Draft-only reporting (`defaultedFields`, `unknownFields`, warnings, ask-user turns) lives in `expected/*.draft-metadata.json`.
- `fairy-snapshot` examples do not call `fairy calc`; chaining happens only after review/confirm via `fairy-calc`.

## Verification

- `git diff --check`
- `pnpm exec tsx --eval "import { readFileSync } from 'node:fs'; import { parseBattleSnapshot, parseCalcResult } from './packages/core/src/validators.ts'; for (const p of ['examples/ai-plugin/snapshots/yixuan-basic.snapshot.json','examples/ai-plugin/snapshots/yixuan-full.snapshot.json']) parseBattleSnapshot(JSON.parse(readFileSync(p, 'utf8'))); parseCalcResult(JSON.parse(readFileSync('examples/ai-plugin/expected/yixuan-basic.calc.json','utf8'))); console.log('ai plugin example JSON schema ok');"`
- `pnpm verify:ai-plugin`
- `pnpm check`
- `pnpm build`
- `pnpm test`
