### PR TITLE
feat(ai-plugin): scaffold V1.2.3 fairy-vision skill

### DIFF
--- a/.claude-plugin/plugins/fairy/plugin.json
+++ b/.claude-plugin/plugins/fairy/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "fairy",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "displayName": {
     "en": "fairy — ZZZ damage calculator",
     "zh": "fairy — 绝区零伤害计算器"
   },
-  "description": "AI-driven assistant for Zenless Zone Zero damage calculation. Build reviewable BattleSnapshot drafts from natural language, run the trusted fairy CLI, and explain trusted CalcResult JSON.",
+  "description": "AI-driven assistant for Zenless Zone Zero damage calculation. Read supported build screenshots, build reviewable BattleSnapshot drafts, run the trusted fairy CLI, and explain trusted CalcResult JSON.",
   "author": "LoTwT",
   "license": "MIT",
   "homepage": "https://github.com/LoTwT/fairy",
@@ -15,6 +15,7 @@
     "codex"
   ],
   "skills": [
+    "fairy-vision",
     "fairy-snapshot",
     "fairy-calc",
     "fairy-explain"
@@ -24,6 +25,7 @@
     "userJourneys": "docs/ai-plugin/user-journeys.md",
     "promptTemplates": "docs/ai-plugin/prompt-templates.md",
     "acceptance": "docs/ai-plugin/acceptance.md",
-    "decision": "docs/product/decisions/D-21-ai-plugin.md"
+    "decision": "docs/product/decisions/D-21-ai-plugin.md",
+    "visionDecision": "docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md"
   }
 }

--- a/.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md
@@ -72,3 +72,4 @@ a brief user-facing summary from the returned `CalcResult`.
 - `docs/ai-plugin/prompt-templates.md`
 - `docs/ai-plugin/acceptance.md`
 - `docs/product/decisions/D-21-ai-plugin.md`
+- `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`

--- a/.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md
@@ -69,3 +69,4 @@ Explain an existing fairy `CalcResult` JSON without rerunning calculation.
 - `docs/ai-plugin/prompt-templates.md`
 - `docs/ai-plugin/acceptance.md`
 - `docs/product/decisions/D-21-ai-plugin.md`
+- `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`

--- a/.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md
@@ -28,8 +28,8 @@ fairy. This skill structures input; it does not calculate damage.
 ## Inputs
 
 - `userBuildDescription`: natural language in zh, en, or mixed language.
-- `partialSnapshot`: optional `BattleSnapshot` draft, including future
-  V1.2.3 vision/OCR output.
+- `partialSnapshot`: optional `BattleSnapshot` draft, including V1.2.3
+  `fairy-vision` output.
 - `lang`: optional session language override, `zh` or `en`.
 
 ## Outputs
@@ -80,3 +80,4 @@ fairy. This skill structures input; it does not calculate damage.
 - `docs/ai-plugin/prompt-templates.md`
 - `docs/ai-plugin/acceptance.md`
 - `docs/product/decisions/D-21-ai-plugin.md`
+- `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`

--- a/.claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md
+++ b/.claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: fairy-vision
+description: Use when the user attaches a supported Zenless Zone Zero community-tool build screenshot and needs a reviewable BattleSnapshot draft. Requires a multimodal-capable host, extracts only source/draft/evidence/confidence metadata, redacts PII, and hands off to fairy-snapshot for review/edit before any CLI calculation.
+displayName:
+  en: Read screenshot
+  zh: 识别截图
+hostRequirement:
+  multimodal: required
+  fallbackOnUnsupportedHost: fairy-snapshot
+---
+
+# fairy-vision
+
+## Purpose
+
+Read one supported ZZZ community-tool screenshot and produce a reviewable
+`BattleSnapshot` draft plus `draftMetadata.evidence`. This skill structures
+image input; it does not calculate damage and it does not confirm the draft.
+
+## Trigger Phrases
+
+- read this screenshot
+- read my build screenshot
+- recognize screenshot
+- screenshot to snapshot
+- 识别截图
+- 从截图识别
+- 帮我读这张图
+- 看这张配装图
+
+## Inputs
+
+- `image`: required single screenshot. V1.2.3 supports one image only; multi-image
+  flows are deferred.
+- `text`: optional user context in zh, en, or mixed language.
+- `lang`: optional session language override, `zh` or `en`.
+
+Supported screenshot sources:
+
+- `zzz-workshop`: 绝区零工坊 community-tool build screenshots.
+- `miyoushe-record`: 米游社绝区零战绩 community-tool build screenshots.
+- `unknown`: unsupported or low-confidence source; fall back to
+  `fairy-snapshot` natural-language flow.
+
+## Outputs
+
+- `battleSnapshotDraft`: strict `BattleSnapshot` draft using total resolved panel
+  values only; no base/bonus split and no ad hoc fields.
+- `draftMetadata.sourceDetection`: source id, user-facing source label, and
+  confidence.
+- `draftMetadata.perFieldConfidence`: field path to `high`, `medium`, `low`, or
+  `missing`.
+- `draftMetadata.evidence`: visible base/bonus stat split, roll counts,
+  source/layout cues, and extracted-field evidence for review.
+- `draftMetadata.piiDetection`: PII kinds and redaction status only; raw UID,
+  username, or account identifiers are discarded.
+- `nextStep`: canonical handoff instruction to `fairy-snapshot` for ask-user
+  policy, review/edit, and confirmation.
+
+## Workflow
+
+1. Check host capability. If the host is not multimodal-capable or cannot read
+   the attached image, do not attempt extraction; fall back to `fairy-snapshot`
+   natural-language flow.
+2. Detect the screenshot source before extracting fields:
+   `zzz-workshop`, `miyoushe-record`, or `unknown`.
+3. Use the source-specific layout map to extract visible agent, W-Engine,
+   Drive Disc, panel total, roll-count, and related build fields.
+4. Resolve entities through packaged cleaned runtime data and public aliases.
+   Do not read raw source archives.
+5. Assign per-field confidence and collect `draftMetadata.evidence`.
+6. Detect PII such as UID or username, record only kind/status in metadata, and
+   discard raw values before handoff.
+7. Emit the draft and handoff instruction to `fairy-snapshot`; the user-facing
+   handoff must read as one continuous assistant conversation without exposing
+   internal skill names.
+
+## Boundaries
+
+- Do not call `fairy calc`, `@randomplay/cli`, or any CLI command.
+- Do not compute damage, daze, anomaly, disorder, multipliers, or result totals.
+- Do not produce a confirmed `BattleSnapshot`; only produce a reviewable draft.
+- Do not bypass downstream schema validation or the user review/edit gate.
+- Do not persist raw PII in snapshots, metadata, fixtures, logs, or examples.
+- Do not add `sourceDetection`, confidence, base/bonus, roll-count, or PII fields
+  to the strict `BattleSnapshot` schema; keep them in `draftMetadata`.
+- Do not read raw source archives or retired source snapshots.
+
+## Failure Policy
+
+- Unsupported source, low source confidence, or majority low field confidence:
+  fall back to `fairy-snapshot` natural-language flow and ask the user for the
+  missing build details.
+- Missing critical field: mark it as `missing` or low confidence in
+  `draftMetadata` and let `fairy-snapshot` apply the 3-tier ask-user policy.
+- Entity ambiguity: surface candidates to `fairy-snapshot` for user confirmation.
+- Host lacks image input: fail loud with a short instruction to describe the
+  build in text, then continue through `fairy-snapshot`.
+
+## References
+
+- `docs/ai-plugin/architecture.md`
+- `docs/ai-plugin/user-journeys.md`
+- `docs/ai-plugin/prompt-templates.md`
+- `docs/ai-plugin/acceptance.md`
+- `docs/product/decisions/D-21-ai-plugin.md`
+- `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`
+- `docs/ai-plugin/v1.2.3-vision/architecture.md`
+- `docs/ai-plugin/v1.2.3-vision/user-journeys.md`
+- `docs/ai-plugin/v1.2.3-vision/prompt-templates.md`
+- `docs/ai-plugin/v1.2.3-vision/acceptance.md`

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,25 +1,31 @@
 # fairy AI plugin · Codex usage notes
 
-V1.2.2 supports Codex as a compatibility surface, not a second full plugin
+V1.2.3 supports Codex as a compatibility surface, not a second full plugin
 runtime. Codex agents should use the same canonical skill contracts defined
 under `.claude-plugin/plugins/fairy/`.
 
 ## Skill Contracts
 
 - `.claude-plugin/plugins/fairy/plugin.json`
+- `.claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md`
 - `.claude-plugin/plugins/fairy/skills/fairy-snapshot/SKILL.md`
 - `.claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md`
 - `.claude-plugin/plugins/fairy/skills/fairy-explain/SKILL.md`
 
 ## Usage Rules
 
-1. Use `fairy-snapshot` when a user describes a ZZZ build and needs a
+1. Use `fairy-vision` when a multimodal-capable host receives one supported
+   community-tool build screenshot and needs a reviewable `BattleSnapshot`
+   draft plus extraction evidence. If image input is unavailable or source
+   confidence is low, fall back to text input through `fairy-snapshot`.
+2. Use `fairy-snapshot` when a user describes a ZZZ build and needs a
    reviewable `BattleSnapshot` draft.
-2. Use `fairy-calc` after user review/confirm or when the user already provides
+3. Use `fairy-calc` after user review/confirm or when the user already provides
    a `BattleSnapshot`.
-3. Use `fairy-explain` only for existing `CalcResult` JSON.
-4. Never calculate damage in model reasoning. Run `fairy calc` through the CLI.
-5. Do not use Cursor-specific configuration in V1.2.2.
+4. Use `fairy-explain` only for existing `CalcResult` JSON.
+5. Never calculate damage in model reasoning. Run `fairy calc` through the CLI.
+6. Do not expose internal skill handoff language in user-facing copy.
+7. Do not use Cursor-specific configuration in V1.2.3.
 
 ## Local Verification
 
@@ -36,3 +42,4 @@ The implementation and acceptance details live in:
 - `docs/ai-plugin/prompt-templates.md`
 - `docs/ai-plugin/acceptance.md`
 - `docs/product/decisions/D-21-ai-plugin.md`
+- `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`

--- a/docs/ai-plugin/acceptance.md
+++ b/docs/ai-plugin/acceptance.md
@@ -1,25 +1,28 @@
 # AI Plugin Acceptance Gates
 
-Status: V1.2.2 plan draft
+Status: V1.2.3 implementation baseline
 Owner: @QA
 Reviewers: @Product, @TechLead, @UX, @lo-user
 Related docs: `docs/ai-plugin/architecture.md`, `docs/ai-plugin/user-journeys.md`, `docs/ai-plugin/prompt-templates.md`, Product AI plugin decision log
 
-This document defines the QA acceptance gates for the V1.2.2 Fairy AI plugin MVP.
+This document defines the QA acceptance gates for the V1.2.3 Fairy AI plugin MVP.
 It is intentionally implementation-facing: the later implementation PR is only
 shippable when these gates are executable, documented, and passing.
 
 ## Scope
 
-V1.2.2 covers:
+V1.2.3 covers:
 
 - Claude Code plugin as the primary implementation.
 - Codex support through repository docs or a thin compatibility shim.
-- Three canonical skills:
+- Four canonical skills:
+  - `fairy-vision` / display label `识别截图`
   - `fairy-snapshot` / display label `生成快照`
   - `fairy-calc` / display label `计算伤害`
   - `fairy-explain` / display label `解释结果`
-- Two user entries:
+- Three user entries:
+  - user provides a supported community-tool screenshot, the agent chains
+    `fairy-vision`, `fairy-snapshot`, then `fairy-calc`;
   - user describes a build, the agent chains `fairy-snapshot` then `fairy-calc`;
   - user provides an existing `CalcResult`, the agent invokes `fairy-explain`.
 - The tri-layer i18n contract:
@@ -27,11 +30,12 @@ V1.2.2 covers:
   - user-facing copy supports zh/en;
   - data/query normalization supports zh/en where current `@randomplay/data` source data supports it.
 
-Out of scope for V1.2.2:
+Out of scope for V1.2.3:
 
 - `fairy-compare`; the AI plugin compare workflow remains deferred even if the
   CLI `fairy compare` command exists independently.
-- Screenshot/OCR/vision ingestion; V1.2.2 may document the V1.2.3 interface only.
+- In-game screenshots, OCR fallback, other source tools, and multi-image vision
+  ingestion.
 - Cursor parity implementation.
 - A standalone npm plugin package or marketplace distribution.
 
@@ -47,7 +51,7 @@ steps is a release blocker.
 
 ## Fixture Strategy
 
-V1.2.2 uses three fixture layers. Do not mirror every fixture in every language;
+V1.2.3 uses three fixture layers. Do not mirror every fixture in every language;
 instead, test the language boundary at the layer where it matters.
 
 | Fixture layer | Purpose | Language coverage |
@@ -82,13 +86,14 @@ The implementation PR must provide a discoverable Claude Code plugin tree:
 .claude-plugin/plugins/fairy/
   plugin.json
   skills/
+    fairy-vision/SKILL.md
     fairy-snapshot/SKILL.md
     fairy-calc/SKILL.md
     fairy-explain/SKILL.md
 ```
 
 Codex support must exist as repository documentation or a thin shim under
-`.codex/`. Cursor files must not be required for V1.2.2 acceptance.
+`.codex/`. Cursor files must not be required for V1.2.3 acceptance.
 
 Required `plugin.json` evidence:
 
@@ -102,13 +107,24 @@ Required `plugin.json` evidence:
 
 Required per-skill evidence:
 
-- canonical skill name: `fairy-snapshot`, `fairy-calc`, `fairy-explain`;
-- zh display label: `生成快照`, `计算伤害`, `解释结果`;
+- canonical skill name: `fairy-vision`, `fairy-snapshot`, `fairy-calc`,
+  `fairy-explain`;
+- zh display label: `识别截图`, `生成快照`, `计算伤害`, `解释结果`;
 - English canonical description;
 - trigger phrases, including zh/en user phrases;
 - inputs and outputs;
 - failure policy;
 - CLI binding policy where applicable.
+
+Required `fairy-vision` evidence:
+
+- multimodal-capable host requirement;
+- supported source ids `zzz-workshop` and `miyoushe-record`;
+- source detection, per-field confidence, PII redaction status, and
+  `draftMetadata.evidence` outputs;
+- handoff to `fairy-snapshot` for review/edit and missing critical fields;
+- no CLI call, no model-side calculation, no confirmed snapshot, and no raw PII
+  persistence.
 
 Acceptance checks:
 
@@ -117,7 +133,9 @@ Acceptance checks:
 - trigger phrases do not conflict in a way that routes the same prompt to the
   wrong skill without a deterministic priority;
 - all linked docs exist;
-- no V1.2.2 requirement references `.cursor/` as mandatory.
+- no V1.2.3 requirement references `.cursor/` as mandatory;
+- no unapproved skill directory exists; the approved set is exactly the four
+  canonical skills above.
 
 ## G2: CLI Binding and No-Model-Calculation
 
@@ -129,9 +147,11 @@ Required behavior:
 - `fairy-calc` checks for a compatible `fairy` / `@randomplay/cli` before use;
 - version mismatch fails loud with an install/upgrade instruction;
 - `fairy-calc` invokes `fairy calc <snapshot> --view verbose --lang <lang>`;
+- `fairy-vision` emits a reviewable screenshot-derived draft and draft metadata
+  only; it does not invoke the CLI, calculate, or produce a confirmed snapshot;
 - `fairy-snapshot` emits a reviewable draft and draft metadata only; after user
   review/confirm, `fairy-calc` validates/calculates through the same `fairy calc`
-  path, because no dedicated `--preflight` flag exists in V1.2.2;
+  path, because no dedicated `--preflight` flag exists in V1.2.3;
 - `fairy-explain` consumes an existing `CalcResult` and does not calculate.
 
 Forbidden behavior:
@@ -233,7 +253,7 @@ Acceptance checks:
 
 ## G6: Compare Workflow (Deferred)
 
-V1.2.2 must explicitly mark compare out of scope.
+V1.2.3 must explicitly mark AI-plugin compare workflow out of scope.
 
 Acceptance checks:
 
@@ -243,7 +263,7 @@ Acceptance checks:
 - metadata verifier fails if a compare skill appears without an explicit Product
   decision and CLI prerequisite.
 
-G6 is not a release blocker for V1.2.2 if it is documented as deferred.
+G6 is not a release blocker for V1.2.3 if it is documented as deferred.
 
 ## G7: Version Sync
 
@@ -255,12 +275,13 @@ Acceptance checks:
 - skill docs state supported `@randomplay/cli` range;
 - runtime preflight reports the discovered CLI version;
 - too-old or missing CLI fails loud with exact install/upgrade commands;
-- V1.2.2 docs do not claim support for unreleased CLI commands.
+- V1.2.3 docs do not claim support for unreleased CLI commands.
 
 ## G8: Privacy and Local-Data Boundary
 
-V1.2.2 must be local-first and text-only. It must not add OCR, vision, remote
-upload, or raw-source processing behavior.
+V1.2.3 must remain local-first except for the host tool's normal model
+transport. It adds supported screenshot input, but must not add OCR fallback,
+arbitrary remote upload behavior, or raw-source processing behavior.
 
 Acceptance checks:
 
@@ -268,14 +289,17 @@ Acceptance checks:
   context unless the host AI tool itself sends prompts to its provider;
 - no implementation reads `packages/data/source/**` or deleted retired raw source
   archives;
-- no V1.2.2 flow requires screenshot upload, OCR, or external vision service;
-- if future V1.2.3 vision/OCR is described, it must route through review/edit,
-  snapshot validation, and calc validation before calculation;
+- `fairy-vision` records PII kind/status only and does not persist raw UID,
+  username, or account identifiers in artifacts;
+- screenshot input routes through review/edit, snapshot validation, and calc
+  validation before calculation;
+- OCR fallback, in-game screenshots, other source tools, and multi-image input
+  remain explicitly deferred;
 - user-facing disclaimers do not imply official HoYoverse/miHoYo support.
 
 ## G9: Distribution Smoke
 
-V1.2.2 ships repo-internal plugin files, not a standalone npm plugin package.
+V1.2.3 ships repo-internal plugin files, not a standalone npm plugin package.
 
 Required smoke:
 
@@ -283,9 +307,10 @@ Required smoke:
 - Codex documentation/shim is present and references the same canonical skill
   names;
 - metadata verifier passes;
-- a scripted fixture can execute the three MVP skill workflows or their closest
+- a scripted fixture can execute the four MVP skill workflows or their closest
   deterministic stand-ins:
   - discovery;
+  - vision metadata/source-detection fixture;
   - snapshot generation fixture;
   - CLI calc fixture;
   - explain fixture.
@@ -305,13 +330,13 @@ Required docs:
 - minimum Fairy CLI version;
 - install/setup steps for Claude Code;
 - Codex usage notes;
-- three skill descriptions with canonical names and zh display labels;
+- four skill descriptions with canonical names and zh display labels;
 - at least one complete zh user journey and one complete en user journey;
 - ask-user examples for critical and optional fields;
 - error recovery examples for missing CLI, version mismatch, invalid snapshot,
   and unsupported compare request;
 - data-source/disclaimer copy in zh/en;
-- V1.2.3 screenshot/vision forward-spec marked as future work.
+- V1.2.3 screenshot/vision source scope and unsupported future-work boundaries.
 
 Acceptance checks:
 
@@ -335,8 +360,9 @@ The implementation PR is not QA-passable until the following evidence is present
 8. `fairy-snapshot` fixture smoke
 9. `fairy-calc` fixture smoke
 10. `fairy-explain` fixture smoke
-11. zh/en user-facing output smoke
-12. package/release gates already used by Fairy when release prep begins
+11. `fairy-vision` metadata/source-detection fixture smoke
+12. zh/en user-facing output smoke
+13. package/release gates already used by Fairy when release prep begins
 
 The exact command names may be finalized by @TechLead in the plan PR, but each
 gate above needs an executable command or a documented manual check before
@@ -344,11 +370,12 @@ implementation can ship.
 
 ## Release-Readiness Addendum
 
-When V1.2.2 ships, release-readiness must verify:
+When V1.2.3 ships, release-readiness must verify:
 
 - published package versions remain synchronized;
 - CLI version satisfies plugin `minFairyCliVersion`;
 - plugin docs in the tag match the released package versions;
 - metadata and fixture verifiers pass on the release tag;
 - fresh install of `@randomplay/cli` can run the plugin fixture commands;
-- no deferred compare or screenshot behavior is advertised as shipped.
+- no deferred compare, OCR, in-game screenshot, or multi-image behavior is
+  advertised as shipped.

--- a/docs/ai-plugin/architecture.md
+++ b/docs/ai-plugin/architecture.md
@@ -1,15 +1,15 @@
-# AI Plugin V1.2.2 Architecture
+# AI Plugin V1.2.3 Architecture
 
-Status: proposed for V1.2.2 plan review
+Status: implementation baseline after V1.2.3 vision plan approval
 Owner: TechLead
 Reviewers: Product, UX, QA, lo-user
 Scope: Claude Code Plugin and Codex compatibility plan for Fairy AI skills
 
 ## Goal
 
-Build a thin AI plugin layer that lets a ZZZ player describe a build, produce a
-reviewable `BattleSnapshot`, run the trusted Fairy CLI, and explain the trusted
-CLI output.
+Build a thin AI plugin layer that lets a ZZZ player read a supported
+community-tool screenshot or describe a build, produce a reviewable
+`BattleSnapshot`, run the trusted Fairy CLI, and explain the trusted CLI output.
 
 The core rule is:
 
@@ -23,24 +23,28 @@ model reasoning as calculation evidence.
 
 | Item | Decision |
 | --- | --- |
-| AI.0 | V1.2.2 is a plan PR followed by an implementation PR; plugin files stay inside this repo. |
-| AI.1 | V1.2.2 supports Claude Code Plugin and Codex only; Cursor is deferred. |
+| AI.0 | AI plugin files stay inside this repo; no standalone plugin package is shipped in V1.2.3. |
+| AI.1 | V1.2.3 supports Claude Code Plugin and Codex only; Cursor is deferred. |
 | AI.2 | `fairy-compare` is deferred to a follow-up plugin patch; CLI compare may exist independently first. |
 | U1 | Primary persona is a ZZZ player using natural language. |
-| U2 | MVP has three internal skills and two user-facing entries. |
+| U2 | V1.2.3 has four approved internal skills and three user-facing entries. |
 | U3 | i18n uses a tri-layer contract: English canonical layer, zh/en user-facing layer, and zh/en data/query layer where source data supports it. |
-| AI.3 | Screenshot/OCR is deferred to V1.2.3 and must enter through the same snapshot draft contract. |
-| AI.4 | V1.2.2 ships MVP only; marketplace/package distribution and extra skills are later patches. |
+| AI.3 | V1.2.3 adds supported community-tool screenshot input through `fairy-vision`; OCR, in-game screenshots, and multi-image flows remain deferred. |
+| AI.4 | V1.2.3 ships MVP vision support only; marketplace/package distribution and extra skills are later patches. |
+| D22.K1 | `fairy-vision` is a separate approved skill; the approved set is `fairy-vision`, `fairy-snapshot`, `fairy-calc`, `fairy-explain`. |
+| D22.K2 | `fairy-vision` emits a draft and evidence only; it does not call the CLI, calculate, bypass schema validation, or persist raw PII. |
+| D22.K4 | Cross-skill handoff is invisible to users; user-facing copy must not expose internal skill names or orchestration phrasing. |
+| D22.K5 | `fairy-vision` requires a multimodal-capable host and falls back to the natural-language path when image input is unavailable. |
 
 ## Non-Goals
 
-V1.2.2 does not include:
+V1.2.3 does not include:
 
 - a standalone npm package for the plugin;
 - Cursor implementation beyond documented deferral;
 - `fairy-compare` skill behavior or direct `fairy compare` binding in the AI
   plugin;
-- screenshot recognition, OCR, or vision model integration;
+- in-game screenshot recognition, OCR fallback, or multi-image vision flows;
 - a new calculation API, formula implementation, or raw source reader;
 - a new `fairy calc --preflight` flag.
 
@@ -61,6 +65,8 @@ before any skill depends on it.
     fairy/
       plugin.json
       skills/
+        fairy-vision/
+          SKILL.md
         fairy-snapshot/
           SKILL.md
         fairy-calc/
@@ -87,12 +93,12 @@ examples/
 
 `.claude-plugin/plugins/fairy/` is the primary implementation target.
 `.codex/README.md` documents how Codex should use the same skill contract. It is
-not a second full implementation in V1.2.2.
+not a second full implementation in V1.2.3.
 
 ## Component Model
 
 ```text
-User text / files
+User text / files / supported screenshot
       |
       v
 Claude Code Plugin / Codex instructions
@@ -104,6 +110,7 @@ Claude Code Plugin / Codex instructions
       |
       v
 Skills
+  fairy-vision    -> BattleSnapshot draft + draftMetadata.evidence -> review handoff
   fairy-snapshot  -> BattleSnapshot draft -> review/confirm handoff
   fairy-calc      -> CLI validation/calculation -> CalcResult JSON + brief summary
   fairy-explain   -> existing CalcResult  -> explanation over actual fields
@@ -119,6 +126,45 @@ The plugin may orchestrate skills in one conversation, but each skill keeps a
 separate contract so fixtures and QA gates can validate behavior independently.
 
 ## Skills
+
+### `fairy-vision`
+
+Display labels:
+
+- zh: `识别截图`
+- en: `Read Screenshot`
+
+Purpose: read one supported community-tool screenshot and produce a reviewable
+`BattleSnapshot` draft plus `draftMetadata.evidence`.
+
+Inputs:
+
+- one image attachment from a multimodal-capable host;
+- optional user text for context not visible in the screenshot;
+- optional language override.
+
+Outputs:
+
+- candidate `BattleSnapshot` draft using total resolved panel values only;
+- `draftMetadata.sourceDetection` with `zzz-workshop`, `miyoushe-record`, or
+  `unknown`;
+- `draftMetadata.perFieldConfidence` and `draftMetadata.evidence`;
+- `draftMetadata.piiDetection` with kind/status only, never raw UID or username;
+- handoff instruction to `fairy-snapshot` for review/edit and ask-user policy.
+
+Rules:
+
+- declare the multimodal host requirement in skill metadata;
+- detect the source before field extraction;
+- use source-specific layout maps for 绝区零工坊 and 米游社 screenshots;
+- resolve entities through packaged cleaned data and public aliases, not raw
+  source files;
+- keep source detection, base/bonus split, roll counts, confidence, and PII
+  status in `draftMetadata`, not in strict `BattleSnapshot`;
+- do not call the CLI, calculate, explain, compare builds, or produce a
+  confirmed snapshot;
+- if the host cannot read images, source confidence is low, or source is
+  unsupported, fall back to `fairy-snapshot` natural-language flow.
 
 ### `fairy-snapshot`
 
@@ -217,10 +263,11 @@ Rules:
 
 ## Skill Orchestration
 
-V1.2.2 has two user-facing entries:
+V1.2.3 has three user-facing entries:
 
 | Entry | Internal skills | User-facing behavior |
 | --- | --- | --- |
+| Read screenshot, then calculate | `fairy-vision` -> `fairy-snapshot` -> `fairy-calc` | User attaches one supported community-tool screenshot, AI extracts a draft and evidence, asks for review/edit or missing critical fields, then `fairy-calc` validates with CLI and summarizes the result. |
 | Build and calculate | `fairy-snapshot` -> `fairy-calc` | User describes a build, AI drafts a snapshot, asks for critical fields, asks for review/confirm, then `fairy-calc` validates with CLI and summarizes the result. |
 | Explain existing result | `fairy-explain` | User pastes or references a `CalcResult`; AI explains the trusted output without recalculation. |
 
@@ -228,9 +275,15 @@ The first entry may be autonomous inside one conversation, but the snapshot draf
 must be reviewable. Critical uncertainty blocks handoff to `fairy-calc` until
 the user answers or explicitly accepts a reduced path that the CLI can validate.
 
+The `fairy-vision` chain is a prompt contract, not a runtime orchestration
+layer. The skill emits `{ battleSnapshotDraft, draftMetadata, nextStep }`; the
+host then presents the review/edit gate and continues the existing
+`fairy-snapshot` -> `fairy-calc` flow. User-facing copy must not say
+"invoking", "transferring to", "handing off to", or expose skill names.
+
 ## Language Contract
 
-V1.2.2 uses three language layers.
+V1.2.3 uses three language layers.
 
 | Layer | Language | Examples |
 | --- | --- | --- |
@@ -259,9 +312,10 @@ pnpm dlx @randomplay/cli@latest --help
 pnpm dlx @randomplay/cli@latest calc <snapshot.json> --view verbose --lang zh
 ```
 
-The plugin contract declares a minimum CLI version. V1.2.2 should start at
-`@randomplay/cli >= 0.1.2`, because V0.1.2 is the first release after data
-ownership cleanup and package payload stabilization.
+The plugin contract declares a minimum CLI version. V1.2.3 keeps
+`@randomplay/cli >= 0.1.2` for this skeleton because `fairy-vision` does not add
+new CLI behavior; later harness or release-prep patches may raise it if a new
+CLI capability becomes required.
 
 The implementation must not:
 
@@ -275,7 +329,7 @@ The implementation must not:
 `plugin.json` should declare:
 
 - plugin name and version;
-- supported tool surfaces (`claude-code`, `codex-docs`);
+- supported tool surfaces (`claude-code`, `codex`);
 - minimum Fairy CLI version;
 - canonical skills and their display labels;
 - documentation entry points.
@@ -316,31 +370,33 @@ Disallowed inputs:
 
 ## Privacy And External Models
 
-V1.2.2 is text-only. The plugin should treat snapshots, user descriptions, and
+The plugin should treat screenshots, snapshots, user descriptions, and
 calculation outputs as user-provided local context. If a host tool sends prompts
-to an external model, that is the host tool's normal behavior and should be
-documented in user-facing onboarding.
+or images to an external model, that is the host tool's normal behavior and
+should be documented in user-facing onboarding.
 
-V1.2.2 does not add new network calls beyond package installation commands the
-user explicitly runs.
+V1.2.3 does not add new network calls beyond package installation commands the
+user explicitly runs. `fairy-vision` records PII detection/redaction status only
+and discards raw account identifiers before any artifact handoff.
 
-## V1.2.3 Screenshot Forward Contract
+## V1.2.3 Screenshot Contract
 
-Screenshot recognition is deferred. The future V1.2.3 pipeline must still enter
-through the same snapshot contract:
+Supported community-tool screenshot recognition enters through the same snapshot
+draft contract:
 
 ```text
 screenshot
-  -> vision/OCR extraction
+  -> fairy-vision extraction
   -> BattleSnapshot draft
+  -> draftMetadata.evidence
   -> user review/edit
   -> fairy calc validation
   -> result/explanation
 ```
 
 The screenshot path must not introduce a parallel snapshot schema. Low
-confidence or failed extraction should fall back to the `fairy-snapshot` natural
-language dialog.
+confidence, failed extraction, unsupported sources, or unavailable multimodal
+host capability fall back to the `fairy-snapshot` natural-language dialog.
 
 ## Release And Verification Plan
 
@@ -356,7 +412,7 @@ Implementation PR deliverables:
 
 - Claude Code plugin skeleton;
 - Codex usage docs;
-- three skills;
+- four skills;
 - metadata verifier;
 - 3-5 prompt/snapshot/expected fixtures;
 - smoke tests for discovery, CLI binding, snapshot validation, calc output, and

--- a/docs/ai-plugin/prompt-templates.md
+++ b/docs/ai-plugin/prompt-templates.md
@@ -1,6 +1,6 @@
 # fairy AI plugin · Prompt templates & i18n
 
-- Status: V1.2.2 plan draft (Phase B)
+- Status: V1.2.3 implementation baseline
 - Owner: @UX
 - Drafted: 2026-05-16
 - Companion: `docs/ai-plugin/user-journeys.md` (UX) · `docs/ai-plugin/architecture.md` (TL) · `docs/ai-plugin/acceptance.md` (QA) · `docs/product/decisions/D-21-ai-plugin.md` (Product)
@@ -22,18 +22,19 @@ This doc is structured to mirror the contract: §2-§3 are Layer 1 (EN only); §
 ```jsonc
 {
   "name": "fairy",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "displayName": {
     "en": "fairy — ZZZ damage calculator",
     "zh": "fairy — 绝区零伤害计算器"
   },
-  "description": "AI-driven damage calculator for Zenless Zone Zero. Build snapshots from natural language, run fairy CLI, and explain the math.",
+  "description": "AI-driven damage calculator for Zenless Zone Zero. Read supported build screenshots, build snapshots from natural language, run fairy CLI, and explain the math.",
   "author": "LoTwT",
   "license": "MIT",
   "homepage": "https://github.com/LoTwT/fairy",
   "minFairyCliVersion": "0.1.2",
   "supportedTools": ["claude-code", "codex"],
   "skills": [
+    "fairy-vision",
     "fairy-snapshot",
     "fairy-calc",
     "fairy-explain"
@@ -44,7 +45,7 @@ This doc is structured to mirror the contract: §2-§3 are Layer 1 (EN only); §
 **Notes**:
 - `displayName` is the only field with embedded localization; rendered by tool host based on user lang preference. Everything else is English canonical.
 - `minFairyCliVersion` is enforced by skill preflight; mismatch → fail-loud with install hint (see §6).
-- `supportedTools` declares V1.2.2 scope; Cursor explicitly not in list.
+- `supportedTools` declares V1.2.3 scope; Cursor explicitly not in list.
 
 ---
 
@@ -52,7 +53,56 @@ This doc is structured to mirror the contract: §2-§3 are Layer 1 (EN only); §
 
 Each skill ships with a `SKILL.md` file under `.claude-plugin/plugins/fairy/skills/<skill>/`. The skill's spec is English-canonical.
 
-### 3.1 fairy-snapshot
+### 3.1 fairy-vision
+
+```yaml
+---
+name: fairy-vision
+displayName:
+  en: Read screenshot
+  zh: 识别截图
+description: >
+  Read a supported community-tool ZZZ build screenshot (绝区零工坊 or 米游社)
+  and produce a reviewable BattleSnapshot draft plus draftMetadata.evidence.
+  Hands off to fairy-snapshot for ask-user dialog and review/edit before any
+  CLI calculation.
+hostRequirement:
+  multimodal: required
+  fallbackOnUnsupportedHost: fairy-snapshot
+trigger:
+  phrases:
+    - "read this screenshot"
+    - "read my build screenshot"
+    - "recognize screenshot"
+    - "screenshot to snapshot"
+    - "识别截图"
+    - "从截图识别"
+    - "帮我读这张图"
+    - "看这张配装图"
+  patterns:
+    - input contains a single image attachment plus optional user text
+inputs:
+  - image: required single screenshot; multi-image flows are deferred
+  - text: optional context not visible in the screenshot
+outputs:
+  - battleSnapshotDraft: strict BattleSnapshot draft with total panel values only
+  - draftMetadata.sourceDetection: "zzz-workshop" | "miyoushe-record" | "unknown"
+  - draftMetadata.perFieldConfidence: field path -> high | medium | low | missing
+  - draftMetadata.evidence: source cues, visible base/bonus split, roll counts, field evidence
+  - draftMetadata.piiDetection: PII kind/status only; raw UID or username discarded
+calls:
+  - none directly; review/edit happens in fairy-snapshot and validation/calculation happens in fairy-calc
+boundary:
+  - requires a multimodal-capable host
+  - never invoke the CLI
+  - never compute damage
+  - never produce a confirmed BattleSnapshot
+  - never persist raw PII
+  - never write confidence/source/base/bonus metadata into strict BattleSnapshot fields
+---
+```
+
+### 3.2 fairy-snapshot
 
 ```yaml
 ---
@@ -94,7 +144,7 @@ boundary:
 ---
 ```
 
-### 3.2 fairy-calc
+### 3.3 fairy-calc
 
 ```yaml
 ---
@@ -134,7 +184,7 @@ boundary:
 ---
 ```
 
-### 3.3 fairy-explain
+### 3.4 fairy-explain
 
 ```yaml
 ---

--- a/docs/ai-plugin/user-journeys.md
+++ b/docs/ai-plugin/user-journeys.md
@@ -1,14 +1,14 @@
 # fairy AI plugin · User Journeys
 
-- Status: V1.2.2 plan draft (Phase B)
+- Status: V1.2.3 implementation baseline
 - Owner: @UX
 - Drafted: 2026-05-16
 - Companion: `docs/ai-plugin/prompt-templates.md` (UX) · `docs/ai-plugin/architecture.md` (TL) · `docs/ai-plugin/acceptance.md` (QA) · `docs/product/decisions/D-21-ai-plugin.md` (Product)
-- Scope lock per Product D-21: 8 decisions locked 4-way; tri-layer i18n; 3 skills; 2 user entries; Claude Code + Codex only; V1.2.3 OCR forward-spec.
+- Scope lock per Product D-21 + D-22: tri-layer i18n; 4 approved skills; 3 user entries; Claude Code + Codex only; community-tool screenshot input via `fairy-vision`; in-game/OCR/multi-image deferred.
 
 ## How to read this document
 
-This is the **user-journey contract** for V1.2.2 AI plugin. It defines who uses the plugin, how they reach it, what each skill does for them, and how the plugin handles missing data / errors / language preference. The contract that QA validates is in `acceptance.md`; the implementation contract is in `architecture.md`; the prompt strings are in `prompt-templates.md`.
+This is the **user-journey contract** for the V1.2.3 AI plugin. It defines who uses the plugin, how they reach it, what each skill does for them, and how the plugin handles missing data / errors / language preference. The contract that QA validates is in `acceptance.md`; the implementation contract is in `architecture.md`; the prompt strings are in `prompt-templates.md`.
 
 Reading order:
 - @TechLead implementing skills → §2 user flows + §3 ask-user policy + §4 error recovery + §7 V1.2.3 forward-spec
@@ -19,7 +19,7 @@ Reading order:
 
 ## 1. Personas
 
-V1.2.2 primary persona is **P1**; P2 / P3 are secondary and not optimization targets. Persona priority is decision input for every UX choice in this doc.
+V1.2.3 primary persona is **P1**; P2 / P3 are secondary and not optimization targets. Persona priority is decision input for every UX choice in this doc.
 
 ### P1 — ZZZ player (primary)
 
@@ -39,13 +39,46 @@ V1.2.2 primary persona is **P1**; P2 / P3 are secondary and not optimization tar
 
 - Another agent in a higher-level workflow (e.g., a build optimizer) needs to invoke fairy.
 - Reaches the plugin as a callable contract — needs stable trigger metadata, deterministic JSON I/O, and version-pinned behavior.
-- Not a V1.2.2 optimization target; covered as a side-effect of P2 contracts being clean.
+- Not a V1.2.3 optimization target; covered as a side-effect of P2 contracts being clean.
 
 ---
 
 ## 2. User entries & skill flows
 
-V1.2.2 ships **2 user entries** backed by **3 internal skills**. The chaining model is **A — AI-autonomous chain** with explicit review/confirm at critical steps; alternative B (user manually triggers each skill) is not implemented.
+V1.2.3 ships **3 user entries** backed by **4 internal skills**. The chaining model is **A — AI-autonomous chain** with explicit review/confirm at critical steps; alternative B (user manually triggers each skill) is not implemented.
+
+### Entry 0 — Screenshot read & calc (P1 primary)
+
+```
+User attaches one supported community-tool screenshot (绝区零工坊 or 米游社):
+  "帮我读这张图，然后算一下"
+
+AI (host is multimodal-capable):
+  invokes fairy-vision
+    ↓ source detection (zzz-workshop / miyoushe-record / unknown)
+    ↓ per-source field extraction
+    ↓ per-field confidence + draftMetadata.evidence
+    ↓ raw PII discarded; piiDetection records kind/status only
+  ⇒ BattleSnapshot draft + draftMetadata
+
+  AI presents one continuous review/edit gate to the user:
+    "我从截图里读到了这些内容，请确认是否正确..."
+
+  User confirms or corrects fields.
+
+  AI continues through fairy-snapshot review/confirm policy, then fairy-calc CLI
+  validation/calculation.
+```
+
+**Critical UX guarantees**:
+- AI never exposes internal handoff phrasing such as "invoking", "transferring
+  to", or skill-name routing in user-facing copy.
+- AI never calc-runs directly from screenshot extraction. The user sees and can
+  correct the draft first.
+- Low source confidence, unsupported source, or unavailable image input falls
+  back to the `fairy-snapshot` natural-language path.
+- Source detection, base/bonus split, roll-counts, confidence, and PII status
+  remain in `draftMetadata`; strict `BattleSnapshot` keeps only schema fields.
 
 ### Entry 1 — Build & calc (P1 primary)
 
@@ -122,11 +155,12 @@ The user does not pick a skill name. The AI agent routes based on trigger phrase
 
 | User input shape | Route |
 |---|---|
+| One image attachment from supported source | `fairy-vision` → `fairy-snapshot` → `fairy-calc` |
 | NL build description (no JSON) | `fairy-snapshot` → auto-chain → `fairy-calc` |
 | Pasted snapshot JSON | `fairy-calc` (skip snapshot-builder if input passes parseBattleSnapshot) |
 | Pasted CalcResult JSON | `fairy-explain` (standalone) |
 | "explain this" / "trace breakdown" + JSON | `fairy-explain` (trace alias) |
-| Ambiguous | Ask user which workflow they want |
+| Ambiguous or unsupported image | Ask user which workflow they want, or fall back to `fairy-snapshot` text flow |
 
 Trigger phrases per skill: see `prompt-templates.md` §Trigger phrases.
 
@@ -247,7 +281,7 @@ Never invent a trace; never explain "what it probably should have been".
 
 ## 5. Lang detection & override
 
-V1.2.2 uses **(ii) auto-detect from input** as the default, with explicit override patterns sticky per session.
+V1.2.3 uses **(ii) auto-detect from input** as the default, with explicit override patterns sticky per session.
 
 ### Detection rules
 
@@ -283,21 +317,23 @@ When the user first invokes any fairy skill (or asks `/help fairy`), AI emits:
 ```
 zh:
   "fairy 是 Zenless Zone Zero 的伤害计算器。
-   我能帮你做三件事：
-   1. 用自然语言描述你的构筑，我帮你组 snapshot 并算伤害（生成快照 + 计算伤害）
-   2. 解释 fairy 算出来的结果，让你看懂每一步（解释结果）
-   3. 校验你的 snapshot.json 是否符合 fairy schema
+   我能帮你做四件事：
+   1. 读绝区零工坊 / 米游社配装截图，先给你确认，再算伤害（识别截图）
+   2. 用自然语言描述你的构筑，我帮你组 snapshot 并算伤害（生成快照 + 计算伤害）
+   3. 解释 fairy 算出来的结果，让你看懂每一步（解释结果）
+   4. 校验你的 snapshot.json 是否符合 fairy schema
 
-   现在告诉我你想算什么？或者直接贴一个 CalcResult JSON 给我解释。"
+   现在发截图、告诉我你想算什么，或者直接贴一个 CalcResult JSON 给我解释。"
 
 en:
   "fairy is a Zenless Zone Zero damage calculator.
-   I can help you with three things:
-   1. Describe your build in natural language — I'll build the snapshot and run the calc.
-   2. Explain a fairy CalcResult — walk through each multiplier and source.
-   3. Validate your snapshot.json against the fairy schema.
+   I can help you with four things:
+   1. Read a supported community-tool build screenshot, ask you to confirm it, then run the calc.
+   2. Describe your build in natural language — I'll build the snapshot and run the calc.
+   3. Explain a fairy CalcResult — walk through each multiplier and source.
+   4. Validate your snapshot.json against the fairy schema.
 
-   What do you want to calculate? Or paste a CalcResult JSON and I'll explain it."
+   Send a screenshot, describe what you want to calculate, or paste a CalcResult JSON and I'll explain it."
 ```
 
 ### Disclaimer surface (per Q4 + D-20 § README disclaimer policy)
@@ -322,26 +358,32 @@ Disclaimer is shown **once per session** in the first AI response that uses live
 
 ---
 
-## 7. V1.2.3 forward-spec (screenshot recognition)
+## 7. V1.2.3 screenshot recognition
 
-V1.2.2 deliberately does **not** ship screenshot recognition / OCR. V1.2.3 will add a multimodal input path. This forward-spec defines the contract V1.2.3 must satisfy so V1.2.2 design decisions stay forward-compatible.
+V1.2.3 ships a multimodal input path for supported community-tool screenshots
+through `fairy-vision`. In-game screenshots, OCR fallback, other source tools,
+and multi-image flows remain V1.2.x+ candidates.
 
 ### V1.2.3 forward-contract
 
-1. **Output shape**: vision/OCR pipeline must produce a `BattleSnapshot` draft conforming to the same schema as `fairy-snapshot`. No parallel schema is introduced.
+1. **Output shape**: `fairy-vision` must produce a `BattleSnapshot` draft conforming to the same schema as `fairy-snapshot`. No parallel schema is introduced.
 2. **Review/edit gate**: the user must be presented with the recognized snapshot draft and given the opportunity to edit before any calc invocation. Vision recognition has non-zero error rate; silent calc on wrong data is the worst UX outcome.
 3. **Validation**: after user edits and review/confirm, the snapshot must pass `fairy calc <snapshot> --view verbose --lang <lang>` validation in the `fairy-calc` gate.
-4. **Fallback**: if vision recognition confidence is below threshold or user is unhappy with the result, the system must fall back to NL dialog (`fairy-snapshot` standard flow).
+4. **Fallback**: if vision recognition confidence is below threshold, the source is unsupported, the host cannot read images, or the user is unhappy with the result, the system must fall back to NL dialog (`fairy-snapshot` standard flow).
 5. **Confidence surface**: AI must indicate per-field confidence (e.g., "我从截图认出仪玄 60 级 (高置信度), 但 Drive Disc 副词条数值置信度低，请你 review") and ask user to confirm low-confidence fields.
 
-### V1.2.3 skill name candidate
+### V1.2.3 approved skill
 
-Likely `fairy-vision` or `fairy-scan` (TBD V1.2.3). Will not be introduced in V1.2.2.
+`fairy-vision` is the approved screenshot skill. Do not add alternate vision
+skill names in this patch.
 
-### V1.2.2 implementation constraints to keep V1.2.3 viable
+### V1.2.3 implementation constraints
 
-- `fairy-snapshot` must accept an optional `partial-snapshot` input shape (alongside NL), so V1.2.3 vision-extracted snapshot can be fed back through the same skill for ask-user dialog on missing/low-confidence fields.
-- Snapshot validation must report per-field validity (not just pass/fail), so V1.2.3 can identify which vision-extracted fields failed and ask user to correct them.
+- `fairy-snapshot` must accept an optional `partial-snapshot` input shape
+  alongside NL, so the `fairy-vision` draft can be fed through the same ask-user
+  dialog on missing/low-confidence fields.
+- Snapshot validation must report actionable field validity where possible, so
+  screenshot-extracted fields that fail validation can be corrected by the user.
 
 ---
 
@@ -356,7 +398,7 @@ QA validates the user journey behavior through `acceptance.md` G3 / G4 / G5 / G8
 | Critical-field unknown does not proceed to calc without explicit user acceptance | G3 |
 | Lang detection (ii) auto-detect + override sticky | G8 (user-facing behavior) |
 | Disclaimer surfaced once per session | G8 |
-| Onboarding copy covers 3 skills + how to start | G10 |
+| Onboarding copy covers 4 skills + how to start | G10 |
 
 QA fixture strategy: per `acceptance.md` 3-tier (skill-spec EN canonical + entity normalization zh/en + user-facing output zh/en smoke).
 
@@ -364,10 +406,10 @@ QA fixture strategy: per `acceptance.md` 3-tier (skill-spec EN canonical + entit
 
 ## 9. Open questions & V1.2.x backlog
 
-- **fairy-compare skill** (V1.2.2.x): deferred per D-21; it should be scoped
+- **fairy-compare skill** (V1.2.x): deferred per D-21; it should be scoped
   as a separate plugin patch after the CLI compare contract is stable.
-- **Plugin marketplace distribution** (V1.2.2.x+): after skill API stabilizes through V1.2.2 dogfooding.
-- **Cursor support** (V1.2.x patch): not in V1.2.2; documented in V1.2.x candidates.
+- **Plugin marketplace distribution** (V1.2.x+): after skill API stabilizes through V1.2.3 dogfooding.
+- **Cursor support** (V1.2.x patch): not in V1.2.3; documented in V1.2.x candidates.
 - **Per-user plugin settings (lang preference, default --view)** (V1.2.x): currently relies on session-level lang detect; future settings system can override.
 - **User-saved snapshot library** (V1.2.x+): allow user to name and reuse common snapshots; would change `fairy-snapshot` to also support load-by-name.
 

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -8,13 +8,14 @@ const repoRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)))
 
 const pluginRoot = path.join(repoRoot, ".claude-plugin/plugins/fairy")
 const pluginJsonPath = path.join(pluginRoot, "plugin.json")
-const skillNames = ["fairy-snapshot", "fairy-calc", "fairy-explain"]
+const skillNames = ["fairy-vision", "fairy-snapshot", "fairy-calc", "fairy-explain"]
 const requiredDocsByKey = {
   architecture: "docs/ai-plugin/architecture.md",
   userJourneys: "docs/ai-plugin/user-journeys.md",
   promptTemplates: "docs/ai-plugin/prompt-templates.md",
   acceptance: "docs/ai-plugin/acceptance.md",
   decision: "docs/product/decisions/D-21-ai-plugin.md",
+  visionDecision: "docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md",
 }
 const requiredDocs = Object.values(requiredDocsByKey)
 const exampleDirs = [
@@ -111,13 +112,13 @@ assert(existsSync(pluginJsonPath), ".claude-plugin/plugins/fairy/plugin.json is 
 const plugin = readJsonPath(pluginJsonPath)
 
 assert(plugin.name === "fairy", "plugin.json name must be fairy")
-assert(typeof plugin.version === "string" && plugin.version.length > 0, "plugin.json version is required")
+assert(plugin.version === "1.2.3", "plugin.json version must be 1.2.3")
 assert(plugin.minFairyCliVersion === "0.1.2", "plugin.json minFairyCliVersion must be 0.1.2")
 assert(plugin.displayName?.en && plugin.displayName?.zh, "plugin.json displayName.en and displayName.zh are required")
 assert(Array.isArray(plugin.supportedTools), "plugin.json supportedTools must be an array")
 assert(plugin.supportedTools?.includes("claude-code"), "plugin.json supportedTools must include claude-code")
 assert(plugin.supportedTools?.includes("codex"), "plugin.json supportedTools must include codex")
-assert(!plugin.supportedTools?.includes("cursor"), "plugin.json must not include cursor for V1.2.2")
+assert(!plugin.supportedTools?.includes("cursor"), "plugin.json must not include cursor for V1.2.3")
 assert(JSON.stringify(plugin.skills) === JSON.stringify(skillNames), "plugin.json skills must match canonical skill names")
 
 for (const doc of requiredDocs)
@@ -183,6 +184,23 @@ const snapshotSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-snapsh
 assert(!snapshotSkill.includes("fairy calc <snapshot>"), "fairy-snapshot must not call fairy calc directly")
 assert(snapshotSkill.includes("review/confirm"), "fairy-snapshot must document review/confirm handoff")
 
+const visionSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md")
+includesAll(visionSkill, ".claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md", [
+  "hostRequirement:",
+  "multimodal: required",
+  "zzz-workshop",
+  "miyoushe-record",
+  "draftMetadata.evidence",
+  "draftMetadata.piiDetection",
+  "perFieldConfidence",
+  "fairy-snapshot",
+  "docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md",
+])
+assert(visionSkill.includes("Do not call `fairy calc`"), "fairy-vision must forbid direct CLI calculation")
+assert(visionSkill.includes("Do not compute damage"), "fairy-vision must forbid model-side calculation")
+assert(visionSkill.includes("Do not produce a confirmed `BattleSnapshot`"), "fairy-vision must only produce reviewable drafts")
+assert(visionSkill.includes("Do not persist raw PII"), "fairy-vision must forbid raw PII persistence")
+
 const calcSkill = readText(".claude-plugin/plugins/fairy/skills/fairy-calc/SKILL.md")
 assert(
   calcSkill.includes("fairy calc <snapshot> --view verbose --lang <zh|en>"),
@@ -198,7 +216,7 @@ const pluginForbiddenPatterns = [
   { pattern: /--dry-run/g, reason: "must not depend on nonexistent --dry-run" },
   { pattern: /fairy-compare/g, reason: "compare skill is deferred" },
   { pattern: /fairy compare/g, reason: "AI plugin compare workflow is deferred" },
-  { pattern: /\.cursor/g, reason: "Cursor is deferred from V1.2.2" },
+  { pattern: /\.cursor/g, reason: "Cursor is deferred from V1.2.3" },
   { pattern: /packages\/data\/source/g, reason: "plugin must not read raw source" },
 ]
 


### PR DESCRIPTION
## Summary

- add `fairy-vision` as the approved fourth AI plugin skill with multimodal host metadata, supported source ids, extraction/evidence/PII boundaries, and handoff policy
- bump plugin metadata to `1.2.3`, add D-22 doc linkage, and update Codex usage notes
- update AI plugin architecture, user journeys, prompt templates, and acceptance docs from the V1.2.2 text-only baseline to the V1.2.3 vision skeleton
- extend `verify-ai-plugin` to enforce the 4-skill approved set and `fairy-vision` contract checks

## Scope notes

This is P1 skeleton only. It does not add vision examples, golden screenshot fixtures, or V-G1..V-G5 harness logic; those remain for P2/P3.

## Verification

- `pnpm verify:ai-plugin`
- `git diff --check`
- `pnpm check`
- `pnpm build`
- `pnpm test`
