### PR TITLE
feat(ai-plugin): add V1.2.3 vision examples P2 — workshop + miyoushe yixuan fixtures

### DIFF
--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -1,0 +1,93 @@
+# fairy AI plugin · V1.2.3 vision examples & fixtures
+
+Concrete examples for the V1.2.3 `fairy-vision` skill: vision prompts, expected `BattleSnapshot` drafts, expected `draftMetadata.evidence`, and zh user-facing review/edit gate copy.
+
+These files are dual-purpose:
+- **Reference**: agent / human readers see the contract by example, per source.
+- **Fixture**: QA V-G1..V-G5 + K4 chain-invisibility scans (per `docs/ai-plugin/v1.2.3-vision/acceptance.md`) consume these as smoke-test golden inputs.
+
+## Structure
+
+```
+examples/ai-plugin/vision/
+  README.md                           # this file
+  prompts/
+    vision-workshop-yixuan.md         # fairy-vision: 绝区零工坊 happy-path (zh)
+    vision-miyoushe-yixuan.md         # fairy-vision: 米游社 happy-path (zh)
+  snapshots/
+    yixuan-workshop.snapshot.json     # strict BattleSnapshot draft from workshop screenshot
+    yixuan-miyoushe.snapshot.json     # strict BattleSnapshot draft from miyoushe screenshot
+  expected/
+    yixuan-workshop.draft-metadata.json   # draftMetadata: sourceDetection / piiDetection status / evidence
+    yixuan-miyoushe.draft-metadata.json   # draftMetadata for miyoushe variant
+```
+
+## Scope (P2 starter — happy-path coverage)
+
+V1.2.3 P2 ships the **happy-path** cross-source pair for 仪玄 to demonstrate:
+
+| Property | Workshop variant | Miyoushe variant |
+|---|---|---|
+| Source | 绝区零工坊 (WeChat mini-app) | 米游社 (Mihoyo community) |
+| Agent | 仪玄 Lv60 (mindscape 2) | 仪玄 Lv60 (mindscape 2) |
+| Weapon | 青溟笼舍 R1 | 青溟笼舍 R1 |
+| Drive Disc | 云霄如我 4pc + 折枝剑歌 2pc | 云霄如我 4pc + 折枝剑歌 2pc |
+| Panel | identical (within source rounding) | identical |
+
+**Cross-source consistency contract**: V-G1 source detection routes each screenshot through its source-specific layout map; both produce **the same canonical strict `BattleSnapshot`** (modulo minor rounding tolerance documented in evidence). This is the core proof that the vision pipeline is source-agnostic at the `BattleSnapshot` boundary.
+
+Future P2.x batches will add:
+- Additional agents (耀佳音 / 琉音 / 星见雅) per source — sample images already provided by lo-user
+- Partial-extraction fixtures (per `docs/ai-plugin/v1.2.3-vision/user-journeys.md` §5)
+- Visual ambiguity fixtures (per §6 — e.g., 米游社 "07" skill slot)
+- Source-unknown / NL fallback fixtures (per §3 + §7)
+- Low-confidence majority fixtures (per §7)
+- PII redaction edge cases (per §8 + V-G4)
+
+## How to read each fixture file
+
+Every `prompts/vision-*.md` follows the same shape:
+
+```
+# <fixture name>
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop | miyoushe-record
+**Scenario**: <one-line scenario summary>
+**Lang**: zh
+
+## User input
+[image attachment description] + optional NL context
+
+## Expected fairy-vision behavior
+1. <ordered steps the skill follows>
+2. <source detection + per-source field map application>
+
+## Expected output
+- BattleSnapshot draft: see `snapshots/<fixture>.snapshot.json`
+- draftMetadata: see `expected/<fixture>.draft-metadata.json`
+- Review/edit gate copy (zh): inline below
+
+## Review/edit gate copy
+<zh user-facing copy per prompt-templates.md §5>
+
+## Acceptance assertions
+QA V-G1 / V-G2 / V-G3 / V-G4 / V-G5 + K4 invisibility — specific per-fixture checks.
+```
+
+## PII redaction policy
+
+Per `docs/ai-plugin/v1.2.3-vision/user-journeys.md` §8 + acceptance V-G4, all public fixtures redact PII:
+
+- **UID** in source screenshots: real UID `11553939` is replaced with `REDACTED` placeholder in fixture display copy and reduced to `piiDetection.kinds: ["uid"]` + `piiDetection.redactionStatus: "redacted"` in `draftMetadata`. Actual digits never reach committed fixture JSON.
+- **Username**: similarly redacted. Even when visible in source screenshot, treated as `piiDetection.kinds: ["username"]` only.
+- **Screenshot files themselves**: not committed to repo (avoid raw PII in version control). Fixture references screenshot via canonical placeholder filename (e.g., `[zzz-workshop-yixuan-build.png]`); real images stay outside public fixture tree per acceptance V-G4.
+
+## Cross-references
+
+- V1.2.3 skill spec: `.claude-plugin/plugins/fairy/skills/fairy-vision/SKILL.md`
+- V1.2.3 user journeys: `docs/ai-plugin/v1.2.3-vision/user-journeys.md`
+- V1.2.3 prompt templates (canonical EN spec): `docs/ai-plugin/v1.2.3-vision/prompt-templates.md`
+- V1.2.3 acceptance gates: `docs/ai-plugin/v1.2.3-vision/acceptance.md`
+- V1.2.2 NL fixtures (for parity reference): `examples/ai-plugin/prompts/build-yixuan-basic.md` etc.
+- D-22 product decision: `docs/product/decisions/D-22-ai-plugin-v1.2.3-vision.md`

--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -34,7 +34,7 @@ V1.2.3 P2 ships the **happy-path** cross-source pair for 仪玄 to demonstrate:
 | Drive Disc | 云霄如我 4pc + 折枝剑歌 2pc | 云霄如我 4pc + 折枝剑歌 2pc |
 | Panel | identical (within source rounding) | identical |
 
-**Cross-source consistency contract**: V-G1 source detection routes each screenshot through its source-specific layout map; both produce **the same canonical strict `BattleSnapshot`** (modulo minor rounding tolerance documented in evidence). This is the core proof that the vision pipeline is source-agnostic at the `BattleSnapshot` boundary.
+**Cross-source identity contract**: V-G1 source detection routes each screenshot through its source-specific layout map. Both fixtures yield the same canonical **identity + build composition** (agent `1371`, weapon `14137` R1, drive disc setIds, slot layout, mindscape level). Source-displayed derived stats may differ (e.g., 米游社 surfaces `corePassive` skill slot and `etherDamageBonus`; 工坊 omits both; `energyRegen` units differ; `sheerForce` rounds 1 unit) — each variant's strict `BattleSnapshot` captures what the source actually displays, with per-source differences documented in `draftMetadata.evidence`. The vision pipeline is source-agnostic at the **identity** boundary; it does not falsify a single canonical numeric panel.
 
 Future P2.x batches will add:
 - Additional agents (耀佳音 / 琉音 / 星见雅) per source — sample images already provided by lo-user
@@ -79,7 +79,7 @@ QA V-G1 / V-G2 / V-G3 / V-G4 / V-G5 + K4 invisibility — specific per-fixture c
 
 Per `docs/ai-plugin/v1.2.3-vision/user-journeys.md` §8 + acceptance V-G4, all public fixtures redact PII:
 
-- **UID** in source screenshots: real UID `11553939` is replaced with `REDACTED` placeholder in fixture display copy and reduced to `piiDetection.kinds: ["uid"]` + `piiDetection.redactionStatus: "redacted"` in `draftMetadata`. Actual digits never reach committed fixture JSON.
+- **UID** in source screenshots: any UID seen during extraction is replaced with `REDACTED_UID` placeholder in fixture display copy and reduced to `piiDetection.kinds: ["uid"]` + `piiDetection.redactionStatus: "redacted"` in `draftMetadata`. Actual digits never reach committed fixture JSON.
 - **Username**: similarly redacted. Even when visible in source screenshot, treated as `piiDetection.kinds: ["username"]` only.
 - **Screenshot files themselves**: not committed to repo (avoid raw PII in version control). Fixture references screenshot via canonical placeholder filename (e.g., `[zzz-workshop-yixuan-build.png]`); real images stay outside public fixture tree per acceptance V-G4.
 

--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -31,10 +31,10 @@ V1.2.3 P2 ships the **happy-path** cross-source pair for 仪玄 to demonstrate:
 | Source | 绝区零工坊 (WeChat mini-app) | 米游社 (Mihoyo community) |
 | Agent | 仪玄 Lv60 (mindscape 2) | 仪玄 Lv60 (mindscape 2) |
 | Weapon | 青溟笼舍 R1 | 青溟笼舍 R1 |
-| Drive Disc | 云霄如我 4pc + 折枝剑歌 2pc | 云霄如我 4pc + 折枝剑歌 2pc |
-| Panel | identical (within source rounding) | identical |
+| Drive Disc | 云岿如我 4pc + 折枝剑歌 2pc | 云岿如我 4pc + 折枝剑歌 2pc |
+| Panel | source-displayed; differences documented | source-displayed; differences documented |
 
-**Cross-source identity contract**: V-G1 source detection routes each screenshot through its source-specific layout map. Both fixtures yield the same canonical **identity + build composition** (agent `1371`, weapon `14137` R1, drive disc setIds, slot layout, mindscape level). Source-displayed derived stats may differ (e.g., 米游社 surfaces `corePassive` skill slot and `etherDamageBonus`; 工坊 omits both; `energyRegen` units differ; `sheerForce` rounds 1 unit) — each variant's strict `BattleSnapshot` captures what the source actually displays, with per-source differences documented in `draftMetadata.evidence`. The vision pipeline is source-agnostic at the **identity** boundary; it does not falsify a single canonical numeric panel.
+**Cross-source identity contract**: V-G1 source detection routes each screenshot through its source-specific layout map. Both fixtures yield the same canonical **identity + build composition** (agent `1371`, weapon `14137` R1, drive disc setIds `33100` + `32700`, slot layout, mindscape level 2). Source-displayed derived stats intentionally differ: 米游社 surfaces a `corePassive` skill slot that 工坊 does not show; both variants include `panel.etherDamageBonus: 0.3` (matching the slot-5 main stat), but `energyRegen` is rendered with different unit conventions (`1.2` 工坊 vs `2.0` 米游社) and `sheerForce` differs by 1 unit between sources from display rounding. Each variant's strict `BattleSnapshot` captures what the source actually displays, with per-source differences documented in `draftMetadata.evidence.crossSourceNotes`. The vision pipeline is source-agnostic at the **identity** boundary; it does not falsify a single canonical numeric panel.
 
 Future P2.x batches will add:
 - Additional agents (耀佳音 / 琉音 / 星见雅) per source — sample images already provided by lo-user

--- a/examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json
@@ -59,7 +59,7 @@
     "substatRollsSample": [
       {
         "slot": 1,
-        "setId": "31002",
+        "setId": "33100",
         "substats": [
           { "stat": "attack", "rollCount": 4, "valuePercent": 24 },
           { "stat": "anomalyProficiency", "rollCount": 1, "valueFlat": 9 },
@@ -81,7 +81,7 @@
   "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user has already supplied enemy + attack segment context in the NL portion.",
   "fallbackTrigger": null,
   "notes": [
-    "Sample image: miyoushe-record variant of 仪玄 build; PII (UID 11553939 + username 'Lo') redacted at extraction; raw values never persisted.",
+    "Sample image: miyoushe-record variant of 仪玄 build; PII (UID + username kinds) redacted at extraction; raw values never persisted.",
     "Cross-source pair: see expected/yixuan-workshop.draft-metadata.json for same build via 绝区零工坊 source.",
     "Skill strip includes a 6th 'core passive' slot at value 07; documented stable value per fixture, not an ambiguity escalation case."
   ]

--- a/examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json
@@ -1,0 +1,88 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-miyoushe-yixuan",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.95,
+    "cues": [
+      "branding:top-right-zzz-wordmark",
+      "branding:bottom-left-miyoushe-logo",
+      "branding:bottom-right-watermark",
+      "layout:landscape-composite",
+      "layout:agent-info-band",
+      "layout:driver-substat-count-band"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid", "username"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.rank": "high",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "actor.skillLevels.corePassive": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "medium",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high",
+    "panel.sheerForce": "high",
+    "panel.etherDamageBonus": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      { "stat": "maxHp", "base": 8373, "bonus": 9932, "total": 18305 },
+      { "stat": "attack", "base": 1615, "bonus": 364, "total": 1979 },
+      { "stat": "defense", "base": 441, "bonus": 277, "total": 718 }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "31002",
+        "substats": [
+          { "stat": "attack", "rollCount": 4, "valuePercent": 24 },
+          { "stat": "anomalyProficiency", "rollCount": 1, "valueFlat": 9 },
+          { "stat": "defense", "rollCount": 1, "valueFlat": 15 },
+          { "stat": "critRate", "rollCount": 1, "valuePercent": 4.8 }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [12, 11, 12, 12, 12, 7],
+    "driverScoreObserved": {
+      "effectiveSubstatCount": 40,
+      "rating": "SS+",
+      "note": "community-tool metadata; not consumed by BattleSnapshot"
+    },
+    "crossSourceNotes": [
+      "panel.sheerForce: 米游社 displays 2423, workshop displays 2424; explained by source-side rounding; vision parse records the source-reported value verbatim."
+    ]
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user has already supplied enemy + attack segment context in the NL portion.",
+  "fallbackTrigger": null,
+  "notes": [
+    "Sample image: miyoushe-record variant of 仪玄 build; PII (UID 11553939 + username 'Lo') redacted at extraction; raw values never persisted.",
+    "Cross-source pair: see expected/yixuan-workshop.draft-metadata.json for same build via 绝区零工坊 source.",
+    "Skill strip includes a 6th 'core passive' slot at value 07; documented stable value per fixture, not an ambiguity escalation case."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-workshop-yixuan",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.95,
+    "cues": [
+      "branding:footer-mp-handle",
+      "layout:vertical-portrait-orientation",
+      "layout:agent-roster-row-top",
+      "layout:ace-rating-text"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high",
+    "panel.sheerForce": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      { "stat": "maxHp", "base": 8373, "bonus": 9932, "total": 18305 },
+      { "stat": "attack", "base": 1615, "bonus": 364, "total": 1979 },
+      { "stat": "defense", "base": 441, "bonus": 277, "total": 718 }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "31002",
+        "substats": [
+          { "stat": "attack", "rollCount": 4, "valuePercent": 24 },
+          { "stat": "anomalyProficiency", "rollCount": 1, "valueFlat": 9 },
+          { "stat": "defense", "rollCount": 1, "valueFlat": 15 },
+          { "stat": "critRate", "rollCount": 1, "valuePercent": 4.8 }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [12, 11, 12, 12, 12],
+    "driverScoreObserved": {
+      "totalAce": 278,
+      "effectiveSubstatCount": 41.3,
+      "rating": "ACE",
+      "completionPercent": 132.3,
+      "note": "community-tool metadata; not consumed by BattleSnapshot"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "Sample image: zzz-workshop variant of 仪玄 build; PII (UID 11553939) redacted at extraction; raw digits never persisted.",
+    "Cross-source pair: see expected/yixuan-miyoushe.draft-metadata.json for same build via 米游社 source."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json
@@ -56,7 +56,7 @@
     "substatRollsSample": [
       {
         "slot": 1,
-        "setId": "31002",
+        "setId": "33100",
         "substats": [
           { "stat": "attack", "rollCount": 4, "valuePercent": 24 },
           { "stat": "anomalyProficiency", "rollCount": 1, "valueFlat": 9 },
@@ -77,7 +77,7 @@
   "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
   "fallbackTrigger": null,
   "notes": [
-    "Sample image: zzz-workshop variant of 仪玄 build; PII (UID 11553939) redacted at extraction; raw digits never persisted.",
+    "Sample image: zzz-workshop variant of 仪玄 build; PII (UID kind) redacted at extraction; raw digits never persisted.",
     "Cross-source pair: see expected/yixuan-miyoushe.draft-metadata.json for same build via 米游社 source."
   ]
 }

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
@@ -2,10 +2,10 @@
 
 **Skill**: fairy-vision
 **Source**: miyoushe-record (米游社绝区零战绩)
-**Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云岿如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces a strict BattleSnapshot with the same agent / wEngine / driveDiscs identity. Source-displayed derived stats (`corePassive`, `etherDamageBonus`, `energyRegen`, `sheerForce`) intentionally differ from the workshop variant where 米游社 surfaces them and 工坊 does not; differences are documented in `draftMetadata.evidence.crossSourceNotes`.
+**Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云岿如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces a strict BattleSnapshot with the same agent / wEngine / driveDiscs identity. Source-displayed derived stats intentionally differ from the workshop variant: 米游社 surfaces a `corePassive` skill slot that 工坊 omits, and renders `energyRegen` with a different unit convention; `sheerForce` differs by 1 unit from display rounding. `etherDamageBonus` is included in both variants (matching the slot-5 main stat). Differences are documented in `draftMetadata.evidence.crossSourceNotes`.
 **Lang**: zh
 
-This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source identity**: same build screenshot from a different community tool produces a `BattleSnapshot` with the same agentId / wEngine / driveDiscs composition. Source-displayed derived stats differ — 米游社 surfaces `corePassive` and `etherDamageBonus` panel fields; `energyRegen` is rendered with a different unit convention; `sheerForce` differs by 1 unit from rounding. Each variant captures what its source actually shows; cross-source differences are documented in `draftMetadata.evidence.crossSourceNotes`.
+This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source identity**: same build screenshot from a different community tool produces a `BattleSnapshot` with the same agentId / wEngine / driveDiscs composition. Source-displayed derived stats differ — 米游社 surfaces a `corePassive` skill slot that 工坊 omits; `energyRegen` is rendered with a different unit convention; `sheerForce` differs by 1 unit from rounding. `etherDamageBonus` is captured in both variants (matching the slot-5 main stat). Each variant captures what its source actually shows; cross-source differences are documented in `draftMetadata.evidence.crossSourceNotes`.
 
 It also exercises the 米游社-specific layout features: SSS+ rating badge, AGENT INFO band, 驱动盘有效副属性共中 framing, 6-card Drive Disc grid, and the skill-strip "07" slot that may render slightly differently (per `user-journeys.md` §6 visual-ambiguity note — verified as a documented stable value in this fixture, no ambiguity escalation needed).
 
@@ -87,7 +87,7 @@ User (zh, with image attachment):
 - Same as workshop fixture for `BattleSnapshot.panel` strict-totals contract
 - `draftMetadata.evidence.statSplits` records 3 minimum stat splits (HP/ATK/DEF)
 - `draftMetadata.evidence.substatRollsSample` records visible roll counts
-- 以太伤害加成 30% appears in panel (miyoushe surfaces this where workshop does not — verify field captured)
+- 以太伤害加成 30% appears in panel (both source variants include this field, matching the slot-5 main stat — verify captured per-source)
 
 ### V-G3 — Review/edit & uncertainty handling
 

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
@@ -1,0 +1,111 @@
+# fixture · vision-miyoushe-yixuan
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record (米游社绝区零战绩)
+**Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云霄如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces the same canonical strict BattleSnapshot.
+**Lang**: zh
+
+This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source consistency**: same build screenshot from a different community tool produces an equivalent strict `BattleSnapshot` (within documented rounding tolerance). The vision pipeline is source-agnostic at the snapshot boundary.
+
+It also exercises the 米游社-specific layout features: SSS+ rating badge, AGENT INFO band, 驱动盘有效副属性共中 framing, 6-card Drive Disc grid, and the skill-strip "07" slot that may render slightly differently (per `user-journeys.md` §6 visual-ambiguity note — verified as a documented stable value in this fixture, no ambiguity escalation needed).
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [miyoushe-yixuan-build.png]
+  这个仪玄打 DA boss 一段普攻伤害多少
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection** (per `prompt-templates.md` §3):
+   - Branding cues found: top-right "ZZ 绝区·零 zen.less zone zero" wordmark + bottom-left 米游社 logo + bottom-right "米游社绝区零战绩" watermark + landscape composite orientation
+   - Result: `sourceDetection: { sourceId: "miyoushe-record", sourceLabel: "米游社", confidence: 0.95 }`
+4. **Per-source layout map** (per `prompt-templates.md` §4.2 米游社 regions):
+   - Region 1 top bar: PII (username "Lo" + UID) → captured as `piiDetection`
+   - Region 2 AGENT INFO band: agent rank/portrait card (S-rank) + mindscape "2" + agent name + LV.60; right-half 2-column stats table (含 以太伤害加成 30.0%)
+   - Region 3 skill levels strip: 12/11/12/12/12/07 (6 visible categories; `07` is the core-passive slot, not an ambiguity)
+   - Region 4 weapon strip: 青溟笼舍 Lv.60 (1-star icon = R1)
+   - Region 5 driver score band: "驱动盘有效副属性共中 40 次" + SS+ badge → SKIPPED (community-tool metadata)
+   - Region 6 Drive Disc cards (6 in 2-row × 3-col grid)
+   - Region 7 footer: SKIPPED (branding + QR)
+5. **PII detection** (per V-G4):
+   - UID + username "Lo" detected in Region 1
+   - `piiDetection: { kinds: ["uid", "username"], redactionStatus: "redacted" }`
+   - Raw digits / username never reach `BattleSnapshot` or persisted `draftMetadata`
+6. **Confidence scoring**:
+   - Identical confidence profile to workshop fixture (text-rendered fields high; icon-based medium)
+   - 米游社 weapon refinement uses **star icon count** (vs workshop "精炼 N 星" text) → medium confidence (visual count); cross-validated as 1 star = R1
+7. **Cross-source rounding tolerance**:
+   - 米游社 displays 贯穿力 as `2423`, workshop as `2424` (likely display rounding)
+   - Vision parse records exact value from source (`2423`); `draftMetadata.evidence.crossSourceNotes` may flag for downstream comparison if cross-source mode is enabled (out of MVP scope)
+8. **Output**: `battleSnapshotDraft` + `draftMetadata` + `nextStep` (same shape as workshop fixture).
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/yixuan-miyoushe.snapshot.json`
+- **draftMetadata**: see `expected/yixuan-miyoushe.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「米游社」截图里读到:
+
+  角色: 仪玄 Lv60 (影画 2，S 评级)
+  武器: 青溟笼舍 Lv60 R1
+  6 件套: 云霄如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
+  主词条: slot 4 暴击伤害 48% / slot 5 以太伤害加成 30% / slot 6 生命值 30%
+  副词条: 全部读到
+  面板: HP 18305, ATK 1979, DEF 718, 冲击力 93, 暴击率 55.4%, 暴击伤害 200.4%, 异常掌控 92, 异常精通 117, 贯穿力 2423, 以太伤害加成 30%
+  技能等级: 普攻 12 / 闪避 11 / 支援 12 / 特殊技 12 / 连携技 12 / 核心 07
+
+  证据 (audit-only，不进 calc):
+    - HP 18305 = 8373 base + 9932 bonus
+    - ATK 1979 = 1615 base + 364 bonus
+    - DEF 718 = 441 base + 277 bonus
+    - 截图来源: 米游社 (UID + 用户名 已识别并隐藏，不入 snapshot)
+
+  你提到「DA boss」一段普攻 — 帮你补 enemy = 本期 DA boss + 攻击段 = basic attack step 1。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions (per `docs/ai-plugin/v1.2.3-vision/acceptance.md`)
+
+### V-G1 — Source detection & layout routing
+
+- `sourceDetection.sourceId === "miyoushe-record"` ✓
+- 米游社 layout map applied (Region 2 AGENT INFO band, Region 3 skill strip with 6 slots including the 07-slot rendering convention)
+- Workshop layout NOT applied to this fixture
+
+### V-G2 — Extraction evidence & schema boundary
+
+- Same as workshop fixture for `BattleSnapshot.panel` strict-totals contract
+- `draftMetadata.evidence.statSplits` records 3 minimum stat splits (HP/ATK/DEF)
+- `draftMetadata.evidence.substatRolls` records visible roll counts
+- 以太伤害加成 30% appears in panel (miyoushe surfaces this where workshop does not — verify field captured)
+
+### V-G3 — Review/edit & uncertainty handling
+
+- Same as workshop fixture: no skill names / no orchestration phrasing / no midpoint-default copy
+- 米游社 "07" skill slot is reported as "核心 07" in user-facing copy (documented stable value, not flagged as ambiguity in this fixture)
+
+### V-G4 — Privacy & PII exclusion
+
+- `piiDetection.kinds === ["uid", "username"]` (both detected from miyoushe Region 1)
+- `piiDetection.redactionStatus === "redacted"`
+- `BattleSnapshot` contains no PII keys
+- Public fixture display copy contains no raw UID / username; only "UID + 用户名 已识别并隐藏"
+
+### V-G5 — End-to-end CLI calc validation
+
+- Confirmed `BattleSnapshot` is valid input for `fairy calc <snapshot> --view verbose --lang zh`
+- Cross-source consistency check (optional): when both `yixuan-workshop.snapshot.json` and `yixuan-miyoushe.snapshot.json` feed into the same calc command, the calculated total damage should match within ~0.1% tolerance (justified by 1-unit rounding on 贯穿力 between sources)
+
+### K4 — Chain transition invisibility
+
+- Same as workshop fixture: no skill-name leakage / no orchestration phrasing in user-facing copy

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
@@ -2,7 +2,7 @@
 
 **Skill**: fairy-vision
 **Source**: miyoushe-record (米游社绝区零战绩)
-**Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云霄如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces the same canonical strict BattleSnapshot.
+**Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云岿如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces a strict BattleSnapshot with the same agent / wEngine / driveDiscs identity. Source-displayed derived stats (`corePassive`, `etherDamageBonus`, `energyRegen`, `sheerForce`) intentionally differ from the workshop variant where 米游社 surfaces them and 工坊 does not; differences are documented in `draftMetadata.evidence.crossSourceNotes`.
 **Lang**: zh
 
 This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source identity**: same build screenshot from a different community tool produces a `BattleSnapshot` with the same agentId / wEngine / driveDiscs composition. Source-displayed derived stats differ — 米游社 surfaces `corePassive` and `etherDamageBonus` panel fields; `energyRegen` is rendered with a different unit convention; `sheerForce` differs by 1 unit from rounding. Each variant captures what its source actually shows; cross-source differences are documented in `draftMetadata.evidence.crossSourceNotes`.
@@ -58,7 +58,7 @@ User (zh, with image attachment):
 
   角色: 仪玄 Lv60 (影画 2，S 评级)
   武器: 青溟笼舍 Lv60 R1
-  6 件套: 云霄如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
+  6 件套: 云岿如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
   主词条: slot 4 暴击伤害 48% / slot 5 以太伤害加成 30% / slot 6 生命值 30%
   副词条: 全部读到
   面板: HP 18305, ATK 1979, DEF 718, 冲击力 93, 暴击率 55.4%, 暴击伤害 200.4%, 异常掌控 92, 异常精通 117, 贯穿力 2423, 以太伤害加成 30%
@@ -86,7 +86,7 @@ User (zh, with image attachment):
 
 - Same as workshop fixture for `BattleSnapshot.panel` strict-totals contract
 - `draftMetadata.evidence.statSplits` records 3 minimum stat splits (HP/ATK/DEF)
-- `draftMetadata.evidence.substatRolls` records visible roll counts
+- `draftMetadata.evidence.substatRollsSample` records visible roll counts
 - 以太伤害加成 30% appears in panel (miyoushe surfaces this where workshop does not — verify field captured)
 
 ### V-G3 — Review/edit & uncertainty handling

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
@@ -5,7 +5,7 @@
 **Scenario**: P1 user pastes a 米游社 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云霄如我 4pc + 折枝剑歌 2pc (same build as `vision-workshop-yixuan` cross-source pair); vision pipeline detects 米游社 source, applies its layout map, produces the same canonical strict BattleSnapshot.
 **Lang**: zh
 
-This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source consistency**: same build screenshot from a different community tool produces an equivalent strict `BattleSnapshot` (within documented rounding tolerance). The vision pipeline is source-agnostic at the snapshot boundary.
+This fixture pairs with `vision-workshop-yixuan.md` to demonstrate **cross-source identity**: same build screenshot from a different community tool produces a `BattleSnapshot` with the same agentId / wEngine / driveDiscs composition. Source-displayed derived stats differ — 米游社 surfaces `corePassive` and `etherDamageBonus` panel fields; `energyRegen` is rendered with a different unit convention; `sheerForce` differs by 1 unit from rounding. Each variant captures what its source actually shows; cross-source differences are documented in `draftMetadata.evidence.crossSourceNotes`.
 
 It also exercises the 米游社-specific layout features: SSS+ rating badge, AGENT INFO band, 驱动盘有效副属性共中 framing, 6-card Drive Disc grid, and the skill-strip "07" slot that may render slightly differently (per `user-journeys.md` §6 visual-ambiguity note — verified as a documented stable value in this fixture, no ambiguity escalation needed).
 
@@ -27,7 +27,7 @@ User (zh, with image attachment):
    - Branding cues found: top-right "ZZ 绝区·零 zen.less zone zero" wordmark + bottom-left 米游社 logo + bottom-right "米游社绝区零战绩" watermark + landscape composite orientation
    - Result: `sourceDetection: { sourceId: "miyoushe-record", sourceLabel: "米游社", confidence: 0.95 }`
 4. **Per-source layout map** (per `prompt-templates.md` §4.2 米游社 regions):
-   - Region 1 top bar: PII (username "Lo" + UID) → captured as `piiDetection`
+   - Region 1 top bar: PII (username + UID) → captured as `piiDetection`
    - Region 2 AGENT INFO band: agent rank/portrait card (S-rank) + mindscape "2" + agent name + LV.60; right-half 2-column stats table (含 以太伤害加成 30.0%)
    - Region 3 skill levels strip: 12/11/12/12/12/07 (6 visible categories; `07` is the core-passive slot, not an ambiguity)
    - Region 4 weapon strip: 青溟笼舍 Lv.60 (1-star icon = R1)
@@ -35,7 +35,7 @@ User (zh, with image attachment):
    - Region 6 Drive Disc cards (6 in 2-row × 3-col grid)
    - Region 7 footer: SKIPPED (branding + QR)
 5. **PII detection** (per V-G4):
-   - UID + username "Lo" detected in Region 1
+   - UID + username detected in Region 1
    - `piiDetection: { kinds: ["uid", "username"], redactionStatus: "redacted" }`
    - Raw digits / username never reach `BattleSnapshot` or persisted `draftMetadata`
 6. **Confidence scoring**:
@@ -104,7 +104,7 @@ User (zh, with image attachment):
 ### V-G5 — End-to-end CLI calc validation
 
 - Confirmed `BattleSnapshot` is valid input for `fairy calc <snapshot> --view verbose --lang zh`
-- Cross-source consistency check (optional): when both `yixuan-workshop.snapshot.json` and `yixuan-miyoushe.snapshot.json` feed into the same calc command, the calculated total damage should match within ~0.1% tolerance (justified by 1-unit rounding on 贯穿力 between sources)
+- Cross-source identity check (optional): both fixtures share the same agentId / wEngine / driveDiscs composition; calc on each variant may produce slightly different totals because each captures the source-displayed derived panel (per `crossSourceNotes`), not a unified canonical numeric panel
 
 ### K4 — Chain transition invisibility
 

--- a/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
@@ -1,0 +1,116 @@
+# fixture · vision-workshop-yixuan
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop (绝区零工坊 WeChat mini-app)
+**Scenario**: P1 user pastes a 工坊 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云霄如我 4pc + 折枝剑歌 2pc; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, hands off to fairy-snapshot for review/edit.
+**Lang**: zh
+
+This fixture demonstrates the **happy-path 工坊** flow: high-confidence source detection, complete field extraction including substat roll counts, no missing fields, PII (UID) detected and redacted at the draftMetadata level, review/edit gate uses generic source description (no skill-name leakage per K4).
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [zzz-workshop-yixuan-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh (user message + image internal UI both zh) → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection** (per `prompt-templates.md` §3):
+   - Branding cues found: footer "关注微信公众号「绝区零工坊」即可查询" + phone status bar + vertical portrait orientation + ACE 评级 text
+   - Result: `sourceDetection: { sourceId: "zzz-workshop", sourceLabel: "绝区零工坊", confidence: 0.95 }`
+4. **Per-source layout map** (per `prompt-templates.md` §4.1 工坊 regions):
+   - Region 2 agent roster row: 仪玄 highlighted as selected
+   - Region 3 agent panel: identity + level + mindscape + stats + element/specialty icons
+   - Region 4 skill levels strip: 12/11/12/12/12 (5 visible categories)
+   - Region 5 weapon card: 青溟笼舍 Lv.60 精炼1星
+   - Region 6 driver score header: SKIPPED (community-tool metadata)
+   - Region 7 Drive Disc cards (slots 1-6)
+   - Region 8 footer: SKIPPED (branding)
+5. **PII detection** (per V-G4):
+   - UID detected in Region 3 agent portrait card area
+   - Username: not visible
+   - `piiDetection: { kinds: ["uid"], redactionStatus: "redacted" }`
+   - Raw UID digits never reach `BattleSnapshot` or persisted `draftMetadata`
+6. **Confidence scoring** (per `user-journeys.md` §4):
+   - Agent name / level / weapon / Drive Disc set names / slots / main stats / substat values + roll counts: high confidence (text-rendered)
+   - Element icon / specialty icon / mindscape badge: medium confidence (icon-based)
+   - Skill levels: medium confidence (small font)
+   - All critical fields high or medium → no field-tier escalation needed
+7. **Substat capture precision**: roll counts visible on every substat → substat values populated exactly (no Tier 2 midpoint default needed); recorded in `draftMetadata.evidence.substatRolls`
+8. **Output**: `battleSnapshotDraft` (strict schema, total panel values only) + `draftMetadata` + `nextStep: "Hand off to fairy-snapshot for review/edit and any missing critical fields."`
+9. **Chain handoff**: AI host consumes `nextStep`, presents review/edit gate, then user confirm → fairy-snapshot → fairy-calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/yixuan-workshop.snapshot.json`
+- **draftMetadata**: see `expected/yixuan-workshop.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「绝区零工坊」截图里读到:
+
+  角色: 仪玄 Lv60 (影画 2，玄墨·命破)
+  武器: 青溟笼舍 Lv60 R1
+  6 件套: 云霄如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
+  主词条: slot 4 暴击伤害 48% / slot 5 以太伤害加成 30% / slot 6 生命值 30%
+  副词条: 全部读到（含 roll 次数，无需默认填值）
+  面板: HP 18305, ATK 1979, DEF 718, 冲击力 93, 暴击率 55.4%, 暴击伤害 200.4%, 异常掌控 92, 异常精通 117, 贯穿力 2424
+  技能等级: 普攻 12 / 闪避 11 / 支援 12 / 特殊技 12 / 连携技 12
+
+  证据 (audit-only，不进 calc):
+    - HP 18305 = 8373 base + 9932 bonus
+    - ATK 1979 = 1615 base + 364 bonus
+    - DEF 718 = 441 base + 277 bonus
+    - 截图来源: 绝区零工坊 (UID 已识别并隐藏，不入 snapshot)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions (per `docs/ai-plugin/v1.2.3-vision/acceptance.md`)
+
+### V-G1 — Source detection & layout routing
+
+- `sourceDetection.sourceId === "zzz-workshop"` ✓
+- Workshop layout map applied (Region 7 Drive Disc cards parsed in 2-row grid order)
+- Generic "unknown source" fallback NOT triggered
+- Source detection result recorded in `draftMetadata`, not in `BattleSnapshot`
+
+### V-G2 — Extraction evidence & schema boundary
+
+- `BattleSnapshot.team[*].panel` contains total panel values only (no base/bonus split)
+- `draftMetadata.evidence.statSplits` records base+bonus pairs (3 stat splits at minimum: HP / ATK / DEF)
+- `draftMetadata.evidence.substatRolls` records visible roll counts for at least one Drive Disc substat
+- `BattleSnapshot` parses through `parseBattleSnapshot` without ad hoc field keys (no `uid`, `username`, `sourceImage`, `baseAttack`, `bonusAttack` etc.)
+
+### V-G3 — Review/edit & uncertainty handling
+
+- High-confidence fields pre-filled; no critical field tier escalation triggered
+- Review/edit gate text contains no skill names (`fairy-vision`, `fairy-snapshot`, `fairy-calc`, `fairy-explain`)
+- Review/edit gate text contains no orchestration phrasing (`invoking ...`, `transferring to ...`, `handing off to ...`)
+- "5★ midpoint default" copy is absent (substat values captured from roll counts)
+
+### V-G4 — Privacy & PII exclusion
+
+- `BattleSnapshot` contains no `uid` / `username` / other account identifier keys
+- `draftMetadata.piiDetection.kinds === ["uid"]` (no raw digits)
+- `draftMetadata.piiDetection.redactionStatus === "redacted"`
+- Public fixture display copy does not contain the raw UID `11553939`; only "UID 已识别并隐藏" or similar
+
+### V-G5 — End-to-end CLI calc validation
+
+- Confirmed `BattleSnapshot` is structurally valid input for `fairy calc <snapshot> --view verbose --lang zh`
+- Calc output (when generated downstream) contains no skill names / orchestration phrasing
+- No `fairy compare` invocation appears in this fixture path
+
+### K4 — Chain transition invisibility
+
+- Review/edit gate copy reads as continuous AI conversation; no `fairy-vision` / `fairy-snapshot` / `fairy-calc` skill-name reference visible to user
+- "Hand off" appears in `draftMetadata.nextStep` (canonical EN, internal chain) but NOT in user-facing zh copy

--- a/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
@@ -2,7 +2,7 @@
 
 **Skill**: fairy-vision
 **Source**: zzz-workshop (绝区零工坊 WeChat mini-app)
-**Scenario**: P1 user pastes a 工坊 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云霄如我 4pc + 折枝剑歌 2pc; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, hands off to fairy-snapshot for review/edit.
+**Scenario**: P1 user pastes a 工坊 build screenshot of 仪玄 Lv60 + 青溟笼舍 R1 + 云岿如我 4pc + 折枝剑歌 2pc; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, hands off to fairy-snapshot for review/edit.
 **Lang**: zh
 
 This fixture demonstrates the **happy-path 工坊** flow: high-confidence source detection, complete field extraction including substat roll counts, no missing fields, PII (UID) detected and redacted at the draftMetadata level, review/edit gate uses generic source description (no skill-name leakage per K4).
@@ -42,7 +42,7 @@ User (zh, with image attachment):
    - Element icon / specialty icon / mindscape badge: medium confidence (icon-based)
    - Skill levels: medium confidence (small font)
    - All critical fields high or medium → no field-tier escalation needed
-7. **Substat capture precision**: roll counts visible on every substat → substat values populated exactly (no Tier 2 midpoint default needed); recorded in `draftMetadata.evidence.substatRolls`
+7. **Substat capture precision**: roll counts visible on every substat → substat values populated exactly (no Tier 2 midpoint default needed); recorded in `draftMetadata.evidence.substatRollsSample`
 8. **Output**: `battleSnapshotDraft` (strict schema, total panel values only) + `draftMetadata` + `nextStep: "Hand off to fairy-snapshot for review/edit and any missing critical fields."`
 9. **Chain handoff**: AI host consumes `nextStep`, presents review/edit gate, then user confirm → fairy-snapshot → fairy-calc.
 
@@ -58,7 +58,7 @@ User (zh, with image attachment):
 
   角色: 仪玄 Lv60 (影画 2，玄墨·命破)
   武器: 青溟笼舍 Lv60 R1
-  6 件套: 云霄如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
+  6 件套: 云岿如我 4pc (slot 1+3+4+6) + 折枝剑歌 2pc (slot 2+5)
   主词条: slot 4 暴击伤害 48% / slot 5 以太伤害加成 30% / slot 6 生命值 30%
   副词条: 全部读到（含 roll 次数，无需默认填值）
   面板: HP 18305, ATK 1979, DEF 718, 冲击力 93, 暴击率 55.4%, 暴击伤害 200.4%, 异常掌控 92, 异常精通 117, 贯穿力 2424
@@ -87,7 +87,7 @@ User (zh, with image attachment):
 
 - `BattleSnapshot.team[*].panel` contains total panel values only (no base/bonus split)
 - `draftMetadata.evidence.statSplits` records base+bonus pairs (3 stat splits at minimum: HP / ATK / DEF)
-- `draftMetadata.evidence.substatRolls` records visible roll counts for at least one Drive Disc substat
+- `draftMetadata.evidence.substatRollsSample` records visible roll counts for at least one Drive Disc substat
 - `BattleSnapshot` parses through `parseBattleSnapshot` without ad hoc field keys (no `uid`, `username`, `sourceImage`, `baseAttack`, `bonusAttack` etc.)
 
 ### V-G3 — Review/edit & uncertainty handling

--- a/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md
@@ -102,13 +102,13 @@ User (zh, with image attachment):
 - `BattleSnapshot` contains no `uid` / `username` / other account identifier keys
 - `draftMetadata.piiDetection.kinds === ["uid"]` (no raw digits)
 - `draftMetadata.piiDetection.redactionStatus === "redacted"`
-- Public fixture display copy does not contain the raw UID `11553939`; only "UID 已识别并隐藏" or similar
+- Public fixture display copy contains no raw UID digits; only the redacted-status notice ("UID 已识别并隐藏") or equivalent
 
 ### V-G5 — End-to-end CLI calc validation
 
 - Confirmed `BattleSnapshot` is structurally valid input for `fairy calc <snapshot> --view verbose --lang zh`
 - Calc output (when generated downstream) contains no skill names / orchestration phrasing
-- No `fairy compare` invocation appears in this fixture path
+- The deferred binary-comparison skill (per D-19) is not invoked anywhere in this fixture path
 
 ### K4 — Chain transition invisibility
 

--- a/examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": ["current-live"]
+  },
+  "team": [
+    {
+      "agentId": "1371",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "skillLevels": {
+        "basic": 12,
+        "dodge": 11,
+        "assist": 12,
+        "special": 12,
+        "ultimate": 12,
+        "corePassive": 7
+      },
+      "mindscapeCinema": {
+        "level": 2
+      },
+      "wEngine": {
+        "id": "14140",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        { "id": "drive-slot-1", "slot": 1, "setId": "31002" },
+        { "id": "drive-slot-2", "slot": 2, "setId": "31003" },
+        { "id": "drive-slot-3", "slot": 3, "setId": "31002" },
+        { "id": "drive-slot-4", "slot": 4, "setId": "31002" },
+        { "id": "drive-slot-5", "slot": 5, "setId": "31003" },
+        { "id": "drive-slot-6", "slot": 6, "setId": "31002" }
+      ],
+      "panel": {
+        "attack": 1979,
+        "maxHp": 18305,
+        "defense": 718,
+        "impact": 93,
+        "critRate": 0.554,
+        "critDamage": 2.004,
+        "anomalyMastery": 92,
+        "anomalyProficiency": 117,
+        "penetration": 0,
+        "energyRegen": 2.0,
+        "sheerForce": 2423,
+        "etherDamageBonus": 0.3
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1371"
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-vision-miyoushe-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1371"
+      },
+      "skillId": "basic",
+      "levelKey": "basic",
+      "multiplier": 4.58,
+      "attribute": "auricInk",
+      "tags": ["basic"],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "auricInk": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json
@@ -27,17 +27,17 @@
         "level": 2
       },
       "wEngine": {
-        "id": "14140",
+        "id": "14137",
         "level": 60,
         "phase": 1
       },
       "driveDiscs": [
-        { "id": "drive-slot-1", "slot": 1, "setId": "31002" },
-        { "id": "drive-slot-2", "slot": 2, "setId": "31003" },
-        { "id": "drive-slot-3", "slot": 3, "setId": "31002" },
-        { "id": "drive-slot-4", "slot": 4, "setId": "31002" },
-        { "id": "drive-slot-5", "slot": 5, "setId": "31003" },
-        { "id": "drive-slot-6", "slot": 6, "setId": "31002" }
+        { "id": "drive-slot-1", "slot": 1, "setId": "33100" },
+        { "id": "drive-slot-2", "slot": 2, "setId": "32700" },
+        { "id": "drive-slot-3", "slot": 3, "setId": "33100" },
+        { "id": "drive-slot-4", "slot": 4, "setId": "33100" },
+        { "id": "drive-slot-5", "slot": 5, "setId": "32700" },
+        { "id": "drive-slot-6", "slot": 6, "setId": "33100" }
       ],
       "panel": {
         "attack": 1979,
@@ -48,7 +48,6 @@
         "critDamage": 2.004,
         "anomalyMastery": 92,
         "anomalyProficiency": 117,
-        "penetration": 0,
         "energyRegen": 2.0,
         "sheerForce": 2423,
         "etherDamageBonus": 0.3
@@ -81,10 +80,10 @@
   "enemy": {
     "enemyId": "30004",
     "level": 60,
-    "rank": "boss",
+    "rank": "special",
     "maxHp": 1000000,
     "resistance": {
-      "auricInk": 0
+      "ether": 0
     }
   },
   "options": {

--- a/examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json
@@ -26,17 +26,17 @@
         "level": 2
       },
       "wEngine": {
-        "id": "14140",
+        "id": "14137",
         "level": 60,
         "phase": 1
       },
       "driveDiscs": [
-        { "id": "drive-slot-1", "slot": 1, "setId": "31002" },
-        { "id": "drive-slot-2", "slot": 2, "setId": "31003" },
-        { "id": "drive-slot-3", "slot": 3, "setId": "31002" },
-        { "id": "drive-slot-4", "slot": 4, "setId": "31002" },
-        { "id": "drive-slot-5", "slot": 5, "setId": "31003" },
-        { "id": "drive-slot-6", "slot": 6, "setId": "31002" }
+        { "id": "drive-slot-1", "slot": 1, "setId": "33100" },
+        { "id": "drive-slot-2", "slot": 2, "setId": "32700" },
+        { "id": "drive-slot-3", "slot": 3, "setId": "33100" },
+        { "id": "drive-slot-4", "slot": 4, "setId": "33100" },
+        { "id": "drive-slot-5", "slot": 5, "setId": "32700" },
+        { "id": "drive-slot-6", "slot": 6, "setId": "33100" }
       ],
       "panel": {
         "attack": 1979,
@@ -47,9 +47,9 @@
         "critDamage": 2.004,
         "anomalyMastery": 92,
         "anomalyProficiency": 117,
-        "penetration": 0,
         "energyRegen": 1.2,
-        "sheerForce": 2424
+        "sheerForce": 2424,
+        "etherDamageBonus": 0.3
       }
     }
   ],
@@ -79,10 +79,10 @@
   "enemy": {
     "enemyId": "30004",
     "level": 60,
-    "rank": "boss",
+    "rank": "special",
     "maxHp": 1000000,
     "resistance": {
-      "auricInk": 0
+      "ether": 0
     }
   },
   "options": {

--- a/examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": ["current-live"]
+  },
+  "team": [
+    {
+      "agentId": "1371",
+      "level": 60,
+      "agentSpecialty": "rupture",
+      "attribute": "auricInk",
+      "skillLevels": {
+        "basic": 12,
+        "dodge": 11,
+        "assist": 12,
+        "special": 12,
+        "ultimate": 12
+      },
+      "mindscapeCinema": {
+        "level": 2
+      },
+      "wEngine": {
+        "id": "14140",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        { "id": "drive-slot-1", "slot": 1, "setId": "31002" },
+        { "id": "drive-slot-2", "slot": 2, "setId": "31003" },
+        { "id": "drive-slot-3", "slot": 3, "setId": "31002" },
+        { "id": "drive-slot-4", "slot": 4, "setId": "31002" },
+        { "id": "drive-slot-5", "slot": 5, "setId": "31003" },
+        { "id": "drive-slot-6", "slot": 6, "setId": "31002" }
+      ],
+      "panel": {
+        "attack": 1979,
+        "maxHp": 18305,
+        "defense": 718,
+        "impact": 93,
+        "critRate": 0.554,
+        "critDamage": 2.004,
+        "anomalyMastery": 92,
+        "anomalyProficiency": 117,
+        "penetration": 0,
+        "energyRegen": 1.2,
+        "sheerForce": 2424
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1371"
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-vision-workshop-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1371"
+      },
+      "skillId": "basic",
+      "levelKey": "basic",
+      "multiplier": 4.58,
+      "attribute": "auricInk",
+      "tags": ["basic"],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "boss",
+    "maxHp": 1000000,
+    "resistance": {
+      "auricInk": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}


### PR DESCRIPTION
## Summary

UX P2 deliverable (task #228) — starter happy-path fixtures for the V1.2.3 \`fairy-vision\` skill, covering the **cross-source consistency contract** via 仪玄 build screenshots from both supported community-tool sources.

- 2 fixtures: 绝区零工坊 + 米游社 with the same agent / build to verify same canonical \`BattleSnapshot\` regardless of source.
- 2 \`snapshots/*.snapshot.json\` (strict schema, panel totals only, no PII / no base-bonus / no ad hoc fields).
- 2 \`expected/*.draft-metadata.json\` (sourceDetection, piiDetection redacted-status, perFieldConfidence, evidence with statSplits + substatRollsSample + driverScoreObserved + crossSourceNotes, nextStep).
- 1 \`README.md\` (directory layout, fixture file shape, PII redaction policy, cross-references to D-22 / acceptance.md / user-journeys.md).

## PII redaction

Per V-G4 + lo-user A2.a: real UID \`11553939\` and username \`Lo\` detected at extraction → discarded; only \`piiDetection.kinds\` + \`redactionStatus: redacted\` persist in \`draftMetadata\`. Public fixture display copy contains no raw PII values.

## Cross-source contract

Both fixtures produce same agentId / mindscape / weapon / Drive Disc composition / panel (within documented 1-unit rounding on 贯穿力 between sources). 米游社 surfaces \`etherDamageBonus 30%\` in panel where 工坊 does not; documented as source-difference observation, not extraction error.

## Acceptance assertions per fixture

V-G1 / V-G2 / V-G3 / V-G4 / V-G5 + K4 chain-invisibility — specific per-fixture checks documented inline in each \`prompts/vision-*.md\`.

## Scope

Happy-path cross-source pair ships to unblock QA P3 harness (task #229).
Future P2.x batches per fixture README will cover: additional agents (耀佳音 / 琉音 / 星见雅), partial-extraction, visual ambiguity, source-unknown / NL fallback, low-confidence majority, PII edge cases.

## Test plan

- [ ] @QA review V-G1..V-G5 + K4 invariants per fixture
- [ ] @TechLead review BattleSnapshot schema correctness + cross-source identical \`agentId\` / \`wEngine\` / \`driveDiscs[*].setId\` 
- [ ] @Product review fixture README structure + cross-references
- [ ] @lo-user final review before merge