### PR TITLE
feat(golden): add V1.2.3 vision fixture harness

### DIFF
--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -20,6 +20,8 @@ examples/ai-plugin/vision/
   expected/
     yixuan-workshop.draft-metadata.json   # draftMetadata: sourceDetection / piiDetection status / evidence
     yixuan-miyoushe.draft-metadata.json   # draftMetadata for miyoushe variant
+    yixuan-workshop.calc.json             # CLI verbose CalcResult baseline from confirmed workshop snapshot
+    yixuan-miyoushe.calc.json             # CLI verbose CalcResult baseline from confirmed miyoushe snapshot
 ```
 
 ## Scope (P2 starter — happy-path coverage)

--- a/examples/ai-plugin/vision/expected/yixuan-miyoushe.calc.json
+++ b/examples/ai-plugin/vision/expected/yixuan-miyoushe.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1371",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 5355.893636363637,
+        "displayDamage": 5356
+      },
+      "crit": {
+        "rawDamage": 16089.104483636365,
+        "displayDamage": 16090
+      }
+    },
+    "rawTotalDamage": 11302.092445752727,
+    "displayTotalDamage": 11303,
+    "expectedDamage": 11302.092445752727,
+    "critDamage": 16089.104483636365,
+    "nonCritDamage": 5355.893636363637,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-vision-miyoushe-1",
+      "actorId": "1371",
+      "attribute": "auricInk",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 11302.092445752727,
+      "segmentDisplayDamage": 11303,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 9063.82,
+      "expectedDamage": 11302.092445752727,
+      "critDamage": 16089.104483636365,
+      "nonCritDamage": 5355.893636363637,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 9063.82,
+      "effectiveMultiplier": 9063.82,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 9063.82,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1.3,
+      "effectiveMultiplier": 1.3,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0.3,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 2.1102160000000003,
+      "effectiveMultiplier": 2.1102160000000003,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 2.1102160000000003,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-miyoushe-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "yixuan-vision-miyoushe-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 9063.82,
+      "displayValue": 9063.82,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "yixuan-vision-miyoushe-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0.3,
+      "displayValue": 1.3,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "yixuan-vision-miyoushe-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 2.1102160000000003,
+      "displayValue": 2.1102160000000003,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "yixuan-vision-miyoushe-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "yixuan-vision-miyoushe-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "yixuan-vision-miyoushe-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "yixuan-vision-miyoushe-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "yixuan-vision-miyoushe-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 9063.82,
+        "damageType": "regular",
+        "multiplier": 4.58,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 11302.092445752727,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 11302.092445752727,
+      "displayValue": 11303,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 11302.092445752727,
+        "output": 11303,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/yixuan-workshop.calc.json
+++ b/examples/ai-plugin/vision/expected/yixuan-workshop.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1371",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 5355.893636363637,
+        "displayDamage": 5356
+      },
+      "crit": {
+        "rawDamage": 16089.104483636365,
+        "displayDamage": 16090
+      }
+    },
+    "rawTotalDamage": 11302.092445752727,
+    "displayTotalDamage": 11303,
+    "expectedDamage": 11302.092445752727,
+    "critDamage": 16089.104483636365,
+    "nonCritDamage": 5355.893636363637,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "yixuan-vision-workshop-1",
+      "actorId": "1371",
+      "attribute": "auricInk",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 11302.092445752727,
+      "segmentDisplayDamage": 11303,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 9063.82,
+      "expectedDamage": 11302.092445752727,
+      "critDamage": 16089.104483636365,
+      "nonCritDamage": 5355.893636363637,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 9063.82,
+      "effectiveMultiplier": 9063.82,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 9063.82,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1.3,
+      "effectiveMultiplier": 1.3,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0.3,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 2.1102160000000003,
+      "effectiveMultiplier": 2.1102160000000003,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 2.1102160000000003,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "yixuan-vision-workshop-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "character.1371.skill.basic"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "yixuan-vision-workshop-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 9063.82,
+      "displayValue": 9063.82,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "yixuan-vision-workshop-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0.3,
+      "displayValue": 1.3,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "yixuan-vision-workshop-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 2.1102160000000003,
+      "displayValue": 2.1102160000000003,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "yixuan-vision-workshop-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "yixuan-vision-workshop-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "yixuan-vision-workshop-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "yixuan-vision-workshop-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "yixuan-vision-workshop-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "character.1371.skill.basic"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 9063.82,
+        "damageType": "regular",
+        "multiplier": 4.58,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 11302.092445752727,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 11302.092445752727,
+      "displayValue": 11303,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 11302.092445752727,
+        "output": 11303,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md
@@ -103,7 +103,7 @@ User (zh, with image attachment):
 
 ### V-G5 — End-to-end CLI calc validation
 
-- Confirmed `BattleSnapshot` is valid input for `fairy calc <snapshot> --view verbose --lang zh`
+- Confirmed `BattleSnapshot` parses through `parseBattleSnapshot` and is valid input for `fairy calc <snapshot> --view verbose --lang zh`
 - Cross-source identity check (optional): both fixtures share the same agentId / wEngine / driveDiscs composition; calc on each variant may produce slightly different totals because each captures the source-displayed derived panel (per `crossSourceNotes`), not a unified canonical numeric panel
 
 ### K4 — Chain transition invisibility

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -39,6 +39,39 @@ const requiredExampleFiles = [
   "examples/ai-plugin/expected/yixuan-basic.explain.zh.md",
   "examples/ai-plugin/expected/yixuan-basic.explain.en.md",
 ]
+const visionExampleDirs = [
+  "examples/ai-plugin/vision/prompts",
+  "examples/ai-plugin/vision/snapshots",
+  "examples/ai-plugin/vision/expected",
+]
+const visionFixtures = [
+  {
+    name: "yixuan-workshop",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/yixuan-workshop.calc.json",
+    piiKinds: ["uid"],
+    userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
+  },
+  {
+    name: "yixuan-miyoushe",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/yixuan-miyoushe.calc.json",
+    piiKinds: ["uid", "username"],
+    userCopyIncludes: ["截图来源: 米游社", "UID + 用户名 已识别并隐藏"],
+  },
+]
+const requiredVisionExampleFiles = [
+  "examples/ai-plugin/vision/README.md",
+  ...visionFixtures.flatMap(fixture => [fixture.prompt, fixture.snapshot, fixture.metadata, fixture.calc]),
+]
 const entitySectionDomains = [
   { heading: "Agents (characters)", domain: "agents", type: "character" },
   { heading: "W-Engines (weapons)", domain: "wEngines", type: "weapon" },
@@ -134,8 +167,14 @@ for (const [key, doc] of Object.entries(plugin.docs ?? {}))
 for (const dir of exampleDirs)
   assert(existsSync(path.join(repoRoot, dir)), `example directory is missing: ${dir}`)
 
+for (const dir of visionExampleDirs)
+  assert(existsSync(path.join(repoRoot, dir)), `vision example directory is missing: ${dir}`)
+
 for (const file of requiredExampleFiles)
   assert(existsSync(path.join(repoRoot, file)), `required AI plugin example fixture is missing: ${file}`)
+
+for (const file of requiredVisionExampleFiles)
+  assert(existsSync(path.join(repoRoot, file)), `required AI plugin vision fixture is missing: ${file}`)
 
 assert(existsSync(path.join(repoRoot, ".codex/README.md")), ".codex/README.md is missing")
 
@@ -419,6 +458,285 @@ function verifyCalcFixture(snapshot) {
   return expected
 }
 
+function verifyNoVisionImageInputsCommitted() {
+  const imageFiles = listFilesRecursive(path.join(repoRoot, "examples/ai-plugin/vision"))
+    .filter(file => /\.(?:png|jpe?g|webp|gif|heic)$/i.test(file))
+    .map(file => path.relative(repoRoot, file))
+  assert(imageFiles.length === 0, `vision fixtures must not commit raw image files: ${imageFiles.join(", ")}`)
+}
+
+function jsonPathJoin(parentPath, key) {
+  return `${parentPath}.${String(key)}`
+}
+
+function walkJson(value, visitor, currentPath = "$") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walkJson(item, visitor, `${currentPath}[${index}]`))
+    return
+  }
+
+  if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = jsonPathJoin(currentPath, key)
+      visitor(key, child, childPath)
+      walkJson(child, visitor, childPath)
+    }
+  }
+}
+
+function assertNoPiiKeys(value, relativePath) {
+  const forbiddenKeys = new Set(["uid", "userId", "username", "nickname", "accountId", "sourceImage"])
+  walkJson(value, (key, child, childPath) => {
+    assert(!forbiddenKeys.has(key), `${relativePath}: PII/evidence-only key is not allowed at ${childPath}`)
+    if (typeof child === "string") {
+      assert(!/11553939/.test(child), `${relativePath}: raw sample UID must not be persisted at ${childPath}`)
+      assert(child !== "Lo", `${relativePath}: raw sample username must not be persisted at ${childPath}`)
+    }
+  })
+}
+
+function assertNoEvidenceOnlySnapshotKeys(snapshot, relativePath) {
+  const forbiddenKeys = new Set([
+    "uid",
+    "userId",
+    "username",
+    "nickname",
+    "accountId",
+    "sourceImage",
+    "baseAttack",
+    "bonusAttack",
+    "baseHp",
+    "bonusHp",
+    "baseDefense",
+    "bonusDefense",
+    "rollCount",
+    "confidence",
+    "sourceDetection",
+    "piiDetection",
+    "draftMetadata",
+    "rawValues",
+  ])
+  walkJson(snapshot, (key, child, childPath) => {
+    assert(!forbiddenKeys.has(key), `${relativePath}: evidence-only key is not allowed in BattleSnapshot at ${childPath}`)
+    if (typeof child === "string")
+      assert(child !== "unknown", `${relativePath}: strict BattleSnapshot must not use unknown as a value at ${childPath}`)
+  })
+}
+
+function assertExactStringArray(actual, expected, context) {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${context}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+  )
+}
+
+function extractReviewEditCopy(relativePath) {
+  const text = readText(relativePath)
+  const match = text.match(/## Review\/edit gate copy[^\n]*\n\n```(?:[a-z]+)?\n([\s\S]*?)\n```/)
+  assert(match !== null, `${relativePath}: missing Review/edit gate fenced copy block`)
+  return match?.[1] ?? ""
+}
+
+function assertNoUserFacingChainLeak(copy, relativePath) {
+  const forbidden = [
+    /fairy-vision/g,
+    /fairy-snapshot/g,
+    /fairy-calc/g,
+    /fairy-explain/g,
+    /\binvok(?:e|ing)\b/gi,
+    /\btransferr?ing to\b/gi,
+    /\bhand(?:ing)? off\b/gi,
+    /调用/g,
+    /移交/g,
+    /转交/g,
+    /链路/g,
+    /编排/g,
+  ]
+  for (const pattern of forbidden) {
+    const matches = copy.match(pattern)
+    assert(!matches, `${relativePath}: user-facing review/edit copy leaks chain implementation phrase ${pattern}`)
+  }
+}
+
+function runVisionCliCalc(relativeSnapshotPath) {
+  const output = execFileSync(
+    "pnpm",
+    [
+      "--silent",
+      "--filter",
+      "@randomplay/cli",
+      "exec",
+      "tsx",
+      "src/index.ts",
+      "calc",
+      `../../${relativeSnapshotPath}`,
+      "--view",
+      "verbose",
+      "--lang",
+      "zh",
+      "--pretty",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  )
+  return JSON.parse(output)
+}
+
+function verifyVisionSnapshot(fixture) {
+  const snapshot = readJson(fixture.snapshot)
+  if (core?.parseBattleSnapshot !== undefined) {
+    try {
+      core.parseBattleSnapshot(snapshot)
+    }
+    catch (error) {
+      errors.push(`${fixture.snapshot} does not parse as BattleSnapshot: ${error.message}`)
+      return snapshot
+    }
+  }
+
+  assertNoPiiKeys(snapshot, fixture.snapshot)
+  assertNoEvidenceOnlySnapshotKeys(snapshot, fixture.snapshot)
+
+  const actor = snapshot.team?.[0]
+  assert(actor?.agentId === "1371", `${fixture.snapshot}: expected agentId 1371`)
+  assert(actor?.wEngine?.id === "14137", `${fixture.snapshot}: expected W-Engine id 14137`)
+  assert(snapshot.activeActor?.agentId === "1371", `${fixture.snapshot}: activeActor must be 仪玄`)
+  assert(snapshot.enemy?.enemyId === "30004", `${fixture.snapshot}: expected enemy id 30004`)
+  assert(snapshot.enemy?.rank === "special", `${fixture.snapshot}: expected enemy rank special`)
+  assert(snapshot.enemy?.resistance?.ether === 0, `${fixture.snapshot}: auric ink fixture must map resistance through ether`)
+
+  assertRuntimeEntity("agents", actor?.agentId, `${fixture.snapshot}: team agent`)
+  assertRuntimeEntity("wEngines", actor?.wEngine?.id, `${fixture.snapshot}: W-Engine`)
+  assertRuntimeEntity("enemies", snapshot.enemy?.enemyId, `${fixture.snapshot}: enemy`)
+
+  const setIds = (actor?.driveDiscs ?? []).map(disc => disc.setId).filter(Boolean)
+  assert(setIds.length === 6, `${fixture.snapshot}: expected six Drive Disc slots`)
+  assert(setIds.filter(id => id === "33100").length === 4, `${fixture.snapshot}: expected 云岿如我 4pc`)
+  assert(setIds.filter(id => id === "32700").length === 2, `${fixture.snapshot}: expected 折枝剑歌 2pc`)
+  for (const id of setIds)
+    assertRuntimeEntity("driveDiscs", id, `${fixture.snapshot}: Drive Disc set`)
+
+  return snapshot
+}
+
+function verifyVisionDraftMetadata(fixture) {
+  const metadata = readJson(fixture.metadata)
+  assertNoPiiKeys(metadata, fixture.metadata)
+  assert(metadata.schemaVersion === "v1.2.3-vision-draft-metadata-v1", `${fixture.metadata}: unexpected schemaVersion`)
+  assert(metadata.fixtureName === `vision-${fixture.name.replace("yixuan-", "")}-yixuan`, `${fixture.metadata}: fixtureName must match fixture`)
+  assert(metadata.sourceDetection?.sourceId === fixture.sourceId, `${fixture.metadata}: sourceDetection.sourceId mismatch`)
+  assert(metadata.sourceDetection?.sourceLabel === fixture.sourceLabel, `${fixture.metadata}: sourceDetection.sourceLabel mismatch`)
+  assert(metadata.sourceDetection?.confidence >= 0.9, `${fixture.metadata}: sourceDetection confidence must be high`)
+  assert(Array.isArray(metadata.sourceDetection?.cues) && metadata.sourceDetection.cues.length >= 3, `${fixture.metadata}: sourceDetection.cues must include source evidence`)
+
+  assertExactStringArray(metadata.piiDetection?.kinds, fixture.piiKinds, `${fixture.metadata}: piiDetection.kinds`)
+  assert(metadata.piiDetection?.redactionStatus === "redacted", `${fixture.metadata}: piiDetection.redactionStatus must be redacted`)
+  assert(metadata.piiDetection?.rawValuesDiscarded === true, `${fixture.metadata}: raw PII values must be discarded`)
+
+  const confidenceValues = Object.values(metadata.perFieldConfidence ?? {})
+  assert(confidenceValues.length > 0, `${fixture.metadata}: perFieldConfidence is required`)
+  for (const value of confidenceValues)
+    assert(["high", "medium", "low"].includes(value), `${fixture.metadata}: invalid confidence value ${value}`)
+
+  const statSplits = metadata.evidence?.statSplits ?? []
+  assert(Array.isArray(statSplits) && statSplits.length >= 3, `${fixture.metadata}: evidence.statSplits must include HP/ATK/DEF audit evidence`)
+  for (const split of statSplits) {
+    assert(typeof split.stat === "string", `${fixture.metadata}: stat split requires stat`)
+    assert(typeof split.base === "number", `${fixture.metadata}: stat split ${split.stat} requires numeric base`)
+    assert(typeof split.bonus === "number", `${fixture.metadata}: stat split ${split.stat} requires numeric bonus`)
+    assert(split.base + split.bonus === split.total, `${fixture.metadata}: stat split ${split.stat} total must equal base + bonus`)
+  }
+
+  const substatRolls = metadata.evidence?.substatRollsSample ?? []
+  assert(Array.isArray(substatRolls) && substatRolls.length > 0, `${fixture.metadata}: evidence.substatRollsSample is required`)
+  assert(
+    substatRolls.some(slot => (slot.substats ?? []).some(substat => typeof substat.rollCount === "number")),
+    `${fixture.metadata}: substat roll-count evidence is required`,
+  )
+  return metadata
+}
+
+function verifyVisionPrompt(fixture) {
+  const text = readText(fixture.prompt)
+  includesAll(text, fixture.prompt, [
+    `**Skill**: fairy-vision`,
+    `**Source**: ${fixture.sourceId}`,
+    `sourceDetection.sourceId === "${fixture.sourceId}"`,
+    "parseBattleSnapshot",
+    "fairy calc <snapshot> --view verbose --lang zh",
+    "substatRollsSample",
+  ])
+  for (const snippet of fixture.userCopyIncludes)
+    assert(text.includes(snippet), `${fixture.prompt}: missing review/edit copy snippet ${snippet}`)
+
+  const copy = extractReviewEditCopy(fixture.prompt)
+  assertNoUserFacingChainLeak(copy, fixture.prompt)
+  assert(!copy.includes("5★ midpoint default"), `${fixture.prompt}: source-tool review copy must not use midpoint default language`)
+}
+
+function verifyVisionCalcFixture(fixture, snapshot) {
+  const expected = readJson(fixture.calc)
+  if (core?.parseCalcResult !== undefined) {
+    try {
+      core.parseCalcResult(expected)
+    }
+    catch (error) {
+      errors.push(`${fixture.calc} does not parse as CalcResult: ${error.message}`)
+    }
+  }
+
+  let actual
+  try {
+    actual = runVisionCliCalc(fixture.snapshot)
+  }
+  catch (error) {
+    errors.push(`${fixture.calc}: fairy calc baseline command failed: ${error.message}`)
+    return expected
+  }
+
+  assert(isDeepStrictEqual(actual, expected), `${fixture.calc} must match freshly generated fairy CLI verbose output`)
+  assert(expected.locale === "zh", `${fixture.calc}: baseline locale must be zh`)
+  assert(expected.summary?.activeActorId === snapshot.activeActor?.agentId, `${fixture.calc}: activeActorId must match snapshot`)
+  assert(expected.summary?.enemyId === snapshot.enemy?.enemyId, `${fixture.calc}: enemyId must match snapshot`)
+  assert(Array.isArray(expected.trace) && expected.trace.length > 0, `${fixture.calc}: verbose baseline must include trace`)
+  assert(Array.isArray(expected.warnings) && expected.warnings.length === 0, `${fixture.calc}: vision happy-path baseline must have no warnings`)
+  assert(Array.isArray(expected.errors) && expected.errors.length === 0, `${fixture.calc}: vision happy-path baseline must have no errors`)
+  const serialized = JSON.stringify(expected)
+  assert(!/fairy-(?:vision|snapshot|calc|explain)|invok|transferr?ing|hand(?:ing)? off/i.test(serialized), `${fixture.calc}: CalcResult baseline must not leak AI chain implementation`)
+  return expected
+}
+
+function verifyVisionFixtures() {
+  verifyNoVisionImageInputsCommitted()
+  const visionReadme = readText("examples/ai-plugin/vision/README.md")
+  includesAll(visionReadme, "examples/ai-plugin/vision/README.md", [
+    "yixuan-workshop.calc.json",
+    "yixuan-miyoushe.calc.json",
+    "Cross-source identity contract",
+    "panel.etherDamageBonus: 0.3",
+    "Actual digits never reach committed fixture JSON",
+  ])
+
+  const calcResults = []
+  for (const fixture of visionFixtures) {
+    verifyVisionPrompt(fixture)
+    const snapshot = verifyVisionSnapshot(fixture)
+    verifyVisionDraftMetadata(fixture)
+    calcResults.push(verifyVisionCalcFixture(fixture, snapshot))
+  }
+
+  const [workshop, miyoushe] = calcResults
+  if (workshop !== undefined && miyoushe !== undefined) {
+    assert(
+      workshop.summary?.lanes?.nonCrit?.displayDamage === miyoushe.summary?.lanes?.nonCrit?.displayDamage,
+      "vision cross-source calc baselines must match nonCrit displayDamage for the selected segment",
+    )
+    assert(
+      workshop.summary?.lanes?.crit?.displayDamage === miyoushe.summary?.lanes?.crit?.displayDamage,
+      "vision cross-source calc baselines must match crit displayDamage for the selected segment",
+    )
+  }
+}
+
 function verifyPromptFixtures(calcResult) {
   const yixuanPrompt = readText("examples/ai-plugin/prompts/build-yixuan-basic.md")
   includesAll(yixuanPrompt, "examples/ai-plugin/prompts/build-yixuan-basic.md", [
@@ -488,6 +806,7 @@ function verifyAiPluginExamples() {
   const calcResult = verifyCalcFixture(basicSnapshot)
   verifyPromptFixtures(calcResult)
   verifyExplainFixture(calcResult)
+  verifyVisionFixtures()
 }
 
 verifyAiPluginExamples()


### PR DESCRIPTION
## Summary

- Add V1.2.3 vision fixture calc baselines for the merged workshop + miyoushe Yixuan fixtures.
- Extend `scripts/verify-ai-plugin.mjs` so `pnpm verify:ai-plugin` now validates the P3 vision harness:
  - required vision file set and no committed raw image inputs
  - source detection / routing metadata for `zzz-workshop` and `miyoushe-record`
  - strict `BattleSnapshot` parse and runtime ID checks
  - draft metadata schema, confidence, stat-split, roll-count evidence
  - PII key/raw-value exclusion
  - K4 review/edit copy chain-invisibility scan
  - CLI verbose baseline deep-match for both confirmed vision snapshots
- Align the Miyoushe fixture assertion wording with the new harness by naming `parseBattleSnapshot` explicitly.

## Verification

- `pnpm verify:ai-plugin`
- `pnpm check`
- `pnpm build`
- `pnpm test`
- `git diff --check`
- targeted stale-text / PII / deferred compare scans over `examples/ai-plugin/vision`

## Notes

- This PR does not implement image-model automation. It turns the existing public P2 fixtures into deterministic local QA evidence for P3.
