### PR TITLE
test(ai-plugin): expand vision happy-path fixtures

### DIFF
--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -14,19 +14,23 @@ examples/ai-plugin/vision/
   prompts/
     vision-workshop-yixuan.md         # fairy-vision: 绝区零工坊 happy-path (zh)
     vision-miyoushe-yixuan.md         # fairy-vision: 米游社 happy-path (zh)
+    vision-workshop-{dialyn,miyabi,astra}.md
+    vision-miyoushe-{dialyn,miyabi,astra}.md
   snapshots/
     yixuan-workshop.snapshot.json     # strict BattleSnapshot draft from workshop screenshot
     yixuan-miyoushe.snapshot.json     # strict BattleSnapshot draft from miyoushe screenshot
+    {dialyn,miyabi,astra}-{workshop,miyoushe}.snapshot.json
   expected/
     yixuan-workshop.draft-metadata.json   # draftMetadata: sourceDetection / piiDetection status / evidence
     yixuan-miyoushe.draft-metadata.json   # draftMetadata for miyoushe variant
     yixuan-workshop.calc.json             # CLI verbose CalcResult baseline from confirmed workshop snapshot
     yixuan-miyoushe.calc.json             # CLI verbose CalcResult baseline from confirmed miyoushe snapshot
+    {dialyn,miyabi,astra}-{workshop,miyoushe}.{draft-metadata,calc}.json
 ```
 
-## Scope (P2 starter — happy-path coverage)
+## Scope (P2 starter + F2 happy-path coverage)
 
-V1.2.3 P2 ships the **happy-path** cross-source pair for 仪玄 to demonstrate:
+V1.2.3 P2 shipped the **happy-path** cross-source pair for 仪玄 to demonstrate:
 
 | Property | Workshop variant | Miyoushe variant |
 |---|---|---|
@@ -38,8 +42,22 @@ V1.2.3 P2 ships the **happy-path** cross-source pair for 仪玄 to demonstrate:
 
 **Cross-source identity contract**: V-G1 source detection routes each screenshot through its source-specific layout map. Both fixtures yield the same canonical **identity + build composition** (agent `1371`, weapon `14137` R1, drive disc setIds `33100` + `32700`, slot layout, mindscape level 2). Source-displayed derived stats intentionally differ: 米游社 surfaces a `corePassive` skill slot that 工坊 does not show; both variants include `panel.etherDamageBonus: 0.3` (matching the slot-5 main stat), but `energyRegen` is rendered with different unit conventions (`1.2` 工坊 vs `2.0` 米游社) and `sheerForce` differs by 1 unit between sources from display rounding. Each variant's strict `BattleSnapshot` captures what the source actually displays, with per-source differences documented in `draftMetadata.evidence.crossSourceNotes`. The vision pipeline is source-agnostic at the **identity** boundary; it does not falsify a single canonical numeric panel.
 
-Future P2.x batches will add:
-- Additional agents (耀佳音 / 琉音 / 星见雅) per source — sample images already provided by lo-user
+F2 adds happy-path source/layout coverage for additional agents using the same no-raw-image fixture contract:
+
+| Fixture | Source | Agent | W-Engine | Drive Disc | Baseline |
+|---|---|---|---|---|---|
+| `miyabi-miyoushe` | 米游社 | 雅 / Miyabi (`1091`) | 霰落星殿 (`14109`) | 折枝剑歌 4pc + 静听嘉音 2pc | `miyabi-miyoushe.calc.json` |
+| `miyabi-workshop` | 绝区零工坊 | 雅 / Miyabi (`1091`) | 霰落星殿 (`14109`) | 折枝剑歌 4pc + 河豚电音 2pc | `miyabi-workshop.calc.json` |
+| `astra-miyoushe` | 米游社 | 耀嘉音 / Astra Yao (`1311`) | 好斗的阿炮 (`13115`) | 月光骑士颂 4pc + 静听嘉音 2pc | `astra-miyoushe.calc.json` |
+| `astra-workshop` | 绝区零工坊 | 耀嘉音 / Astra Yao (`1311`) | 好斗的阿炮 (`13115`) | 月光骑士颂 4pc + 静听嘉音 2pc | `astra-workshop.calc.json` |
+| `dialyn-miyoushe` | 米游社 | 琉音 / Dialyn (`1481`) | 昨夜来电 (`14148`) | 山大王 4pc + 月光骑士颂 2pc | `dialyn-miyoushe.calc.json` |
+| `dialyn-workshop` | 绝区零工坊 | 琉音 / Dialyn (`1481`) | 昨夜来电 (`14148`) | 山大王 4pc + 月光骑士颂 2pc | `dialyn-workshop.calc.json` |
+
+These F2 fixtures are **individual extraction + calc baselines**, not cross-source parity pairs. The recovered same-agent source screenshots are not guaranteed to be the same build, so `verify:ai-plugin` only applies cross-source parity to the original Yixuan pair.
+
+The F2 calc baselines use a deterministic `vision-smoke-hit` attack segment to prove that the extracted `BattleSnapshot` is schema-valid and CLI-calculable. They are regression fixtures for vision extraction, entity normalization, and privacy boundaries, not character-rotation modeling claims.
+
+Future P2.x / F2 boundary batches will add:
 - Partial-extraction fixtures (per `docs/ai-plugin/v1.2.3-vision/user-journeys.md` §5)
 - Visual ambiguity fixtures (per §6 — e.g., 米游社 "07" skill slot)
 - Source-unknown / NL fallback fixtures (per §3 + §7)

--- a/examples/ai-plugin/vision/expected/astra-miyoushe.calc.json
+++ b/examples/ai-plugin/vision/expected/astra-miyoushe.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1311",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1376.6382782828864,
+        "displayDamage": 1377
+      },
+      "crit": {
+        "rawDamage": 2791.8224283576938,
+        "displayDamage": 2792
+      }
+    },
+    "rawTotalDamage": 1990.828199415353,
+    "displayTotalDamage": 1991,
+    "expectedDamage": 1990.828199415353,
+    "critDamage": 2791.8224283576938,
+    "nonCritDamage": 1376.6382782828864,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "astra-miyoushe-vision-smoke-1",
+      "actorId": "1311",
+      "attribute": "ether",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 1990.828199415353,
+      "segmentDisplayDamage": 1991,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 3013,
+      "expectedDamage": 1990.828199415353,
+      "critDamage": 2791.8224283576938,
+      "nonCritDamage": 1376.6382782828864,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 3013,
+      "effectiveMultiplier": 3013,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 3013,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 1.446152,
+      "effectiveMultiplier": 1.446152,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 1.446152,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45689952813902635,
+      "effectiveMultiplier": 0.45689952813902635,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-miyoushe-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 3013,
+      "displayValue": 3013,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1.446152,
+      "displayValue": 1.446152,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45689952813902635,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "astra-miyoushe-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 3013,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 1990.828199415353,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 1990.828199415353,
+      "displayValue": 1991,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 1990.828199415353,
+        "output": 1991,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/astra-miyoushe.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/astra-miyoushe.draft-metadata.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-miyoushe-astra",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.95,
+    "cues": [
+      "branding:miyoushe-footer",
+      "layout:full-card-portrait",
+      "layout:agent-info-card-left",
+      "layout:disc-grid-2x3"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid",
+      "username"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 8609,
+        "bonus": 2717,
+        "total": 11326
+      },
+      {
+        "stat": "attack",
+        "base": 1339,
+        "bonus": 1674,
+        "total": 3013
+      },
+      {
+        "stat": "defense",
+        "base": 600,
+        "bonus": 358,
+        "total": 958
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "33400",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      11,
+      3,
+      3,
+      12,
+      12
+    ],
+    "driveDiscSetCounts": {
+      "32800": 2,
+      "33400": 4
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "miyoushe-2-57177655.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 米游社 fixture for 耀嘉音; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/astra-workshop.calc.json
+++ b/examples/ai-plugin/vision/expected/astra-workshop.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1311",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1556.8181818181818,
+        "displayDamage": 1557
+      },
+      "crit": {
+        "rawDamage": 2559.409090909091,
+        "displayDamage": 2560
+      }
+    },
+    "rawTotalDamage": 1703.1964545454546,
+    "displayTotalDamage": 1704,
+    "expectedDamage": 1703.1964545454546,
+    "critDamage": 2559.409090909091,
+    "nonCritDamage": 1556.8181818181818,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "astra-workshop-vision-smoke-1",
+      "actorId": "1311",
+      "attribute": "ether",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 1703.1964545454546,
+      "segmentDisplayDamage": 1704,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 3425,
+      "expectedDamage": 1703.1964545454546,
+      "critDamage": 2559.409090909091,
+      "nonCritDamage": 1556.8181818181818,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 3425,
+      "effectiveMultiplier": 3425,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 3425,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 1.094024,
+      "effectiveMultiplier": 1.094024,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 1.094024,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "astra-workshop-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "astra-workshop-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 3425,
+      "displayValue": 3425,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "astra-workshop-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "astra-workshop-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1.094024,
+      "displayValue": 1.094024,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "astra-workshop-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "astra-workshop-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "astra-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "astra-workshop-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "astra-workshop-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 3425,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 1703.1964545454546,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 1703.1964545454546,
+      "displayValue": 1704,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 1703.1964545454546,
+        "output": 1704,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/astra-workshop.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/astra-workshop.draft-metadata.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-workshop-astra",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.95,
+    "cues": [
+      "branding:workshop-header",
+      "layout:phone-status-bar",
+      "layout:agent-roster-row-top",
+      "layout:ace-rating-text"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 8609,
+        "bonus": 2458,
+        "total": 11067
+      },
+      {
+        "stat": "attack",
+        "base": 1339,
+        "bonus": 2086,
+        "total": 3425
+      },
+      {
+        "stat": "defense",
+        "base": 600,
+        "bonus": 430,
+        "total": 1030
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "33400",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      11,
+      3,
+      3,
+      12,
+      12
+    ],
+    "driveDiscSetCounts": {
+      "32800": 2,
+      "33400": 4
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "workshop-3-bddc89e0.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 绝区零工坊 fixture for 耀嘉音; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/dialyn-miyoushe.calc.json
+++ b/examples/ai-plugin/vision/expected/dialyn-miyoushe.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1481",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1405.7727272727273,
+        "displayDamage": 1406
+      },
+      "crit": {
+        "rawDamage": 2918.384181818182,
+        "displayDamage": 2919
+      }
+    },
+    "rawTotalDamage": 2918.3841818181822,
+    "displayTotalDamage": 2919,
+    "expectedDamage": 2918.3841818181822,
+    "critDamage": 2918.384181818182,
+    "nonCritDamage": 1405.7727272727273,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "dialyn-miyoushe-vision-smoke-1",
+      "actorId": "1481",
+      "attribute": "physical",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 2918.3841818181822,
+      "segmentDisplayDamage": 2919,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 2379,
+      "expectedDamage": 2918.3841818181822,
+      "critDamage": 2918.384181818182,
+      "nonCritDamage": 1405.7727272727273,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 2379,
+      "effectiveMultiplier": 2379,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 2379,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1.3,
+      "effectiveMultiplier": 1.3,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 0.3,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 2.076,
+      "effectiveMultiplier": 2.076,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 2.076,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-miyoushe-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 2379,
+      "displayValue": 2379,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0.3,
+      "displayValue": 1.3,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 2.076,
+      "displayValue": 2.076,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "dialyn-miyoushe-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 2379,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 2918.3841818181822,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 2918.3841818181822,
+      "displayValue": 2919,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 2918.3841818181822,
+        "output": 2919,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/dialyn-miyoushe.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/dialyn-miyoushe.draft-metadata.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-miyoushe-dialyn",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.95,
+    "cues": [
+      "branding:miyoushe-footer",
+      "layout:full-card-portrait",
+      "layout:agent-info-card-left",
+      "layout:disc-grid-2x3"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid",
+      "username"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 8250,
+        "bonus": 2919,
+        "total": 11169
+      },
+      {
+        "stat": "attack",
+        "base": 1471,
+        "bonus": 908,
+        "total": 2379
+      },
+      {
+        "stat": "defense",
+        "base": 612,
+        "bonus": 213,
+        "total": 825
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "33200",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      12,
+      11,
+      12,
+      12,
+      12
+    ],
+    "driveDiscSetCounts": {
+      "33200": 4,
+      "33400": 2
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "miyoushe-3-9e1826de.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 米游社 fixture for 琉音; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/dialyn-workshop.calc.json
+++ b/examples/ai-plugin/vision/expected/dialyn-workshop.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1481",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1431.7727272727273,
+        "displayDamage": 1432
+      },
+      "crit": {
+        "rawDamage": 2834.91,
+        "displayDamage": 2835
+      }
+    },
+    "rawTotalDamage": 2834.91,
+    "displayTotalDamage": 2835,
+    "expectedDamage": 2834.91,
+    "critDamage": 2834.91,
+    "nonCritDamage": 1431.7727272727273,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "dialyn-workshop-vision-smoke-1",
+      "actorId": "1481",
+      "attribute": "physical",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 2834.91,
+      "segmentDisplayDamage": 2835,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 2423,
+      "expectedDamage": 2834.91,
+      "critDamage": 2834.91,
+      "nonCritDamage": 1431.7727272727273,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 2423,
+      "effectiveMultiplier": 2423,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 2423,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1.3,
+      "effectiveMultiplier": 1.3,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 0.3,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 1.98,
+      "effectiveMultiplier": 1.98,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 1.98,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.45454545454545453,
+      "effectiveMultiplier": 0.45454545454545453,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "dialyn-workshop-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 2423,
+      "displayValue": 2423,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0.3,
+      "displayValue": 1.3,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1.98,
+      "displayValue": 1.98,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.45454545454545453,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "dialyn-workshop-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 2423,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 2834.91,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 2834.91,
+      "displayValue": 2835,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 2834.91,
+        "output": 2835,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/dialyn-workshop.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/dialyn-workshop.draft-metadata.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-workshop-dialyn",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.95,
+    "cues": [
+      "branding:workshop-header",
+      "layout:phone-status-bar",
+      "layout:agent-roster-row-top",
+      "layout:ace-rating-text"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 8250,
+        "bonus": 3414,
+        "total": 11664
+      },
+      {
+        "stat": "attack",
+        "base": 1471,
+        "bonus": 952,
+        "total": 2423
+      },
+      {
+        "stat": "defense",
+        "base": 612,
+        "bonus": 184,
+        "total": 796
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "33400",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      12,
+      11,
+      12,
+      12,
+      12
+    ],
+    "driveDiscSetCounts": {
+      "33200": 4,
+      "33400": 2
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "workshop-1-6701bde2.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 绝区零工坊 fixture for 琉音; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/miyabi-miyoushe.calc.json
+++ b/examples/ai-plugin/vision/expected/miyabi-miyoushe.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1091",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1615.55278956602,
+        "displayDamage": 1616
+      },
+      "crit": {
+        "rawDamage": 4387.841376461311,
+        "displayDamage": 4388
+      }
+    },
+    "rawTotalDamage": 3617.145149304419,
+    "displayTotalDamage": 3618,
+    "expectedDamage": 3617.145149304419,
+    "critDamage": 4387.841376461311,
+    "nonCritDamage": 1615.55278956602,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "miyabi-miyoushe-vision-smoke-1",
+      "actorId": "1091",
+      "attribute": "frost",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 3617.145149304419,
+      "segmentDisplayDamage": 3618,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 3034,
+      "expectedDamage": 3617.145149304419,
+      "critDamage": 4387.841376461311,
+      "nonCritDamage": 1615.55278956602,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 3034,
+      "effectiveMultiplier": 3034,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 3034,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 2.238952,
+      "effectiveMultiplier": 2.238952,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 2.238952,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.5324827915510942,
+      "effectiveMultiplier": 0.5324827915510942,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-miyoushe-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 3034,
+      "displayValue": 3034,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 2.238952,
+      "displayValue": 2.238952,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.5324827915510942,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "miyabi-miyoushe-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 3034,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 3617.145149304419,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 3617.145149304419,
+      "displayValue": 3618,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 3617.145149304419,
+        "output": 3618,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/miyabi-miyoushe.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/miyabi-miyoushe.draft-metadata.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-miyoushe-miyabi",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.95,
+    "cues": [
+      "branding:miyoushe-footer",
+      "layout:full-card-portrait",
+      "layout:agent-info-card-left",
+      "layout:disc-grid-2x3"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid",
+      "username"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 7673,
+        "bonus": 3109,
+        "total": 10782
+      },
+      {
+        "stat": "attack",
+        "base": 1623,
+        "bonus": 1411,
+        "total": 3034
+      },
+      {
+        "stat": "defense",
+        "base": 606,
+        "bonus": 199,
+        "total": 805
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "32700",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      16,
+      16,
+      16,
+      16,
+      16
+    ],
+    "driveDiscSetCounts": {
+      "32700": 4,
+      "32800": 2
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "miyoushe-1-883a2666.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 米游社 fixture for 雅; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/miyabi-workshop.calc.json
+++ b/examples/ai-plugin/vision/expected/miyabi-workshop.calc.json
@@ -1,0 +1,435 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "calculationId": "calc-1",
+  "locale": "zh",
+  "summary": {
+    "activeActorId": "1091",
+    "enemyId": "30004",
+    "damageType": "regular",
+    "lanes": {
+      "nonCrit": {
+        "rawDamage": 1855.7268722466958,
+        "displayDamage": 1856
+      },
+      "crit": {
+        "rawDamage": 4416.629955947136,
+        "displayDamage": 4417
+      }
+    },
+    "rawTotalDamage": 3335.9288546255502,
+    "displayTotalDamage": 3336,
+    "expectedDamage": 3335.9288546255502,
+    "critDamage": 4416.629955947136,
+    "nonCritDamage": 1855.7268722466958,
+    "dazeValue": 0,
+    "anomalyBuildup": 0,
+    "disorderDamage": 0,
+    "trueDamage": 0
+  },
+  "attackSegments": [
+    {
+      "id": "miyabi-workshop-vision-smoke-1",
+      "actorId": "1091",
+      "attribute": "frost",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "rawDamage": 3335.9288546255502,
+      "segmentDisplayDamage": 3336,
+      "roundingMode": "ceilPerSegment",
+      "baseDamage": 3370,
+      "expectedDamage": 3335.9288546255502,
+      "critDamage": 4416.629955947136,
+      "nonCritDamage": 1855.7268722466958,
+      "traceRefs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8",
+        "trace-9",
+        "trace-10"
+      ]
+    }
+  ],
+  "buckets": [
+    {
+      "bucketId": "baseDamageZone",
+      "before": 0,
+      "after": 3370,
+      "effectiveMultiplier": 3370,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:base-regular",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 3370,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-1"
+      ]
+    },
+    {
+      "bucketId": "damageBonusZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:attribute-damage-bonus",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-2"
+      ]
+    },
+    {
+      "bucketId": "critZone",
+      "before": 1,
+      "after": 1.79764,
+      "effectiveMultiplier": 1.79764,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:crit-expected",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 1.79764,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-3"
+      ]
+    },
+    {
+      "bucketId": "defenseZone",
+      "before": 1,
+      "after": 0.5506607929515418,
+      "effectiveMultiplier": 0.5506607929515418,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:base-defense",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 952.8,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-4"
+      ]
+    },
+    {
+      "bucketId": "resistanceZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:resistance",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-5"
+      ]
+    },
+    {
+      "bucketId": "vulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 0,
+          "operation": "add",
+          "active": false
+        }
+      ],
+      "traceRefs": [
+        "trace-6"
+      ]
+    },
+    {
+      "bucketId": "dazeVulnerabilityZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:daze-vulnerability",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-7"
+      ]
+    },
+    {
+      "bucketId": "specialZone",
+      "before": 1,
+      "after": 1,
+      "effectiveMultiplier": 1,
+      "contributors": [
+        {
+          "id": "miyabi-workshop-vision-smoke-1:distance-decay",
+          "source": {
+            "sourceId": "examples.ai-plugin.vision",
+            "sourceVersion": "v1.2.3",
+            "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+          },
+          "value": 1,
+          "operation": "multiply",
+          "active": true
+        }
+      ],
+      "traceRefs": [
+        "trace-8"
+      ]
+    }
+  ],
+  "modifiers": [],
+  "trace": [
+    {
+      "id": "trace-1",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=baseDamageZone].contributors[0]",
+      "inputs": {
+        "bucketId": "baseDamageZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:base-regular",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 3370,
+      "displayValue": 3370,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-2",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=damageBonusZone].contributors[0]",
+      "inputs": {
+        "bucketId": "damageBonusZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:attribute-damage-bonus",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-3",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=critZone].contributors[0]",
+      "inputs": {
+        "bucketId": "critZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:crit-expected",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1.79764,
+      "displayValue": 1.79764,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-4",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=defenseZone].contributors[0]",
+      "inputs": {
+        "bucketId": "defenseZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:base-defense",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 952.8,
+      "displayValue": 0.5506607929515418,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-5",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=resistanceZone].contributors[0]",
+      "inputs": {
+        "bucketId": "resistanceZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:resistance",
+        "operation": "add",
+        "active": true
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-6",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=vulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "vulnerabilityZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:corrupted-shield-damage-reduction",
+        "operation": "add",
+        "active": false
+      },
+      "rawValue": 0,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-7",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=dazeVulnerabilityZone].contributors[0]",
+      "inputs": {
+        "bucketId": "dazeVulnerabilityZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:daze-vulnerability",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-8",
+      "kind": "bucketContribution",
+      "path": "buckets[?bucketId=specialZone].contributors[0]",
+      "inputs": {
+        "bucketId": "specialZone",
+        "contributorId": "miyabi-workshop-vision-smoke-1:distance-decay",
+        "operation": "multiply",
+        "active": true
+      },
+      "rawValue": 1,
+      "displayValue": 1,
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    },
+    {
+      "id": "trace-9",
+      "kind": "formula",
+      "path": "attackSegments[0].rawDamage",
+      "inputs": {
+        "baseDamage": 3370,
+        "damageType": "regular",
+        "multiplier": 1,
+        "bucketIds": [
+          "baseDamageZone",
+          "damageBonusZone",
+          "critZone",
+          "defenseZone",
+          "resistanceZone",
+          "vulnerabilityZone",
+          "dazeVulnerabilityZone",
+          "specialZone"
+        ]
+      },
+      "formula": "baseDamageZone * damageBonusZone * critZone * defenseZone * resistanceZone * vulnerabilityZone * dazeVulnerabilityZone * specialZone",
+      "rawValue": 3335.9288546255502,
+      "refs": [
+        "trace-1",
+        "trace-2",
+        "trace-3",
+        "trace-4",
+        "trace-5",
+        "trace-6",
+        "trace-7",
+        "trace-8"
+      ]
+    },
+    {
+      "id": "trace-10",
+      "kind": "rounding",
+      "path": "attackSegments[0].segmentDisplayDamage",
+      "rawValue": 3335.9288546255502,
+      "displayValue": 3336,
+      "rounding": {
+        "mode": "ceilPerSegment",
+        "input": 3335.9288546255502,
+        "output": 3336,
+        "reason": "Game display rounds each attack segment up before summing."
+      }
+    }
+  ],
+  "warnings": [],
+  "errors": []
+}

--- a/examples/ai-plugin/vision/expected/miyabi-workshop.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/miyabi-workshop.draft-metadata.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-workshop-miyabi",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.95,
+    "cues": [
+      "branding:workshop-header",
+      "layout:phone-status-bar",
+      "layout:agent-roster-row-top",
+      "layout:ace-rating-text"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [
+      "uid"
+    ],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "actor.mindscape.level": "high",
+    "actor.attribute": "medium",
+    "actor.agentSpecialty": "medium",
+    "actor.skillLevels.basic": "medium",
+    "actor.skillLevels.dodge": "medium",
+    "actor.skillLevels.assist": "medium",
+    "actor.skillLevels.special": "medium",
+    "actor.skillLevels.ultimate": "medium",
+    "wEngine.id": "high",
+    "wEngine.level": "high",
+    "wEngine.phase": "high",
+    "driveDiscs[*].setId": "high",
+    "driveDiscs[*].slot": "high",
+    "driveDiscs[*].level": "high",
+    "driveDiscs[*].mainStat": "high",
+    "driveDiscs[*].substats[*].value": "high",
+    "driveDiscs[*].substats[*].rollCount": "high",
+    "panel.attack": "high",
+    "panel.maxHp": "high",
+    "panel.defense": "high",
+    "panel.impact": "high",
+    "panel.critRate": "high",
+    "panel.critDamage": "high",
+    "panel.anomalyMastery": "high",
+    "panel.anomalyProficiency": "high"
+  },
+  "evidence": {
+    "statSplits": [
+      {
+        "stat": "maxHp",
+        "base": 7673,
+        "bonus": 2766,
+        "total": 10439
+      },
+      {
+        "stat": "attack",
+        "base": 1623,
+        "bonus": 1747,
+        "total": 3370
+      },
+      {
+        "stat": "defense",
+        "base": 606,
+        "bonus": 184,
+        "total": 790
+      }
+    ],
+    "substatRollsSample": [
+      {
+        "slot": 1,
+        "setId": "31100",
+        "substats": [
+          {
+            "stat": "critDamage",
+            "rollCount": 2,
+            "valuePercent": 14.4
+          },
+          {
+            "stat": "attack",
+            "rollCount": 1,
+            "valuePercent": 6
+          },
+          {
+            "stat": "critRate",
+            "rollCount": 1,
+            "valuePercent": 4.8
+          }
+        ]
+      }
+    ],
+    "skillLevelsObserved": [
+      16,
+      16,
+      16,
+      16,
+      16
+    ],
+    "driveDiscSetCounts": {
+      "31100": 2,
+      "32700": 4
+    },
+    "localRecoveryReference": {
+      "note": "local-only recovered screenshot; raw image is not committed",
+      "file": "workshop-2-d6f09bfc.jpg"
+    }
+  },
+  "nextStep": "Hand off to fairy-snapshot for review/edit and any missing critical fields; user will likely supply enemy + attack segment context.",
+  "fallbackTrigger": null,
+  "notes": [
+    "F2 happy-path 绝区零工坊 fixture for 雅; raw account values discarded.",
+    "Calc baseline is an individual fixture smoke and is not part of a cross-source parity group unless explicitly configured."
+  ]
+}

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-astra.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-astra.md
@@ -1,0 +1,70 @@
+# fixture · vision-miyoushe-astra
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record (米游社)
+**Scenario**: F2 user pastes a 米游社 build screenshot of 耀嘉音 Lv60 + 好斗的阿炮; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 米游社** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: miyoushe-2-57177655.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [miyoushe-astra-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "miyoushe-record", sourceLabel: "米游社", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID and username are detected
+   - `piiDetection: { kinds: ["uid","username"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/astra-miyoushe.snapshot.json`
+- **draftMetadata**: see `expected/astra-miyoushe.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「米游社」截图里读到:
+
+  角色: 耀嘉音 Lv60 (影画 2)
+  武器: 好斗的阿炮 Lv60 R5
+  6 件套: 月光骑士颂 4pc (slot 1+2+3+6) + 静听嘉音 2pc (slot 4+5)
+  面板: HP 11326, ATK 3013, DEF 958, 冲击力 83, 暴击率 43.4%, 暴击伤害 102.8%, 异常掌控 93, 异常精通 110
+  以太伤害加成 0%
+  技能等级: 普攻 11 / 闪避 3 / 支援 3 / 特殊技 12 / 连携技 12
+
+  证据 (audit-only，不进 calc):
+    - HP 11326 = 8609 base + 2717 bonus
+    - ATK 3013 = 1339 base + 1674 bonus
+    - DEF 958 = 600 base + 358 bonus
+    - 截图来源: 米游社 (UID + 用户名 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "miyoushe-record"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-dialyn.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-dialyn.md
@@ -1,0 +1,70 @@
+# fixture · vision-miyoushe-dialyn
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record (米游社)
+**Scenario**: F2 user pastes a 米游社 build screenshot of 琉音 Lv60 + 昨夜来电; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 米游社** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: miyoushe-3-9e1826de.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [miyoushe-dialyn-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "miyoushe-record", sourceLabel: "米游社", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID and username are detected
+   - `piiDetection: { kinds: ["uid","username"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/dialyn-miyoushe.snapshot.json`
+- **draftMetadata**: see `expected/dialyn-miyoushe.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「米游社」截图里读到:
+
+  角色: 琉音 Lv60 (影画 2)
+  武器: 昨夜来电 Lv60 R1
+  6 件套: 山大王 4pc (slot 1+2+4+5) + 月光骑士颂 2pc (slot 3+6)
+  面板: HP 11169, ATK 2379, DEF 825, 冲击力 110, 暴击率 100%, 暴击伤害 107.6%, 异常掌控 94, 异常精通 156
+  物理伤害加成 30%
+  技能等级: 普攻 12 / 闪避 11 / 支援 12 / 特殊技 12 / 连携技 12
+
+  证据 (audit-only，不进 calc):
+    - HP 11169 = 8250 base + 2919 bonus
+    - ATK 2379 = 1471 base + 908 bonus
+    - DEF 825 = 612 base + 213 bonus
+    - 截图来源: 米游社 (UID + 用户名 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "miyoushe-record"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/prompts/vision-miyoushe-miyabi.md
+++ b/examples/ai-plugin/vision/prompts/vision-miyoushe-miyabi.md
@@ -1,0 +1,70 @@
+# fixture · vision-miyoushe-miyabi
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record (米游社)
+**Scenario**: F2 user pastes a 米游社 build screenshot of 雅 Lv60 + 霰落星殿; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 米游社** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: miyoushe-1-883a2666.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [miyoushe-miyabi-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "miyoushe-record", sourceLabel: "米游社", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID and username are detected
+   - `piiDetection: { kinds: ["uid","username"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/miyabi-miyoushe.snapshot.json`
+- **draftMetadata**: see `expected/miyabi-miyoushe.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「米游社」截图里读到:
+
+  角色: 雅 Lv60 (影画 6)
+  武器: 霰落星殿 Lv60 R1
+  6 件套: 折枝剑歌 4pc (slot 1+3+4+6) + 静听嘉音 2pc (slot 2+5)
+  面板: HP 10782, ATK 3034, DEF 805, 冲击力 86, 暴击率 72.2%, 暴击伤害 171.6%, 异常掌控 116, 异常精通 247
+  冰属性伤害加成 0%
+  技能等级: 普攻 16 / 闪避 16 / 支援 16 / 特殊技 16 / 连携技 16
+
+  证据 (audit-only，不进 calc):
+    - HP 10782 = 7673 base + 3109 bonus
+    - ATK 3034 = 1623 base + 1411 bonus
+    - DEF 805 = 606 base + 199 bonus
+    - 截图来源: 米游社 (UID + 用户名 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "miyoushe-record"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/prompts/vision-workshop-astra.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-astra.md
@@ -1,0 +1,70 @@
+# fixture · vision-workshop-astra
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop (绝区零工坊)
+**Scenario**: F2 user pastes a 绝区零工坊 build screenshot of 耀嘉音 Lv60 + 好斗的阿炮; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 绝区零工坊** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: workshop-3-bddc89e0.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [workshop-astra-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "zzz-workshop", sourceLabel: "绝区零工坊", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID is detected
+   - `piiDetection: { kinds: ["uid"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/astra-workshop.snapshot.json`
+- **draftMetadata**: see `expected/astra-workshop.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「绝区零工坊」截图里读到:
+
+  角色: 耀嘉音 Lv60 (影画 1)
+  武器: 好斗的阿炮 Lv60 R5
+  6 件套: 月光骑士颂 4pc (slot 1+2+4+5) + 静听嘉音 2pc (slot 3+6)
+  面板: HP 11067, ATK 3425, DEF 1030, 冲击力 83, 暴击率 14.6%, 暴击伤害 64.4%, 异常掌控 93, 异常精通 110
+  以太伤害加成 0%
+  技能等级: 普攻 11 / 闪避 3 / 支援 3 / 特殊技 12 / 连携技 12
+
+  证据 (audit-only，不进 calc):
+    - HP 11067 = 8609 base + 2458 bonus
+    - ATK 3425 = 1339 base + 2086 bonus
+    - DEF 1030 = 600 base + 430 bonus
+    - 截图来源: 绝区零工坊 (UID 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "zzz-workshop"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/prompts/vision-workshop-dialyn.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-dialyn.md
@@ -1,0 +1,70 @@
+# fixture · vision-workshop-dialyn
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop (绝区零工坊)
+**Scenario**: F2 user pastes a 绝区零工坊 build screenshot of 琉音 Lv60 + 昨夜来电; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 绝区零工坊** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: workshop-1-6701bde2.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [workshop-dialyn-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "zzz-workshop", sourceLabel: "绝区零工坊", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID is detected
+   - `piiDetection: { kinds: ["uid"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/dialyn-workshop.snapshot.json`
+- **draftMetadata**: see `expected/dialyn-workshop.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「绝区零工坊」截图里读到:
+
+  角色: 琉音 Lv60 (影画 2)
+  武器: 昨夜来电 Lv60 R1
+  6 件套: 山大王 4pc (slot 2+4+5+6) + 月光骑士颂 2pc (slot 1+3)
+  面板: HP 11664, ATK 2423, DEF 796, 冲击力 110, 暴击率 101%, 暴击伤害 98%, 异常掌控 94, 异常精通 147
+  物理伤害加成 30%
+  技能等级: 普攻 12 / 闪避 11 / 支援 12 / 特殊技 12 / 连携技 12
+
+  证据 (audit-only，不进 calc):
+    - HP 11664 = 8250 base + 3414 bonus
+    - ATK 2423 = 1471 base + 952 bonus
+    - DEF 796 = 612 base + 184 bonus
+    - 截图来源: 绝区零工坊 (UID 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "zzz-workshop"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/prompts/vision-workshop-miyabi.md
+++ b/examples/ai-plugin/vision/prompts/vision-workshop-miyabi.md
@@ -1,0 +1,70 @@
+# fixture · vision-workshop-miyabi
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop (绝区零工坊)
+**Scenario**: F2 user pastes a 绝区零工坊 build screenshot of 雅 Lv60 + 霰落星殿; vision pipeline detects source, extracts full build, produces reviewable BattleSnapshot draft + draftMetadata, and hands off for review/edit.
+**Lang**: zh
+
+This fixture demonstrates an F2 **happy-path 绝区零工坊** flow for a non-Yixuan agent. It expands source/layout regression coverage without committing raw image assets. Source image recovered locally for authoring: workshop-2-d6f09bfc.jpg.
+
+---
+
+## User input
+
+```
+User (zh, with image attachment):
+  [workshop-miyabi-build.png]
+  帮我算一下这个的伤害，本期 DA boss
+```
+
+## Expected fairy-vision behavior
+
+1. **Lang detect**: zh → session lang = zh.
+2. **Multimodal capability check**: host supports image input → proceed.
+3. **Source detection**:
+   - Result: `sourceDetection: { sourceId: "zzz-workshop", sourceLabel: "绝区零工坊", confidence: 0.95 }`
+   - Source cues recorded in draftMetadata; raw screenshot is not persisted.
+4. **Per-source layout map**: parse agent identity, level, mindscape, skill strip, W-Engine, panel totals, and six Drive Disc cards.
+5. **PII detection**:
+   - UID is detected
+   - `piiDetection: { kinds: ["uid"], redactionStatus: "redacted" }`
+   - Raw account values never reach `BattleSnapshot` or committed `draftMetadata`.
+6. **Confidence scoring**: critical fields are high or medium confidence; no field-tier escalation needed.
+7. **Substat capture precision**: visible substat values and roll markers are recorded in `draftMetadata.evidence.substatRollsSample`.
+8. **Output**: `battleSnapshotDraft` (strict schema) + `draftMetadata` + review/edit gate; user confirms before downstream calc.
+
+## Expected output
+
+- **BattleSnapshot draft**: see `snapshots/miyabi-workshop.snapshot.json`
+- **draftMetadata**: see `expected/miyabi-workshop.draft-metadata.json`
+
+## Review/edit gate copy (zh user-facing)
+
+```
+我从这张「绝区零工坊」截图里读到:
+
+  角色: 雅 Lv60 (影画 6)
+  武器: 霰落星殿 Lv60 R1
+  6 件套: 折枝剑歌 4pc (slot 2+3+4+6) + 河豚电音 2pc (slot 1+5)
+  面板: HP 10439, ATK 3370, DEF 790, 冲击力 86, 暴击率 57.8%, 暴击伤害 138%, 异常掌控 116, 异常精通 265
+  冰属性伤害加成 0%
+  技能等级: 普攻 16 / 闪避 16 / 支援 16 / 特殊技 16 / 连携技 16
+
+  证据 (audit-only，不进 calc):
+    - HP 10439 = 7673 base + 2766 bonus
+    - ATK 3370 = 1623 base + 1747 bonus
+    - DEF 790 = 606 base + 184 bonus
+    - 截图来源: 绝区零工坊 (UID 已识别并隐藏)
+
+  你提到「本期 DA boss」我帮你补到 enemy 字段。
+  直接算吗？要改哪里告诉我。
+```
+
+## Acceptance assertions
+
+- `sourceDetection.sourceId === "zzz-workshop"` ✓
+- Draft parses with `parseBattleSnapshot` after user confirmation.
+- Confirmed draft can run through `fairy calc <snapshot> --view verbose --lang zh`.
+- `draftMetadata.evidence.substatRollsSample` records visible roll-count evidence.
+- Review/edit gate copy contains no skill names or chain handoff wording.
+- PII is represented by kind/status only; raw account values are not persisted.

--- a/examples/ai-plugin/vision/snapshots/astra-miyoushe.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/astra-miyoushe.snapshot.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1311",
+      "level": 60,
+      "agentSpecialty": "support",
+      "attribute": "ether",
+      "skillLevels": {
+        "basic": 11,
+        "dodge": 3,
+        "assist": 3,
+        "special": 12,
+        "ultimate": 12
+      },
+      "mindscapeCinema": {
+        "level": 2
+      },
+      "wEngine": {
+        "id": "13115",
+        "level": 60,
+        "phase": 5
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "32800"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "32800"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "33400"
+        }
+      ],
+      "panel": {
+        "attack": 3013,
+        "maxHp": 11326,
+        "defense": 958,
+        "impact": 83,
+        "critRate": 0.434,
+        "critDamage": 1.028,
+        "anomalyMastery": 93,
+        "anomalyProficiency": 110,
+        "penetrationRate": 0,
+        "flatPenetration": 9,
+        "energyRegen": 3.58,
+        "etherDamageBonus": 0
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1311"
+  },
+  "attackSegments": [
+    {
+      "id": "astra-miyoushe-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1311"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "ether",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-miyoushe.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "ether": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/astra-workshop.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/astra-workshop.snapshot.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1311",
+      "level": 60,
+      "agentSpecialty": "support",
+      "attribute": "ether",
+      "skillLevels": {
+        "basic": 11,
+        "dodge": 3,
+        "assist": 3,
+        "special": 12,
+        "ultimate": 12
+      },
+      "mindscapeCinema": {
+        "level": 1
+      },
+      "wEngine": {
+        "id": "13115",
+        "level": 60,
+        "phase": 5
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "32800"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "32800"
+        }
+      ],
+      "panel": {
+        "attack": 3425,
+        "maxHp": 11067,
+        "defense": 1030,
+        "impact": 83,
+        "critRate": 0.146,
+        "critDamage": 0.644,
+        "anomalyMastery": 93,
+        "anomalyProficiency": 110,
+        "penetrationRate": 0,
+        "energyRegen": 3.59,
+        "etherDamageBonus": 0
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1311"
+  },
+  "attackSegments": [
+    {
+      "id": "astra-workshop-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1311"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "ether",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.astra-workshop.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "ether": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/dialyn-miyoushe.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/dialyn-miyoushe.snapshot.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1481",
+      "level": 60,
+      "agentSpecialty": "stun",
+      "attribute": "physical",
+      "skillLevels": {
+        "basic": 12,
+        "dodge": 11,
+        "assist": 12,
+        "special": 12,
+        "ultimate": 12
+      },
+      "mindscapeCinema": {
+        "level": 2
+      },
+      "wEngine": {
+        "id": "14148",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "33400"
+        }
+      ],
+      "panel": {
+        "attack": 2379,
+        "maxHp": 11169,
+        "defense": 825,
+        "impact": 110,
+        "critRate": 1,
+        "critDamage": 1.076,
+        "anomalyMastery": 94,
+        "anomalyProficiency": 156,
+        "penetrationRate": 0,
+        "flatPenetration": 0,
+        "energyRegen": 2.16,
+        "physicalDamageBonus": 0.3
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1481"
+  },
+  "attackSegments": [
+    {
+      "id": "dialyn-miyoushe-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1481"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "physical",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-miyoushe.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "physical": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/dialyn-workshop.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/dialyn-workshop.snapshot.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1481",
+      "level": 60,
+      "agentSpecialty": "stun",
+      "attribute": "physical",
+      "skillLevels": {
+        "basic": 12,
+        "dodge": 11,
+        "assist": 12,
+        "special": 12,
+        "ultimate": 12
+      },
+      "mindscapeCinema": {
+        "level": 2
+      },
+      "wEngine": {
+        "id": "14148",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "33400"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "33200"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "33200"
+        }
+      ],
+      "panel": {
+        "attack": 2423,
+        "maxHp": 11664,
+        "defense": 796,
+        "impact": 110,
+        "critRate": 1.01,
+        "critDamage": 0.98,
+        "anomalyMastery": 94,
+        "anomalyProficiency": 147,
+        "penetrationRate": 0,
+        "energyRegen": 2.16,
+        "physicalDamageBonus": 0.3
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1481"
+  },
+  "attackSegments": [
+    {
+      "id": "dialyn-workshop-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1481"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "physical",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.dialyn-workshop.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "physical": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/miyabi-miyoushe.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/miyabi-miyoushe.snapshot.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1091",
+      "level": 60,
+      "agentSpecialty": "anomaly",
+      "attribute": "frost",
+      "skillLevels": {
+        "basic": 16,
+        "dodge": 16,
+        "assist": 16,
+        "special": 16,
+        "ultimate": 16
+      },
+      "mindscapeCinema": {
+        "level": 6
+      },
+      "wEngine": {
+        "id": "14109",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "32800"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "32800"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "32700"
+        }
+      ],
+      "panel": {
+        "attack": 3034,
+        "maxHp": 10782,
+        "defense": 805,
+        "impact": 86,
+        "critRate": 0.722,
+        "critDamage": 1.716,
+        "anomalyMastery": 116,
+        "anomalyProficiency": 247,
+        "penetrationRate": 0.24,
+        "flatPenetration": 27,
+        "energyRegen": 1.2,
+        "iceDamageBonus": 0
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1091"
+  },
+  "attackSegments": [
+    {
+      "id": "miyabi-miyoushe-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1091"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "frost",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-miyoushe.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "ice": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/examples/ai-plugin/vision/snapshots/miyabi-workshop.snapshot.json
+++ b/examples/ai-plugin/vision/snapshots/miyabi-workshop.snapshot.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "1.0.0",
+  "gameVersion": "ZZZ-2.8",
+  "ruleSetVersion": "rules-v0.1",
+  "dataVersion": "nanoka@2.8",
+  "sourceVersion": "nanoka@2.8",
+  "locale": "zh",
+  "context": {
+    "gameMode": "hollowZeroAssault",
+    "activeRuleIds": [
+      "current-live"
+    ]
+  },
+  "team": [
+    {
+      "agentId": "1091",
+      "level": 60,
+      "agentSpecialty": "anomaly",
+      "attribute": "frost",
+      "skillLevels": {
+        "basic": 16,
+        "dodge": 16,
+        "assist": 16,
+        "special": 16,
+        "ultimate": 16
+      },
+      "mindscapeCinema": {
+        "level": 6
+      },
+      "wEngine": {
+        "id": "14109",
+        "level": 60,
+        "phase": 1
+      },
+      "driveDiscs": [
+        {
+          "id": "drive-slot-1",
+          "slot": 1,
+          "setId": "31100"
+        },
+        {
+          "id": "drive-slot-2",
+          "slot": 2,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-3",
+          "slot": 3,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-4",
+          "slot": 4,
+          "setId": "32700"
+        },
+        {
+          "id": "drive-slot-5",
+          "slot": 5,
+          "setId": "31100"
+        },
+        {
+          "id": "drive-slot-6",
+          "slot": 6,
+          "setId": "32700"
+        }
+      ],
+      "panel": {
+        "attack": 3370,
+        "maxHp": 10439,
+        "defense": 790,
+        "impact": 86,
+        "critRate": 0.578,
+        "critDamage": 1.38,
+        "anomalyMastery": 116,
+        "anomalyProficiency": 265,
+        "penetrationRate": 0.32,
+        "energyRegen": 1.2,
+        "iceDamageBonus": 0
+      }
+    }
+  ],
+  "activeActor": {
+    "agentId": "1091"
+  },
+  "attackSegments": [
+    {
+      "id": "miyabi-workshop-vision-smoke-1",
+      "actor": {
+        "kind": "agent",
+        "agentId": "1091"
+      },
+      "skillId": "vision-smoke-hit",
+      "levelKey": "basic",
+      "multiplier": 1,
+      "attribute": "frost",
+      "tags": [
+        "basic"
+      ],
+      "damageType": "regular",
+      "source": {
+        "sourceId": "examples.ai-plugin.vision",
+        "sourceVersion": "v1.2.3",
+        "dataPath": "visionFixtures.miyabi-workshop.smokeSegment"
+      }
+    }
+  ],
+  "enemy": {
+    "enemyId": "30004",
+    "level": 60,
+    "rank": "special",
+    "maxHp": 1000000,
+    "resistance": {
+      "ice": 0
+    }
+  },
+  "options": {
+    "includeTrace": true,
+    "lang": "zh"
+  }
+}

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -47,25 +47,189 @@ const visionExampleDirs = [
 const visionFixtures = [
   {
     name: "yixuan-workshop",
+    mode: "calc",
+    fixtureName: "vision-workshop-yixuan",
     sourceId: "zzz-workshop",
     sourceLabel: "绝区零工坊",
     prompt: "examples/ai-plugin/vision/prompts/vision-workshop-yixuan.md",
     snapshot: "examples/ai-plugin/vision/snapshots/yixuan-workshop.snapshot.json",
     metadata: "examples/ai-plugin/vision/expected/yixuan-workshop.draft-metadata.json",
     calc: "examples/ai-plugin/vision/expected/yixuan-workshop.calc.json",
-    piiKinds: ["uid"],
+    expected: {
+      agentId: "1371",
+      wEngineId: "14137",
+      activeActorId: "1371",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ether: 0 },
+      driveDiscSetCounts: { "33100": 4, "32700": 2 },
+      piiKinds: ["uid"],
+      sourceConfidenceMin: 0.9,
+    },
+    parityGroup: "yixuan-build",
     userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
   },
   {
     name: "yixuan-miyoushe",
+    mode: "calc",
+    fixtureName: "vision-miyoushe-yixuan",
     sourceId: "miyoushe-record",
     sourceLabel: "米游社",
     prompt: "examples/ai-plugin/vision/prompts/vision-miyoushe-yixuan.md",
     snapshot: "examples/ai-plugin/vision/snapshots/yixuan-miyoushe.snapshot.json",
     metadata: "examples/ai-plugin/vision/expected/yixuan-miyoushe.draft-metadata.json",
     calc: "examples/ai-plugin/vision/expected/yixuan-miyoushe.calc.json",
-    piiKinds: ["uid", "username"],
+    expected: {
+      agentId: "1371",
+      wEngineId: "14137",
+      activeActorId: "1371",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ether: 0 },
+      driveDiscSetCounts: { "33100": 4, "32700": 2 },
+      piiKinds: ["uid", "username"],
+      sourceConfidenceMin: 0.9,
+    },
+    parityGroup: "yixuan-build",
     userCopyIncludes: ["截图来源: 米游社", "UID + 用户名 已识别并隐藏"],
+  },
+  {
+    name: "miyabi-miyoushe",
+    mode: "calc",
+    fixtureName: "vision-miyoushe-miyabi",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-miyoushe-miyabi.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/miyabi-miyoushe.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/miyabi-miyoushe.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/miyabi-miyoushe.calc.json",
+    expected: {
+      agentId: "1091",
+      wEngineId: "14109",
+      activeActorId: "1091",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ice: 0 },
+      driveDiscSetCounts: { "32700": 4, "32800": 2 },
+      piiKinds: ["uid", "username"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 米游社", "UID + 用户名 已识别并隐藏"],
+  },
+  {
+    name: "astra-miyoushe",
+    mode: "calc",
+    fixtureName: "vision-miyoushe-astra",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-miyoushe-astra.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/astra-miyoushe.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/astra-miyoushe.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/astra-miyoushe.calc.json",
+    expected: {
+      agentId: "1311",
+      wEngineId: "13115",
+      activeActorId: "1311",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ether: 0 },
+      driveDiscSetCounts: { "33400": 4, "32800": 2 },
+      piiKinds: ["uid", "username"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 米游社", "UID + 用户名 已识别并隐藏"],
+  },
+  {
+    name: "dialyn-miyoushe",
+    mode: "calc",
+    fixtureName: "vision-miyoushe-dialyn",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-miyoushe-dialyn.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/dialyn-miyoushe.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/dialyn-miyoushe.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/dialyn-miyoushe.calc.json",
+    expected: {
+      agentId: "1481",
+      wEngineId: "14148",
+      activeActorId: "1481",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { physical: 0 },
+      driveDiscSetCounts: { "33200": 4, "33400": 2 },
+      piiKinds: ["uid", "username"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 米游社", "UID + 用户名 已识别并隐藏"],
+  },
+  {
+    name: "dialyn-workshop",
+    mode: "calc",
+    fixtureName: "vision-workshop-dialyn",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-workshop-dialyn.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/dialyn-workshop.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/dialyn-workshop.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/dialyn-workshop.calc.json",
+    expected: {
+      agentId: "1481",
+      wEngineId: "14148",
+      activeActorId: "1481",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { physical: 0 },
+      driveDiscSetCounts: { "33200": 4, "33400": 2 },
+      piiKinds: ["uid"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
+  },
+  {
+    name: "miyabi-workshop",
+    mode: "calc",
+    fixtureName: "vision-workshop-miyabi",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-workshop-miyabi.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/miyabi-workshop.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/miyabi-workshop.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/miyabi-workshop.calc.json",
+    expected: {
+      agentId: "1091",
+      wEngineId: "14109",
+      activeActorId: "1091",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ice: 0 },
+      driveDiscSetCounts: { "32700": 4, "31100": 2 },
+      piiKinds: ["uid"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
+  },
+  {
+    name: "astra-workshop",
+    mode: "calc",
+    fixtureName: "vision-workshop-astra",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-workshop-astra.md",
+    snapshot: "examples/ai-plugin/vision/snapshots/astra-workshop.snapshot.json",
+    metadata: "examples/ai-plugin/vision/expected/astra-workshop.draft-metadata.json",
+    calc: "examples/ai-plugin/vision/expected/astra-workshop.calc.json",
+    expected: {
+      agentId: "1311",
+      wEngineId: "13115",
+      activeActorId: "1311",
+      enemyId: "30004",
+      enemyRank: "special",
+      resistance: { ether: 0 },
+      driveDiscSetCounts: { "33400": 4, "32800": 2 },
+      piiKinds: ["uid"],
+      sourceConfidenceMin: 0.9,
+    },
+    userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
   },
 ]
 const requiredVisionExampleFiles = [
@@ -594,6 +758,18 @@ function runVisionCliCalc(relativeSnapshotPath) {
   return JSON.parse(output)
 }
 
+function countBy(values) {
+  return values.reduce((counts, value) => {
+    counts[value] = (counts[value] ?? 0) + 1
+    return counts
+  }, {})
+}
+
+function assertJsonObjectIncludes(actual, expected, context) {
+  for (const [key, value] of Object.entries(expected ?? {}))
+    assert(actual?.[key] === value, `${context}: expected ${key}=${value}, got ${actual?.[key]}`)
+}
+
 function verifyVisionSnapshot(fixture) {
   const snapshot = readJson(fixture.snapshot)
   if (core?.parseBattleSnapshot !== undefined) {
@@ -610,12 +786,13 @@ function verifyVisionSnapshot(fixture) {
   assertNoEvidenceOnlySnapshotKeys(snapshot, fixture.snapshot)
 
   const actor = snapshot.team?.[0]
-  assert(actor?.agentId === "1371", `${fixture.snapshot}: expected agentId 1371`)
-  assert(actor?.wEngine?.id === "14137", `${fixture.snapshot}: expected W-Engine id 14137`)
-  assert(snapshot.activeActor?.agentId === "1371", `${fixture.snapshot}: activeActor must be 仪玄`)
-  assert(snapshot.enemy?.enemyId === "30004", `${fixture.snapshot}: expected enemy id 30004`)
-  assert(snapshot.enemy?.rank === "special", `${fixture.snapshot}: expected enemy rank special`)
-  assert(snapshot.enemy?.resistance?.ether === 0, `${fixture.snapshot}: auric ink fixture must map resistance through ether`)
+  const expected = fixture.expected ?? {}
+  assert(actor?.agentId === expected.agentId, `${fixture.snapshot}: expected agentId ${expected.agentId}`)
+  assert(actor?.wEngine?.id === expected.wEngineId, `${fixture.snapshot}: expected W-Engine id ${expected.wEngineId}`)
+  assert(snapshot.activeActor?.agentId === expected.activeActorId, `${fixture.snapshot}: activeActor mismatch`)
+  assert(snapshot.enemy?.enemyId === expected.enemyId, `${fixture.snapshot}: expected enemy id ${expected.enemyId}`)
+  assert(snapshot.enemy?.rank === expected.enemyRank, `${fixture.snapshot}: expected enemy rank ${expected.enemyRank}`)
+  assertJsonObjectIncludes(snapshot.enemy?.resistance, expected.resistance, `${fixture.snapshot}: enemy.resistance`)
 
   assertRuntimeEntity("agents", actor?.agentId, `${fixture.snapshot}: team agent`)
   assertRuntimeEntity("wEngines", actor?.wEngine?.id, `${fixture.snapshot}: W-Engine`)
@@ -623,8 +800,10 @@ function verifyVisionSnapshot(fixture) {
 
   const setIds = (actor?.driveDiscs ?? []).map(disc => disc.setId).filter(Boolean)
   assert(setIds.length === 6, `${fixture.snapshot}: expected six Drive Disc slots`)
-  assert(setIds.filter(id => id === "33100").length === 4, `${fixture.snapshot}: expected 云岿如我 4pc`)
-  assert(setIds.filter(id => id === "32700").length === 2, `${fixture.snapshot}: expected 折枝剑歌 2pc`)
+  assert(
+    isDeepStrictEqual(countBy(setIds), expected.driveDiscSetCounts),
+    `${fixture.snapshot}: expected Drive Disc set counts ${JSON.stringify(expected.driveDiscSetCounts)}, got ${JSON.stringify(countBy(setIds))}`,
+  )
   for (const id of setIds)
     assertRuntimeEntity("driveDiscs", id, `${fixture.snapshot}: Drive Disc set`)
 
@@ -635,13 +814,13 @@ function verifyVisionDraftMetadata(fixture) {
   const metadata = readJson(fixture.metadata)
   assertNoPiiKeys(metadata, fixture.metadata)
   assert(metadata.schemaVersion === "v1.2.3-vision-draft-metadata-v1", `${fixture.metadata}: unexpected schemaVersion`)
-  assert(metadata.fixtureName === `vision-${fixture.name.replace("yixuan-", "")}-yixuan`, `${fixture.metadata}: fixtureName must match fixture`)
+  assert(metadata.fixtureName === fixture.fixtureName, `${fixture.metadata}: fixtureName must match fixture`)
   assert(metadata.sourceDetection?.sourceId === fixture.sourceId, `${fixture.metadata}: sourceDetection.sourceId mismatch`)
   assert(metadata.sourceDetection?.sourceLabel === fixture.sourceLabel, `${fixture.metadata}: sourceDetection.sourceLabel mismatch`)
-  assert(metadata.sourceDetection?.confidence >= 0.9, `${fixture.metadata}: sourceDetection confidence must be high`)
+  assert(metadata.sourceDetection?.confidence >= fixture.expected.sourceConfidenceMin, `${fixture.metadata}: sourceDetection confidence must be high`)
   assert(Array.isArray(metadata.sourceDetection?.cues) && metadata.sourceDetection.cues.length >= 3, `${fixture.metadata}: sourceDetection.cues must include source evidence`)
 
-  assertExactStringArray(metadata.piiDetection?.kinds, fixture.piiKinds, `${fixture.metadata}: piiDetection.kinds`)
+  assertExactStringArray(metadata.piiDetection?.kinds, fixture.expected.piiKinds, `${fixture.metadata}: piiDetection.kinds`)
   assert(metadata.piiDetection?.redactionStatus === "redacted", `${fixture.metadata}: piiDetection.redactionStatus must be redacted`)
   assert(metadata.piiDetection?.rawValuesDiscarded === true, `${fixture.metadata}: raw PII values must be discarded`)
 
@@ -724,29 +903,42 @@ function verifyVisionFixtures() {
   includesAll(visionReadme, "examples/ai-plugin/vision/README.md", [
     "yixuan-workshop.calc.json",
     "yixuan-miyoushe.calc.json",
+    "miyabi-miyoushe.calc.json",
+    "astra-workshop.calc.json",
+    "dialyn-workshop.calc.json",
     "Cross-source identity contract",
     "panel.etherDamageBonus: 0.3",
     "Actual digits never reach committed fixture JSON",
   ])
 
-  const calcResults = []
+  const calcResultsByName = new Map()
   for (const fixture of visionFixtures) {
     verifyVisionPrompt(fixture)
     const snapshot = verifyVisionSnapshot(fixture)
     verifyVisionDraftMetadata(fixture)
-    calcResults.push(verifyVisionCalcFixture(fixture, snapshot))
+    if (fixture.mode === "calc")
+      calcResultsByName.set(fixture.name, verifyVisionCalcFixture(fixture, snapshot))
   }
 
-  const [workshop, miyoushe] = calcResults
-  if (workshop !== undefined && miyoushe !== undefined) {
-    assert(
-      workshop.summary?.lanes?.nonCrit?.displayDamage === miyoushe.summary?.lanes?.nonCrit?.displayDamage,
-      "vision cross-source calc baselines must match nonCrit displayDamage for the selected segment",
-    )
-    assert(
-      workshop.summary?.lanes?.crit?.displayDamage === miyoushe.summary?.lanes?.crit?.displayDamage,
-      "vision cross-source calc baselines must match crit displayDamage for the selected segment",
-    )
+  const parityGroups = new Map()
+  for (const fixture of visionFixtures.filter(f => f.parityGroup !== undefined)) {
+    const group = parityGroups.get(fixture.parityGroup) ?? []
+    group.push(fixture)
+    parityGroups.set(fixture.parityGroup, group)
+  }
+  for (const [group, fixtures] of parityGroups) {
+    const baselines = fixtures.map(fixture => calcResultsByName.get(fixture.name)).filter(Boolean)
+    const [first] = baselines
+    for (const baseline of baselines.slice(1)) {
+      assert(
+        first.summary?.lanes?.nonCrit?.displayDamage === baseline.summary?.lanes?.nonCrit?.displayDamage,
+        `vision parity group ${group} must match nonCrit displayDamage for the selected segment`,
+      )
+      assert(
+        first.summary?.lanes?.crit?.displayDamage === baseline.summary?.lanes?.crit?.displayDamage,
+        `vision parity group ${group} must match crit displayDamage for the selected segment`,
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- refactor the vision fixture verifier into a table-driven matrix instead of Yixuan-only hard-coded assertions
- add six F2 happy-path text fixtures for Miyabi / Astra Yao / Dialyn across Miyoushe and ZZZ Workshop
- add per-fixture draft metadata, strict snapshots, and regenerated CLI calc baselines while keeping raw screenshots out of the repo
- document that only the original Yixuan pair remains a parity group; new same-agent source pairs are individual baselines because recovered screenshots are not build-identical

## Verification

- pnpm verify:ai-plugin
- pnpm check
- pnpm test
- pnpm build
- git diff --check

## Privacy

No raw screenshots or image assets are committed. Recovered attachments stayed local-only under the agent workspace; committed fixtures contain only text snapshots/metadata/calc baselines and PII kind/status redaction.