### PR TITLE
test(ai-plugin): add vision boundary fixtures

### DIFF
--- a/examples/ai-plugin/vision/README.md
+++ b/examples/ai-plugin/vision/README.md
@@ -16,6 +16,7 @@ examples/ai-plugin/vision/
     vision-miyoushe-yixuan.md         # fairy-vision: 米游社 happy-path (zh)
     vision-workshop-{dialyn,miyabi,astra}.md
     vision-miyoushe-{dialyn,miyabi,astra}.md
+    vision-boundary-*.md              # fairy-vision: ask-don't-guess boundary cases
   snapshots/
     yixuan-workshop.snapshot.json     # strict BattleSnapshot draft from workshop screenshot
     yixuan-miyoushe.snapshot.json     # strict BattleSnapshot draft from miyoushe screenshot
@@ -26,6 +27,7 @@ examples/ai-plugin/vision/
     yixuan-workshop.calc.json             # CLI verbose CalcResult baseline from confirmed workshop snapshot
     yixuan-miyoushe.calc.json             # CLI verbose CalcResult baseline from confirmed miyoushe snapshot
     {dialyn,miyabi,astra}-{workshop,miyoushe}.{draft-metadata,calc}.json
+    vision-boundary-*.draft-metadata.json # blocked drafts; no strict snapshot/calc output
 ```
 
 ## Scope (P2 starter + F2 happy-path coverage)
@@ -57,12 +59,17 @@ These F2 fixtures are **individual extraction + calc baselines**, not cross-sour
 
 The F2 calc baselines use a deterministic `vision-smoke-hit` attack segment to prove that the extracted `BattleSnapshot` is schema-valid and CLI-calculable. They are regression fixtures for vision extraction, entity normalization, and privacy boundaries, not character-rotation modeling claims.
 
-Future P2.x / F2 boundary batches will add:
-- Partial-extraction fixtures (per `docs/ai-plugin/v1.2.3-vision/user-journeys.md` §5)
-- Visual ambiguity fixtures (per §6 — e.g., 米游社 "07" skill slot)
-- Source-unknown / NL fallback fixtures (per §3 + §7)
-- Low-confidence majority fixtures (per §7)
-- PII redaction edge cases (per §8 + V-G4)
+F2 also adds **boundary fixtures** that regression-test the failure policy from the dogfood plan:
+
+| Fixture | Boundary | Required behavior |
+|---|---|---|
+| `vision-boundary-unknown-source` | unsupported / unknown source | low-confidence `sourceId=unknown`; ask for manual entry or supported screenshot; no snapshot/calc |
+| `vision-boundary-low-confidence` | blurry supported source | name low-confidence fields; ask for confirmation; no snapshot/calc |
+| `vision-boundary-missing-critical` | cropped critical fields | ask for exact missing fields; no defaulting; no snapshot/calc |
+| `vision-boundary-ambiguous-field` | multiple plausible readings | record candidates; ask the user to choose; no silent selection |
+| `vision-boundary-pii-overlap` | redaction overlaps critical fields | preserve redaction, discard raw values, ask for blocked fields; no snapshot/calc |
+
+Boundary fixtures intentionally have `draftMetadata` only. They must set `shouldNotCalc: true`, a specific `fallbackTrigger`, and a concrete `nextStep`; no strict `BattleSnapshot` or `CalcResult` file is committed for them.
 
 ## How to read each fixture file
 

--- a/examples/ai-plugin/vision/expected/vision-boundary-ambiguous-field.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/vision-boundary-ambiguous-field.draft-metadata.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-boundary-ambiguous-field",
+  "shouldNotCalc": true,
+  "snapshotStatus": "blocked",
+  "calcStatus": "not-run",
+  "fallbackTrigger": "ambiguous-field",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.9,
+    "cues": [
+      "branding:miyoushe-watermark",
+      "layout:landscape-composite",
+      "layout:skill-strip"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid", "username"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "low",
+    "actor.level": "high",
+    "skillLevels.corePassive": "low",
+    "wEngine.id": "medium",
+    "driveDiscs[*].setId": "medium"
+  },
+  "ambiguityCandidates": {
+    "skillLevels.corePassive": ["07", "01"],
+    "actor.id": ["1091", "1311"]
+  },
+  "evidence": {
+    "blockingReasons": [
+      "The core-passive skill slot has two plausible OCR readings.",
+      "Two adjacent agent portraits create an ambiguous active actor."
+    ],
+    "askUserFields": ["skillLevels.corePassive", "actor.id"]
+  },
+  "nextStep": "请确认核心技等级是 07 还是 01，并确认角色是雅还是耀嘉音。",
+  "notes": [
+    "Synthetic ambiguity fixture; candidates are stored without choosing one.",
+    "Ask-don't-guess behavior is required before any strict snapshot is produced."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/vision-boundary-low-confidence.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/vision-boundary-low-confidence.draft-metadata.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-boundary-low-confidence",
+  "shouldNotCalc": true,
+  "snapshotStatus": "blocked",
+  "calcStatus": "not-run",
+  "fallbackTrigger": "low-confidence",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.88,
+    "cues": [
+      "branding:zzz-workshop-header",
+      "layout:workshop-stat-grid",
+      "layout:workshop-drive-disc-cards"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "wEngine.id": "high",
+    "driveDiscs[*].setId": "medium",
+    "panel.attack": "low",
+    "panel.critRate": "low",
+    "driveDiscs[5].mainStat": "low"
+  },
+  "evidence": {
+    "blockingReasons": [
+      "Glare and compression artifacts make attack and crit-rate values unreliable.",
+      "The slot-6 main-stat label is partly obscured."
+    ],
+    "uncertainFields": ["panel.attack", "panel.critRate", "driveDiscs[5].mainStat"]
+  },
+  "nextStep": "请确认攻击力、暴击率和 6 号位主词条；这些字段确认前不应进入计算。",
+  "notes": [
+    "Synthetic low-confidence fixture derived from the supported workshop layout.",
+    "PII is reduced to kind/status only; raw values are discarded."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/vision-boundary-missing-critical.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/vision-boundary-missing-critical.draft-metadata.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-boundary-missing-critical",
+  "shouldNotCalc": true,
+  "snapshotStatus": "blocked",
+  "calcStatus": "not-run",
+  "fallbackTrigger": "missing-critical",
+  "sourceDetection": {
+    "sourceId": "miyoushe-record",
+    "sourceLabel": "米游社",
+    "confidence": 0.91,
+    "cues": [
+      "branding:miyoushe-watermark",
+      "layout:landscape-composite",
+      "layout:agent-info-band"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid", "username"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "actor.level": "high",
+    "wEngine.id": "low",
+    "driveDiscs[4].mainStat": "low",
+    "driveDiscs[5].mainStat": "low",
+    "panel.attack": "medium"
+  },
+  "missingCriticalFields": ["wEngine.id", "driveDiscs[4].mainStat", "driveDiscs[5].mainStat"],
+  "evidence": {
+    "blockingReasons": [
+      "The crop cuts off the W-Engine name.",
+      "Slot-5 and slot-6 main-stat labels are outside the visible area."
+    ],
+    "visibleFields": ["actor.id", "actor.level", "panel.attack"]
+  },
+  "nextStep": "请补充音擎名称、5 号位主词条和 6 号位主词条，或发完整面板。",
+  "notes": [
+    "Synthetic missing-critical fixture; no real screenshot is committed.",
+    "Do not infer cropped fields from typical builds."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/vision-boundary-pii-overlap.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/vision-boundary-pii-overlap.draft-metadata.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-boundary-pii-overlap",
+  "shouldNotCalc": true,
+  "snapshotStatus": "blocked",
+  "calcStatus": "not-run",
+  "fallbackTrigger": "pii-overlap",
+  "sourceDetection": {
+    "sourceId": "zzz-workshop",
+    "sourceLabel": "绝区零工坊",
+    "confidence": 0.89,
+    "cues": [
+      "branding:zzz-workshop-header",
+      "layout:workshop-stat-grid",
+      "layout:workshop-drive-disc-cards"
+    ]
+  },
+  "piiDetection": {
+    "kinds": ["uid", "username"],
+    "redactionStatus": "redacted",
+    "rawValuesDiscarded": true,
+    "overlapStatus": "redaction-blocks-critical-fields"
+  },
+  "perFieldConfidence": {
+    "actor.id": "high",
+    "wEngine.id": "high",
+    "driveDiscs[3].substats": "low",
+    "driveDiscs[4].mainStat": "low",
+    "panel.attack": "medium"
+  },
+  "missingCriticalFields": ["driveDiscs[3].substats", "driveDiscs[4].mainStat"],
+  "evidence": {
+    "blockingReasons": [
+      "The redacted personal-information region overlaps slot-4 substats.",
+      "The same redaction masks the slot-5 main stat."
+    ],
+    "privacyDecision": "PII redaction is preserved; blocked build fields must be supplied by the user."
+  },
+  "nextStep": "个人信息区域已隐藏；请补充 4 号位副词条和 5 号位主词条。",
+  "notes": [
+    "Synthetic privacy boundary fixture; raw personal values are not stored.",
+    "Privacy redaction takes priority over extraction completeness."
+  ]
+}

--- a/examples/ai-plugin/vision/expected/vision-boundary-unknown-source.draft-metadata.json
+++ b/examples/ai-plugin/vision/expected/vision-boundary-unknown-source.draft-metadata.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "v1.2.3-vision-draft-metadata-v1",
+  "fixtureName": "vision-boundary-unknown-source",
+  "shouldNotCalc": true,
+  "snapshotStatus": "blocked",
+  "calcStatus": "not-run",
+  "fallbackTrigger": "unsupported-source",
+  "sourceDetection": {
+    "sourceId": "unknown",
+    "sourceLabel": "未知来源",
+    "confidence": 0.24,
+    "cues": [
+      "missing:zzz-workshop-layout",
+      "missing:miyoushe-record-watermark",
+      "layout:unsupported-generic-card"
+    ]
+  },
+  "piiDetection": {
+    "kinds": [],
+    "redactionStatus": "not-present",
+    "rawValuesDiscarded": true
+  },
+  "perFieldConfidence": {
+    "source.layout": "low",
+    "actor.id": "low",
+    "wEngine.id": "low",
+    "driveDiscs[*].setId": "low"
+  },
+  "evidence": {
+    "blockingReasons": [
+      "The screenshot does not match any supported source layout.",
+      "Critical build fields cannot be mapped to a known source parser."
+    ],
+    "safeFallbacks": ["manual-entry", "supported-panel-resubmission"]
+  },
+  "nextStep": "请手动录入角色、音擎、驱动盘和敌人信息，或发一张清晰的角色面板截图。",
+  "notes": [
+    "Synthetic boundary fixture; no source screenshot is committed.",
+    "Unsupported source must not produce a strict BattleSnapshot or calc result."
+  ]
+}

--- a/examples/ai-plugin/vision/prompts/vision-boundary-ambiguous-field.md
+++ b/examples/ai-plugin/vision/prompts/vision-boundary-ambiguous-field.md
@@ -1,0 +1,39 @@
+# vision-boundary-ambiguous-field
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record
+**Scenario**: supported source is detected, but two fields have multiple plausible readings.
+**Lang**: zh
+
+## User input
+
+[miyoushe-ambiguous-field.png] 一张合成/脱敏的米游社面板；角色区域和技能等级区域存在视觉歧义。
+
+## Expected fairy-vision behavior
+
+1. Detect `sourceDetection.sourceId === "miyoushe-record"`.
+2. Record ambiguity candidates instead of choosing silently.
+3. Set `shouldNotCalc === true` and `fallbackTrigger === "ambiguous-field"`.
+4. Ask the user to choose between the concrete candidates.
+
+## Expected output
+
+- draftMetadata: see `expected/vision-boundary-ambiguous-field.draft-metadata.json`
+- No confirmed BattleSnapshot
+- No CalcResult
+
+## Review/edit gate copy
+
+```zh
+我看到两处不确定信息：核心技等级是 07 还是 01，角色是雅还是耀嘉音。
+
+请先确认后我再继续；我不会替你静默选择其中一个。
+```
+
+## Acceptance assertions
+
+- `shouldNotCalc === true`
+- `fallbackTrigger === "ambiguous-field"`
+- Ambiguity candidates are recorded for the uncertain fields.
+- No strict snapshot or calc baseline is produced.
+- User-facing copy does not leak internal orchestration wording.

--- a/examples/ai-plugin/vision/prompts/vision-boundary-low-confidence.md
+++ b/examples/ai-plugin/vision/prompts/vision-boundary-low-confidence.md
@@ -1,0 +1,39 @@
+# vision-boundary-low-confidence
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop
+**Scenario**: supported source is detected, but critical numeric fields are blurry and below confidence floor.
+**Lang**: zh
+
+## User input
+
+[zzz-workshop-low-confidence.png] 一张合成/脱敏的绝区零工坊角色面板；来源标识清楚，但关键读数模糊。
+
+## Expected fairy-vision behavior
+
+1. Detect `sourceDetection.sourceId === "zzz-workshop"` with supported-source confidence.
+2. Mark critical fields with `perFieldConfidence: "low"`.
+3. Set `shouldNotCalc === true` and `fallbackTrigger === "low-confidence"`.
+4. Ask the user to confirm the concrete uncertain fields before any calculation.
+
+## Expected output
+
+- draftMetadata: see `expected/vision-boundary-low-confidence.draft-metadata.json`
+- No confirmed BattleSnapshot
+- No CalcResult
+
+## Review/edit gate copy
+
+```zh
+截图来源看起来是绝区零工坊，但攻击力、暴击率和 6 号位主词条读数不够可靠。
+
+请确认这三项后我再继续；在确认前不会计算伤害。
+```
+
+## Acceptance assertions
+
+- `shouldNotCalc === true`
+- `fallbackTrigger === "low-confidence"`
+- The low-confidence fields are explicitly named.
+- No strict snapshot or calc baseline is produced.
+- User-facing copy does not leak internal orchestration wording.

--- a/examples/ai-plugin/vision/prompts/vision-boundary-missing-critical.md
+++ b/examples/ai-plugin/vision/prompts/vision-boundary-missing-critical.md
@@ -1,0 +1,39 @@
+# vision-boundary-missing-critical
+
+**Skill**: fairy-vision
+**Source**: miyoushe-record
+**Scenario**: supported source is detected, but the screenshot is cropped and misses required build fields.
+**Lang**: zh
+
+## User input
+
+[miyoushe-missing-critical.png] 一张合成/脱敏的米游社面板；顶部和右侧被裁掉。
+
+## Expected fairy-vision behavior
+
+1. Detect `sourceDetection.sourceId === "miyoushe-record"`.
+2. Identify missing critical fields rather than filling defaults.
+3. Set `shouldNotCalc === true` and `fallbackTrigger === "missing-critical"`.
+4. Ask for the exact missing fields.
+
+## Expected output
+
+- draftMetadata: see `expected/vision-boundary-missing-critical.draft-metadata.json`
+- No confirmed BattleSnapshot
+- No CalcResult
+
+## Review/edit gate copy
+
+```zh
+这张米游社截图里，音擎名称、5 号位主词条和 6 号位主词条被裁掉了。
+
+请补充这些字段，或发一张完整面板；在补齐前我不会推断默认值。
+```
+
+## Acceptance assertions
+
+- `shouldNotCalc === true`
+- `fallbackTrigger === "missing-critical"`
+- `nextStep` asks for the exact missing fields.
+- No strict snapshot or calc baseline is produced.
+- User-facing copy does not leak internal orchestration wording.

--- a/examples/ai-plugin/vision/prompts/vision-boundary-pii-overlap.md
+++ b/examples/ai-plugin/vision/prompts/vision-boundary-pii-overlap.md
@@ -1,0 +1,39 @@
+# vision-boundary-pii-overlap
+
+**Skill**: fairy-vision
+**Source**: zzz-workshop
+**Scenario**: PII redaction overlaps critical build fields; privacy wins and the user is asked to supply the blocked fields.
+**Lang**: zh
+
+## User input
+
+[zzz-workshop-pii-overlap.png] 一张合成/脱敏的绝区零工坊面板；个人信息区域与部分驱动盘字段重叠。
+
+## Expected fairy-vision behavior
+
+1. Detect `sourceDetection.sourceId === "zzz-workshop"`.
+2. Redact PII kinds and discard raw values.
+3. Set `shouldNotCalc === true` and `fallbackTrigger === "pii-overlap"` because redaction blocks critical fields.
+4. Ask the user for only the blocked build fields.
+
+## Expected output
+
+- draftMetadata: see `expected/vision-boundary-pii-overlap.draft-metadata.json`
+- No confirmed BattleSnapshot
+- No CalcResult
+
+## Review/edit gate copy
+
+```zh
+个人信息区域已隐藏，但它挡住了 4 号位副词条和 5 号位主词条。
+
+请补充这两项后我再继续；我不会保留或展示原始个人信息。
+```
+
+## Acceptance assertions
+
+- `shouldNotCalc === true`
+- `fallbackTrigger === "pii-overlap"`
+- PII is represented only as kinds/status and raw values are discarded.
+- No strict snapshot or calc baseline is produced.
+- User-facing copy does not leak internal orchestration wording.

--- a/examples/ai-plugin/vision/prompts/vision-boundary-unknown-source.md
+++ b/examples/ai-plugin/vision/prompts/vision-boundary-unknown-source.md
@@ -1,0 +1,38 @@
+# vision-boundary-unknown-source
+
+**Skill**: fairy-vision
+**Source**: unknown
+**Scenario**: unsupported screenshot source; route to manual input instead of guessing.
+**Lang**: zh
+
+## User input
+
+[unknown-source-character-card.png] 一张合成的非支持来源角色图；没有绝区零工坊或米游社布局标识。
+
+## Expected fairy-vision behavior
+
+1. Detect `sourceDetection.sourceId === "unknown"` with low confidence.
+2. Set `shouldNotCalc === true` and `fallbackTrigger === "unsupported-source"`.
+3. Ask the user for manual field entry or a clearer supported character panel screenshot.
+
+## Expected output
+
+- draftMetadata: see `expected/vision-boundary-unknown-source.draft-metadata.json`
+- No confirmed BattleSnapshot
+- No CalcResult
+
+## Review/edit gate copy
+
+```zh
+暂时无法识别这张图来自支持的面板来源。
+
+我不会根据这张图直接计算。请手动录入角色、音擎、驱动盘和敌人信息，或换一张清晰的角色面板截图。
+```
+
+## Acceptance assertions
+
+- `shouldNotCalc === true`
+- `fallbackTrigger === "unsupported-source"`
+- `nextStep` names manual input and a supported screenshot as the safe path.
+- No strict snapshot or calc baseline is produced.
+- User-facing copy does not leak internal orchestration wording.

--- a/scripts/verify-ai-plugin.mjs
+++ b/scripts/verify-ai-plugin.mjs
@@ -231,10 +231,101 @@ const visionFixtures = [
     },
     userCopyIncludes: ["截图来源: 绝区零工坊", "UID 已识别并隐藏"],
   },
+  {
+    name: "boundary-unknown-source",
+    mode: "boundary",
+    fixtureName: "vision-boundary-unknown-source",
+    sourceId: "unknown",
+    sourceLabel: "未知来源",
+    prompt: "examples/ai-plugin/vision/prompts/vision-boundary-unknown-source.md",
+    metadata: "examples/ai-plugin/vision/expected/vision-boundary-unknown-source.draft-metadata.json",
+    expected: {
+      fallbackTrigger: "unsupported-source",
+      sourceConfidenceMax: 0.4,
+      piiKinds: [],
+      nextStepIncludes: ["手动录入", "清晰的角色面板截图"],
+    },
+    userCopyIncludes: ["暂时无法识别这张图来自支持的面板来源", "我不会根据这张图直接计算"],
+  },
+  {
+    name: "boundary-low-confidence",
+    mode: "boundary",
+    fixtureName: "vision-boundary-low-confidence",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-boundary-low-confidence.md",
+    metadata: "examples/ai-plugin/vision/expected/vision-boundary-low-confidence.draft-metadata.json",
+    expected: {
+      fallbackTrigger: "low-confidence",
+      sourceConfidenceMin: 0.8,
+      piiKinds: ["uid"],
+      lowConfidenceFields: ["panel.attack", "panel.critRate", "driveDiscs[5].mainStat"],
+      nextStepIncludes: ["攻击力", "暴击率", "6 号位主词条"],
+    },
+    userCopyIncludes: ["截图来源看起来是绝区零工坊", "攻击力、暴击率和 6 号位主词条读数不够可靠"],
+  },
+  {
+    name: "boundary-missing-critical",
+    mode: "boundary",
+    fixtureName: "vision-boundary-missing-critical",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-boundary-missing-critical.md",
+    metadata: "examples/ai-plugin/vision/expected/vision-boundary-missing-critical.draft-metadata.json",
+    expected: {
+      fallbackTrigger: "missing-critical",
+      sourceConfidenceMin: 0.8,
+      piiKinds: ["uid", "username"],
+      missingCriticalFields: ["wEngine.id", "driveDiscs[4].mainStat", "driveDiscs[5].mainStat"],
+      nextStepIncludes: ["音擎名称", "5 号位主词条", "6 号位主词条"],
+    },
+    userCopyIncludes: ["音擎名称、5 号位主词条和 6 号位主词条被裁掉", "请补充这些字段"],
+  },
+  {
+    name: "boundary-ambiguous-field",
+    mode: "boundary",
+    fixtureName: "vision-boundary-ambiguous-field",
+    sourceId: "miyoushe-record",
+    sourceLabel: "米游社",
+    prompt: "examples/ai-plugin/vision/prompts/vision-boundary-ambiguous-field.md",
+    metadata: "examples/ai-plugin/vision/expected/vision-boundary-ambiguous-field.draft-metadata.json",
+    expected: {
+      fallbackTrigger: "ambiguous-field",
+      sourceConfidenceMin: 0.8,
+      piiKinds: ["uid", "username"],
+      ambiguityCandidates: {
+        "skillLevels.corePassive": ["07", "01"],
+        "actor.id": ["1091", "1311"],
+      },
+      nextStepIncludes: ["核心技等级是 07 还是 01", "角色是雅还是耀嘉音"],
+    },
+    userCopyIncludes: ["我看到两处不确定信息", "请先确认后我再继续"],
+  },
+  {
+    name: "boundary-pii-overlap",
+    mode: "boundary",
+    fixtureName: "vision-boundary-pii-overlap",
+    sourceId: "zzz-workshop",
+    sourceLabel: "绝区零工坊",
+    prompt: "examples/ai-plugin/vision/prompts/vision-boundary-pii-overlap.md",
+    metadata: "examples/ai-plugin/vision/expected/vision-boundary-pii-overlap.draft-metadata.json",
+    expected: {
+      fallbackTrigger: "pii-overlap",
+      sourceConfidenceMin: 0.8,
+      piiKinds: ["uid", "username"],
+      missingCriticalFields: ["driveDiscs[3].substats", "driveDiscs[4].mainStat"],
+      nextStepIncludes: ["个人信息区域已隐藏", "4 号位副词条", "5 号位主词条"],
+    },
+    userCopyIncludes: ["个人信息区域已隐藏", "挡住了 4 号位副词条和 5 号位主词条"],
+  },
 ]
 const requiredVisionExampleFiles = [
   "examples/ai-plugin/vision/README.md",
-  ...visionFixtures.flatMap(fixture => [fixture.prompt, fixture.snapshot, fixture.metadata, fixture.calc]),
+  ...visionFixtures.flatMap(fixture => [
+    fixture.prompt,
+    fixture.metadata,
+    ...(fixture.mode === "calc" ? [fixture.snapshot, fixture.calc] : []),
+  ]),
 ]
 const entitySectionDomains = [
   { heading: "Agents (characters)", domain: "agents", type: "character" },
@@ -852,17 +943,89 @@ function verifyVisionPrompt(fixture) {
   includesAll(text, fixture.prompt, [
     `**Skill**: fairy-vision`,
     `**Source**: ${fixture.sourceId}`,
-    `sourceDetection.sourceId === "${fixture.sourceId}"`,
-    "parseBattleSnapshot",
-    "fairy calc <snapshot> --view verbose --lang zh",
-    "substatRollsSample",
   ])
+  if (fixture.mode === "calc") {
+    includesAll(text, fixture.prompt, [
+      `sourceDetection.sourceId === "${fixture.sourceId}"`,
+      "parseBattleSnapshot",
+      "fairy calc <snapshot> --view verbose --lang zh",
+      "substatRollsSample",
+    ])
+  }
+  else if (fixture.mode === "boundary") {
+    includesAll(text, fixture.prompt, [
+      "shouldNotCalc === true",
+      `fallbackTrigger === "${fixture.expected.fallbackTrigger}"`,
+      "No confirmed BattleSnapshot",
+      "No CalcResult",
+    ])
+  }
+  else {
+    assert(false, `${fixture.name}: unknown vision fixture mode ${fixture.mode}`)
+  }
   for (const snippet of fixture.userCopyIncludes)
     assert(text.includes(snippet), `${fixture.prompt}: missing review/edit copy snippet ${snippet}`)
 
   const copy = extractReviewEditCopy(fixture.prompt)
   assertNoUserFacingChainLeak(copy, fixture.prompt)
   assert(!copy.includes("5★ midpoint default"), `${fixture.prompt}: source-tool review copy must not use midpoint default language`)
+}
+
+function verifyVisionBoundaryMetadata(fixture) {
+  const metadata = readJson(fixture.metadata)
+  assertNoPiiKeys(metadata, fixture.metadata)
+  assert(metadata.schemaVersion === "v1.2.3-vision-draft-metadata-v1", `${fixture.metadata}: unexpected schemaVersion`)
+  assert(metadata.fixtureName === fixture.fixtureName, `${fixture.metadata}: fixtureName must match fixture`)
+  assert(metadata.shouldNotCalc === true, `${fixture.metadata}: shouldNotCalc must be true`)
+  assert(metadata.snapshotStatus === "blocked", `${fixture.metadata}: snapshotStatus must be blocked`)
+  assert(metadata.calcStatus === "not-run", `${fixture.metadata}: calcStatus must be not-run`)
+  assert(metadata.fallbackTrigger === fixture.expected.fallbackTrigger, `${fixture.metadata}: fallbackTrigger mismatch`)
+  assert(metadata.sourceDetection?.sourceId === fixture.sourceId, `${fixture.metadata}: sourceDetection.sourceId mismatch`)
+  assert(metadata.sourceDetection?.sourceLabel === fixture.sourceLabel, `${fixture.metadata}: sourceDetection.sourceLabel mismatch`)
+
+  if (fixture.expected.sourceConfidenceMin !== undefined)
+    assert(metadata.sourceDetection?.confidence >= fixture.expected.sourceConfidenceMin, `${fixture.metadata}: sourceDetection confidence must meet supported-source floor`)
+  if (fixture.expected.sourceConfidenceMax !== undefined)
+    assert(metadata.sourceDetection?.confidence <= fixture.expected.sourceConfidenceMax, `${fixture.metadata}: sourceDetection confidence must stay below unsupported-source ceiling`)
+
+  assertExactStringArray(metadata.piiDetection?.kinds, fixture.expected.piiKinds, `${fixture.metadata}: piiDetection.kinds`)
+  if ((fixture.expected.piiKinds ?? []).length > 0) {
+    assert(metadata.piiDetection?.redactionStatus === "redacted", `${fixture.metadata}: piiDetection.redactionStatus must be redacted`)
+    assert(metadata.piiDetection?.rawValuesDiscarded === true, `${fixture.metadata}: raw PII values must be discarded`)
+  }
+  else {
+    assert(metadata.piiDetection?.redactionStatus === "not-present", `${fixture.metadata}: piiDetection.redactionStatus must be not-present`)
+    assert(metadata.piiDetection?.rawValuesDiscarded === true, `${fixture.metadata}: raw PII discard flag must remain true`)
+  }
+
+  const confidenceValues = Object.values(metadata.perFieldConfidence ?? {})
+  assert(confidenceValues.length > 0, `${fixture.metadata}: perFieldConfidence is required`)
+  for (const value of confidenceValues)
+    assert(["high", "medium", "low"].includes(value), `${fixture.metadata}: invalid confidence value ${value}`)
+
+  for (const field of fixture.expected.lowConfidenceFields ?? [])
+    assert(metadata.perFieldConfidence?.[field] === "low", `${fixture.metadata}: ${field} must be low confidence`)
+
+  if (fixture.expected.missingCriticalFields !== undefined)
+    assertExactStringArray(metadata.missingCriticalFields, fixture.expected.missingCriticalFields, `${fixture.metadata}: missingCriticalFields`)
+
+  if (fixture.expected.ambiguityCandidates !== undefined) {
+    for (const [field, candidates] of Object.entries(fixture.expected.ambiguityCandidates)) {
+      const actual = metadata.ambiguityCandidates?.[field]
+      assertExactStringArray(actual, candidates, `${fixture.metadata}: ambiguityCandidates.${field}`)
+    }
+  }
+
+  assert(typeof metadata.nextStep === "string" && metadata.nextStep.length > 0, `${fixture.metadata}: nextStep is required`)
+  for (const snippet of fixture.expected.nextStepIncludes ?? [])
+    assert(metadata.nextStep.includes(snippet), `${fixture.metadata}: nextStep must mention ${snippet}`)
+
+  const blockingReasons = metadata.evidence?.blockingReasons ?? []
+  assert(Array.isArray(blockingReasons) && blockingReasons.length > 0, `${fixture.metadata}: evidence.blockingReasons is required`)
+
+  const serialized = JSON.stringify(metadata)
+  assert(!/displayTotalDamage|CalcResult|confirmedSnapshot|battleSnapshotDraft|trace-\d+/i.test(serialized), `${fixture.metadata}: boundary fixture must not embed calc or confirmed snapshot output`)
+  return metadata
 }
 
 function verifyVisionCalcFixture(fixture, snapshot) {
@@ -914,10 +1077,14 @@ function verifyVisionFixtures() {
   const calcResultsByName = new Map()
   for (const fixture of visionFixtures) {
     verifyVisionPrompt(fixture)
-    const snapshot = verifyVisionSnapshot(fixture)
-    verifyVisionDraftMetadata(fixture)
-    if (fixture.mode === "calc")
+    if (fixture.mode === "calc") {
+      const snapshot = verifyVisionSnapshot(fixture)
+      verifyVisionDraftMetadata(fixture)
       calcResultsByName.set(fixture.name, verifyVisionCalcFixture(fixture, snapshot))
+    }
+    else if (fixture.mode === "boundary") {
+      verifyVisionBoundaryMetadata(fixture)
+    }
   }
 
   const parityGroups = new Map()


### PR DESCRIPTION
## Summary
- add five F2-3 fairy-vision boundary fixtures for unsupported source, low confidence, missing critical fields, ambiguity, and PII overlap
- extend verify-ai-plugin with boundary-mode matrix assertions for shouldNotCalc, fallbackTrigger, ask-don't-guess nextStep, PII kind/status/rawValuesDiscarded, and no snapshot/calc output
- document boundary fixture scope in the vision examples README

## Verification
- pnpm verify:ai-plugin
- pnpm check
- pnpm test
- pnpm build
- git diff --check

Note: an initial parallel local gate run hit a transient ERR_MODULE_NOT_FOUND because pnpm build cleaned core dist while check/test imported it. The gates above were rerun sequentially and passed.